### PR TITLE
docs(en-US): enable social sign-in

### DIFF
--- a/docs/docs/tutorials/get-started/_connectors-wip.md
+++ b/docs/docs/tutorials/get-started/_connectors-wip.md
@@ -1,0 +1,3 @@
+:::note
+We're still working on more connectors! If you don't see the connector you want, follow [Create your connector](../../recipes/create-your-connector/README.md) to extend or file a [Feature Request](#) on GitHub.
+:::

--- a/docs/docs/tutorials/get-started/customize-sign-in-experience.md
+++ b/docs/docs/tutorials/get-started/customize-sign-in-experience.md
@@ -47,4 +47,4 @@ Let's skip "Sign-in methods" for now and move to the "Others" tab. In most cases
 Yeah, yeah. Signing in without entering the password is the trend. Logto cannot miss it and has built-in support. Choose the one you like to continue:
 
 - [Enable SMS or email passcode sign-in](./enable-passcode-sign-in.mdx)
-- [Add a social connector and enable social sign-in](./enable-social-sign-in.md)
+- [Add a social connector and enable social sign-in](./enable-social-sign-in.mdx)

--- a/docs/docs/tutorials/get-started/enable-passcode-sign-in.mdx
+++ b/docs/docs/tutorials/get-started/enable-passcode-sign-in.mdx
@@ -7,7 +7,7 @@ import ConnectorsIntro from './_connectors-intro.md';
 
 # Enable SMS or email passcode sign-in
 
-In the "Get Started" tab, click the "Enable" button on the right, and the browser will redirect to the Connectors tab.
+In the "Get Started" tab, click the "Enable" button on the right, and the browser will redirect to the "Connectors" -> "Email and SMS connectors" tab.
 
 The enabling process for SMS and email are very close, so we combine them into one tutorial.
 
@@ -35,13 +35,13 @@ We're still working on more connectors! If you don't see the connector you want,
 A full-screen page will guide you through setting things up correctly. Follow the steps below to finish the setup:
 
 1. Go through the README doc on the left, then follow the instructions inside.
-2. Fill out the JSON that the connector needs on the right.
+2. Fill out the JSON that the connector needs in the editor on the right.
 3. Click "Next", and in step 2, test if the connector works as expected.
 4. Click "Done" to finish.
 
 ## Enable connector in sign-in experience
 
-Switch to the "Sign-in Experience" tab by clicking the link in the very left section of the page, then click then "Sign-in Methods" tab.
+Switch to the "Sign-in Experience" tab by clicking the link in the very left section of the page, then click the "Sign-in Methods" tab.
 
 If you didn't add any other sign-in methods before, "Enable secondary sign-in" should be off. Turn it on, and check "Email sign-in" or "Phone number sign-in" based on which connector you just set up.
 

--- a/docs/docs/tutorials/get-started/enable-passcode-sign-in.mdx
+++ b/docs/docs/tutorials/get-started/enable-passcode-sign-in.mdx
@@ -56,7 +56,7 @@ Open the demo app again to try out the new sign-in method.
 See [Configure sign-in methods](../../recipes/customize-sie/configure-sign-in-methods.md) for a complete picture of sign-in methods combinations.
 :::
 
-## What's Next
+## What's next
 
 - [Add a social connector and enable social sign-in](./enable-social-sign-in.mdx) (in case you haven't tried)
 - [Further readings](./further-readings.md)

--- a/docs/docs/tutorials/get-started/enable-passcode-sign-in.mdx
+++ b/docs/docs/tutorials/get-started/enable-passcode-sign-in.mdx
@@ -4,6 +4,7 @@ sidebar_position: 4
 
 import Columns from '@components/Columns';
 import ConnectorsIntro from './_connectors-intro.md';
+import ConnectorsWip from './_connectors-wip.md';
 
 # Enable SMS or email passcode sign-in
 
@@ -26,11 +27,9 @@ Logto has some built-in connectors which allows out-of-box usage:
 
 Choose the one that suits you, and click "Next" to continue.
 
-:::note
-We're still working on more connectors! If you don't see the connector you want, follow [Create your connector](../../recipes/create-your-connector/README.md) to extend or file a [Feature Request](#) on GitHub.
-:::
+<ConnectorsWip />
 
-## Configure and test
+## Configure connector and test
 
 A full-screen page will guide you through setting things up correctly. Follow the steps below to finish the setup:
 
@@ -47,6 +46,8 @@ If you didn't add any other sign-in methods before, "Enable secondary sign-in" s
 
 Now you should see the text "Sign in with Phone number" or "Sign in with Email" under the big "Sign In" button.
 
+Click "Save changes" to push the changes to go live.
+
 :::tip
 Open the demo app again to try out the new sign-in method.
 :::
@@ -54,3 +55,8 @@ Open the demo app again to try out the new sign-in method.
 :::note
 See [Configure sign-in methods](../../recipes/customize-sie/configure-sign-in-methods.md) for a complete picture of sign-in methods combinations.
 :::
+
+## What's Next
+
+- [Add a social connector and enable social sign-in](./enable-social-sign-in.mdx) (in case you haven't tried)
+- [Further readings](./further-readings.md)

--- a/docs/docs/tutorials/get-started/enable-social-sign-in.md
+++ b/docs/docs/tutorials/get-started/enable-social-sign-in.md
@@ -1,5 +1,0 @@
----
-sidebar_position: 5
----
-
-# Enable social sign-in

--- a/docs/docs/tutorials/get-started/enable-social-sign-in.mdx
+++ b/docs/docs/tutorials/get-started/enable-social-sign-in.mdx
@@ -1,0 +1,11 @@
+---
+sidebar_position: 5
+---
+
+import ConnectorsIntro from './_connectors-intro.md';
+
+# Enable social sign-in
+
+In the "Get Started" tab, click the "Add" button on the right, and the browser will redirect to the "Connectors" -> "Social connectors" tab.
+
+<ConnectorsIntro />

--- a/docs/docs/tutorials/get-started/enable-social-sign-in.mdx
+++ b/docs/docs/tutorials/get-started/enable-social-sign-in.mdx
@@ -3,9 +3,59 @@ sidebar_position: 5
 ---
 
 import ConnectorsIntro from './_connectors-intro.md';
+import ConnectorsWip from './_connectors-wip.md';
 
 # Enable social sign-in
 
 In the "Get Started" tab, click the "Add" button on the right, and the browser will redirect to the "Connectors" -> "Social connectors" tab.
 
 <ConnectorsIntro />
+
+
+## Add a social connector
+
+Click the "Add social connector" button to look for the connector you want. The opening modal shows the built-in connectors, which allow out-of-box usage:
+
+- Alipay
+- Apple
+- Facebook
+- GitHub
+- Google
+- WeChat
+
+<ConnectorsWip />
+
+## Configure social connector
+
+A full-screen page will guide you through setting things up correctly. Follow the steps below to finish the setup:
+
+1. Go through the README doc on the left, then follow the instructions inside.
+2. Fill out the JSON that the connector needs in the editor on the right.
+3. Click "Done" to finish.
+
+## Enable connector in sign-in experience
+
+Switch to the "Sign-in Experience" tab by clicking the link in the very left section of the page, then click the "Sign-in Methods" tab.
+
+If you didn't add any other sign-in methods before, "Enable secondary sign-in" should be off. Turn it on, and check "Social sign-in".
+
+On the table that just showed up, look for the connector you just added in the left column, "Social connectors". Then click the plus icon on the right.
+
+You should see a logo representing the identity provider under the big "Sign In" button.
+
+If you have multiple social connectors in use (in the right column), you can drag and drop them to reorder.
+
+Click "Save changes" to push the changes to go live.
+
+:::tip
+Open the demo app again to try out the new sign-in method.
+:::
+
+:::note
+See [Configure sign-in methods](../../recipes/customize-sie/configure-sign-in-methods.md) for a complete picture of sign-in methods combinations.
+:::
+
+## What's Next
+
+- [Enable SMS or email passcode sign-in](./enable-passcode-sign-in.mdx) (in case you haven't tried)
+- [Further readings](./further-readings.md)

--- a/docs/docs/tutorials/get-started/enable-social-sign-in.mdx
+++ b/docs/docs/tutorials/get-started/enable-social-sign-in.mdx
@@ -11,7 +11,6 @@ In the "Get Started" tab, click the "Add" button on the right, and the browser w
 
 <ConnectorsIntro />
 
-
 ## Add a social connector
 
 Click the "Add social connector" button to look for the connector you want. The opening modal shows the built-in connectors, which allow out-of-box usage:
@@ -55,7 +54,7 @@ Open the demo app again to try out the new sign-in method.
 See [Configure sign-in methods](../../recipes/customize-sie/configure-sign-in-methods.md) for a complete picture of sign-in methods combinations.
 :::
 
-## What's Next
+## What's next
 
 - [Enable SMS or email passcode sign-in](./enable-passcode-sign-in.mdx) (in case you haven't tried)
 - [Further readings](./further-readings.md)


### PR DESCRIPTION
- enable social sign-in tutorial
- align content and wording between social/passcode tutorials