### PR TITLE
style(docs): minor content style update

### DIFF
--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -10,7 +10,7 @@
 
 :root {
   --ifm-color-primary: #5d34f2;
-  --ifm-color-primary-dark: #4718f0	;
+  --ifm-color-primary-dark: #4718f0;
   --ifm-color-primary-darker: #3e0feb;
   --ifm-color-primary-darkest: #330cc1;
   --ifm-color-primary-light: #7350f4;
@@ -19,14 +19,13 @@
   --ifm-hover-overlay: rgba(93, 52, 242, 0.12);
   --ifm-code-font-size: 95%;
   --ifm-navbar-height: 64px;
-  --doc-sidebar-width: 380px !important;
+  --doc-sidebar-width: 340px !important;
   --doc-sidebar-section-title: #c9c5d0;
   --logto-border: #c4c7c7;
   --ifm-menu-link-sublist-icon: url('/static/img/menu-link-sublist-icon.svg');
 
   --padding-max-width: 100px;
 }
-
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
 [data-theme='dark'] {
@@ -41,7 +40,6 @@
   --doc-sidebar-section-title: #777;
   --logto-border: #5c5f60;
 }
-
 
 // Top Nav
 .navbar {
@@ -71,7 +69,7 @@
   font-weight: 600;
 }
 
-.sidebar-section > a.menu__link  {
+.sidebar-section > a.menu__link {
   color: var(--doc-sidebar-section-title);
   padding: 0;
   pointer-events: none;
@@ -88,7 +86,7 @@
 }
 
 .menu__link {
-  word-break: break-all;
+  word-break: break-word;
 }
 
 .menu__list-item-collapsible {
@@ -104,6 +102,7 @@
       height: 1rem;
       width: 1rem;
       background: none;
+      filter: none;
       mask: var(--ifm-menu-link-sublist-icon) 50% / 1rem 1rem;
       background-color: var(--ifm-menu-color);
     }
@@ -124,6 +123,7 @@
     content: '';
     margin-right: _.unit(1);
     background: none;
+    filter: none;
     mask: var(--ifm-menu-link-sublist-icon) 50% / 1rem 1rem;
     height: 1rem;
     width: 1rem;
@@ -138,12 +138,12 @@
 
   &.menu__link--active {
     &::before {
-     background-color: var(--ifm-menu-color-active);
+      background-color: var(--ifm-menu-color-active);
     }
   }
 }
 
-.menu__list-item--collapsed  {
+.menu__list-item--collapsed {
   .menu__link--sublist-caret::before {
     transform: rotateZ(90deg);
   }
@@ -188,13 +188,12 @@ main {
   }
 }
 
-
 @media (min-width: 997px) {
   .navbar__brand {
     .navbar__logo {
       margin-right: _.unit(6);
     }
-  
+
     &::after {
       position: absolute;
       right: 0;
@@ -204,7 +203,6 @@ main {
       width: 1px;
       height: 16px;
       transform: translateY(-8px);
-  
     }
   }
 

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -167,6 +167,13 @@
   padding: 0 var(--ifm-pre-padding);
 }
 
+main {
+  padding-bottom: var(--ifm-spacing-horizontal);
+  & > .container {
+    padding: calc(var(--ifm-spacing-horizontal) * 2);
+  }
+}
+
 [data-theme='dark'] .docusaurus-highlight-code-line {
   background-color: rgba(0, 0, 0, 0.3);
 }


### PR DESCRIPTION
minor content style update

1. Gives extra space to the main content bottom

<img width="1216" alt="image" src="https://user-images.githubusercontent.com/36393111/174957337-f3b2e9c9-0767-4b31-883b-6868d01fcb30.png">

2. Set the sidebar menu work-break: break-word
3. Remove the default menu arrow filter as it cause issue under darkmode.

give extra space to the main content 