### PR TITLE
fix(docs): fix some doc site bugs

### DIFF
--- a/docs/docs/recipes/protect-your-api/README.md
+++ b/docs/docs/recipes/protect-your-api/README.md
@@ -31,7 +31,7 @@ Next, click on the **Create API Resource** button and fill out the form to regis
 
 <!-- TODO: Replace the API resource AC screenshot -->
 
-<img src="/img/docs/api_resource_create.png" width="100%" />
+![](/img/docs/api_resource_create.png)
 <br />
 <br />
 
@@ -43,7 +43,7 @@ The new API will show up on the list once created. You may manage or delete it o
 
 <!-- TODO: Replace the API resource AC screenshot -->
 
-<img src="/img/docs/api_resource_manage.png" width="100%" />
+![](/img/docs/api_resource_manage.png)
 <br />
 <br />
 

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/docs/recipes/protect-your-api/README.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/docs/recipes/protect-your-api/README.md
@@ -31,7 +31,7 @@ Logto 服务可以从每一个授权请求中识别出所申请的目标 [API �
 
 <!-- TODO: Replace the API resource AC screenshot -->
 
-<img src="/img/docs/api_resource_create.png" width="100%" />
+![](/img/docs/api_resource_create.png)
 <br />
 <br />
 
@@ -43,7 +43,7 @@ API Identifier 将被 Logto 用作全局唯一的 API 资源标识符。 一经�
 
 <!-- TODO: Replace the API resource AC screenshot -->
 
-<img src="/img/docs/api_resource_manage.png" width="100%" />
+![](/img/docs/api_resource_manage.png)
 <br />
 <br />
 

--- a/i18n/zh-cn/docusaurus-theme-classic/navbar.json
+++ b/i18n/zh-cn/docusaurus-theme-classic/navbar.json
@@ -1,8 +1,4 @@
 {
-  "title": {
-    "message": "Logto",
-    "description": "The title in the navbar"
-  },
   "item.label.Docs": {
     "message": "文档",
     "description": "Navbar item with label Docs"

--- a/src/theme/Footer/FooterLayout.tsx
+++ b/src/theme/Footer/FooterLayout.tsx
@@ -11,8 +11,6 @@ type Props = {
 };
 
 const FooterLayout = ({ links, logo, copyright }: Props) => {
-  console.log(logo);
-
   return (
     <footer className={styles.footer}>
       <div className={styles.container}>

--- a/src/theme/Footer/FooterLayout.tsx
+++ b/src/theme/Footer/FooterLayout.tsx
@@ -11,6 +11,8 @@ type Props = {
 };
 
 const FooterLayout = ({ links, logo, copyright }: Props) => {
+  console.log(logo);
+
   return (
     <footer className={styles.footer}>
       <div className={styles.container}>


### PR DESCRIPTION
fix some doc site bugs.

1. remove the logto title settings under CN page config
<img width="1171" alt="image" src="https://user-images.githubusercontent.com/36393111/177342113-8db92b5d-e38b-409a-8f93-13210dba6276.png">

2. update the img element in markdown, as somehow HTML img element src attribute is not processed to proper static file location as expected. 
<img width="806" alt="image" src="https://user-images.githubusercontent.com/36393111/177342210-98f1ee9e-96cc-4741-a998-54853b5a286b.png">

@logto-io/eng 
