### PR TITLE
refactor: move annotation out of bash script block

### DIFF
--- a/docs/docs/tutorials/get-started/README.mdx
+++ b/docs/docs/tutorials/get-started/README.mdx
@@ -11,8 +11,11 @@ import TabItem from '@theme/TabItem';
 
 Docker Compose CLI usually comes with [Docker Desktop](https://www.docker.com/products/docker-desktop).
 
+:::note
+Before the first stable version is available, we use the `prerelease` tag for the Docker image.
+:::
+
 ```bash
-# Before the first stable version is available, we use the `prerelease` tag for the Docker image.
 curl -fsSL https://raw.githubusercontent.com/logto-io/logto/HEAD/docker-compose.yml | TAG=prerelease docker compose -p logto -f - up
 ```
 
@@ -25,8 +28,11 @@ After a successful composition, you will see the message like:
 1. Prepare a [PostgreSQL](https://www.postgresql.org/)@^14.0 instance。
 2. Pull the image from ghcr.io:
 
+:::note
+Before the first stable version is available, we use the `prerelease` tag for the Docker image.
+:::
+
 ```bash
-# Before the first stable version is available, we use the `prerelease` tag for the Docker image.
 docker pull ghcr.io/logto-io/logto:prerelease
 ```
 

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/docs/tutorials/get-started/README.mdx
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/docs/tutorials/get-started/README.mdx
@@ -11,8 +11,11 @@ import TabItem from '@theme/TabItem';
 
 [Docker Desktop](https://www.docker.com/products/docker-desktop) 通常自带 Docker Compose CLI。
 
+:::note
+在第一个稳定版本之前，我们使用 `prerelease` 作为 Docker image 的 tag。
+:::
+
 ```bash
-# 在第一个稳定版本之前，我们使用 `prerelease` 作为 Docker image 的 tag。
 curl -fsSL https://raw.githubusercontent.com/logto-io/logto/HEAD/docker-compose.yml | TAG=prerelease docker compose -p logto -f - up
 ```
 
@@ -25,8 +28,11 @@ curl -fsSL https://raw.githubusercontent.com/logto-io/logto/HEAD/docker-compose.
 1. 准备一个 [PostgreSQL](https://www.postgresql.org/)@^14.0 实例。
 2. 从 ghcr.io 拉取镜像：
 
+:::note
+在第一个稳定版本之前，我们使用 `prerelease` 作为 Docker image 的 tag。
+:::
+
 ```bash
-# 在第一个稳定版本之前，我们使用 `prerelease` 作为 Docker image 的 tag。
 docker pull ghcr.io/logto-io/logto:prerelease
 ```
 


### PR DESCRIPTION
Move annotation out of bash script block, in order to avoid being copied along with the command on clicking the copy button