### PR TITLE
chore: fix footer logo

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -84,8 +84,8 @@ const config = {
       },
       footer: {
         logo: {
-          alt: 'Logto Logo',
-          src: 'img/silverhand.svg',
+          alt: 'Logo',
+          src: '/img/silverhand.svg',
         },
         style: 'dark',
         links: [


### PR DESCRIPTION
use absolute url. tested locally

<img width="1017" alt="image" src="https://user-images.githubusercontent.com/14722250/178097831-cc7134dd-0c5f-4252-a818-21205abc8257.png">
