### PR TITLE
style(docs): adjust side nav font-size

### DIFF
--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -101,6 +101,8 @@ body #__docusaurus {
 
 .menu__link {
   word-break: break-word;
+  line-height: 20px;
+  font-size: 14px;
 }
 
 // overwrite default link hover color.


### PR DESCRIPTION
adjust side nav font-size

Before:
![image](https://user-images.githubusercontent.com/36393111/178641647-720601d9-0207-4150-934d-97c7cc7eef13.png)

After:
![image](https://user-image@logto-io/eng thubusercontent.com/36393111/178641666-80d4c596-a80f-4812-b098-0f81aa1897fc.png)

@eng