### PR TITLE
fix: deploy docs with swagger.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "prepare": "if test \"$NODE_ENV\" != \"production\" && test \"$CI\" != \"true\" ; then husky install ; fi",
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "build": "docusaurus build",
+    "build": "pnpm build:swagger && docusaurus build",
     "build:swagger": "curl -o src/pages/Api/swagger.json https://logto.dev/api/swagger.json",
     "swizzle": "docusaurus swizzle",
     "deploy": "pnpm build:swagger && docusaurus deploy",


### PR DESCRIPTION
`.github/deploy.yml` uses `pnpm build` (not `pnpm deploy`) to deploy docs.

We should append `build:swagger` to `build` in `package.json` to fix the content of API Reference.