### PR TITLE
fix: page scrolling issue on API page

### DIFF
--- a/src/pages/Api/index.scss
+++ b/src/pages/Api/index.scss
@@ -1,0 +1,9 @@
+.menu-content {
+  /*
+  The API page has a scrolling issue. When scrolling up, the Redoc menu will be scrolled up with the content,
+  and get blocked by the topbar. This is caused by incorrect positioning of the menu, using inline styles.
+  Have to use `!important` to override the incorrect inline styles as a workaround.
+  */
+  top: var(--ifm-navbar-height) !important;
+  height: calc(100vh - var(--ifm-navbar-height)) !important;
+}

--- a/src/pages/Api/index.tsx
+++ b/src/pages/Api/index.tsx
@@ -3,6 +3,7 @@ import Redoc from '@theme/Redoc';
 import React from 'react';
 
 import spec from './swagger.json';
+import './index.scss';
 
 const Api = () => (
   <Layout>


### PR DESCRIPTION
Force set `top` and `height` of the sidebar to avoid being scrolled to top with page content and got blocked by header.

You can only beat magic with magic.