### PR TITLE
docs: logto sdk convention zh-cn

### DIFF
--- a/docs/docs/references/logto-sdk-convention/README.mdx
+++ b/docs/docs/references/logto-sdk-convention/README.mdx
@@ -4,6 +4,6 @@ This section demonstrates functionalities provided by Logto SDK and the conventi
 
 This convention contains three main parts:
 
-- [Design Strategy](./design-strategy)
-- [Core SDK Convention](./core-sdk-convention)
-- [Platform SDK Convention](./platform-sdk-convention)
+- [Design Strategy](./design-strategy.md)
+- [Core SDK Convention](./core-sdk-convention.md)
+- [Platform SDK Convention](./platform-sdk-convention.md)

--- a/docs/docs/references/logto-sdk-convention/README.mdx
+++ b/docs/docs/references/logto-sdk-convention/README.mdx
@@ -4,6 +4,6 @@ This section demonstrates functionalities provided by Logto SDK and the conventi
 
 This convention contains three main parts:
 
-- [Design Strategy](./design-strategy.md)
-- [Core SDK Convention](./core-sdk-convention.md)
-- [Platform SDK Convention](./platform-sdk-convention.md)
+- [Design Strategy](./design-strategy)
+- [Core SDK Convention](./core-sdk-convention)
+- [Platform SDK Convention](./platform-sdk-convention)

--- a/docs/docs/references/logto-sdk-convention/platform-sdk-convention.md
+++ b/docs/docs/references/logto-sdk-convention/platform-sdk-convention.md
@@ -10,7 +10,7 @@ import PlatformLogtoClientProperties from './fragments/\_platform_logto_client_p
 
 Platform SDK provides a standard way to integrate the client with Logto service in the specific platform and accelerates the integration process.
 
-- Platform SDK encapsulates [the core](./core-sdk-convention.md) with platform-specific implementation.
+- Platform SDK encapsulates [the core](./core-sdk-convention) with platform-specific implementation.
 - Platform SDK should provide basic types that make SDK easier to use.
 - Platform SDK should be exported as a class named `LogtoClient`.
 

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/docs/references/logto-sdk-convention/README.mdx
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/docs/references/logto-sdk-convention/README.mdx
@@ -1,0 +1,9 @@
+# 📃 Logto SDK 约定
+
+这一部分主要说明 Logto SDK 提供的功能以及 SDK 在各种语言和平台上实现的约定。
+
+该约定主要包含三个主要部分：
+
+- [Design Strategy](./design-strategy)
+- [Core SDK Convention](./core-sdk-convention)
+- [Platform SDK Convention](./platform-sdk-convention)


### PR DESCRIPTION
- Provide a Chinese version of the Logto SDK Convention summary.
- Support falling back to the English version by removing the file extension type in the navigation link.