### PR TITLE
docs: fix docker instructions (missing env vars)

### DIFF
--- a/docs/docs/tutorials/get-started/README.mdx
+++ b/docs/docs/tutorials/get-started/README.mdx
@@ -53,8 +53,8 @@ docker pull ghcr.io/logto-io/logto:prerelease
 ```yml
 ALL_YES: 1
 NO_INQUIRY: 0
-TRUST_PROXY_HEADER: true
-ENDPOINT: http://localhost:3001 # Replace with your logto endpoint uri
+TRUST_PROXY_HEADER: 1 # Set to 1 if you have an HTTPS proxy (e.g. Nginx) in front of Logto
+ENDPOINT: http://localhost:3001 # Replace with your Logto endpoint URL if you are using a custom domain
 DB_URL_DEFAULT: postgres://username:password@your_postgres_url:5432 # Replace with your Postgres DSN
 ```
 

--- a/docs/docs/tutorials/get-started/README.mdx
+++ b/docs/docs/tutorials/get-started/README.mdx
@@ -53,6 +53,8 @@ docker pull ghcr.io/logto-io/logto:prerelease
 ```yml
 ALL_YES: 1
 NO_INQUIRY: 0
+TRUST_PROXY_HEADER: true
+ENDPOINT: http://localhost:3001 # Replace with your logto endpoint uri
 DB_URL_DEFAULT: postgres://username:password@your_postgres_url:5432 # Replace with your Postgres DSN
 ```
 

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/docs/tutorials/get-started/README.mdx
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/docs/tutorials/get-started/README.mdx
@@ -53,8 +53,8 @@ docker pull ghcr.io/logto-io/logto:prerelease
 ```yml
 ALL_YES: 1
 NO_INQUIRY: 0
-TRUST_PROXY_HEADER: true
-ENDPOINT: http://localhost:3001 # 用你的logto端点URI替换
+TRUST_PROXY_HEADER: 1 # 如果你在 Logto 前使用了一个 HTTPS 代理（例如 Nginx），设置为 1
+ENDPOINT: http://localhost:3001 # 如果你在使用自定义域名，将地址替换成你的 Logto URL
 DB_URL_DEFAULT: postgres://username:password@your_postgres_url:5432 # 替换成你的 Postgres DSN
 ```
 

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/docs/tutorials/get-started/README.mdx
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/docs/tutorials/get-started/README.mdx
@@ -53,6 +53,8 @@ docker pull ghcr.io/logto-io/logto:prerelease
 ```yml
 ALL_YES: 1
 NO_INQUIRY: 0
+TRUST_PROXY_HEADER: true
+ENDPOINT: http://localhost:3001 # 用你的logto端点URI替换
 DB_URL_DEFAULT: postgres://username:password@your_postgres_url:5432 # 替换成你的 Postgres DSN
 ```
 


### PR DESCRIPTION
## Summary

Some environment variables are missing with the Docker instructions. Here is a pull request to fix it.

## Testing

/

