### PR TITLE
docs: fix "frontend proxy" link in core service references

### DIFF
--- a/docs/docs/references/core/README.mdx
+++ b/docs/docs/references/core/README.mdx
@@ -57,7 +57,7 @@ To simplify, we divide Core Service into four major modules:
       <td>Frontend proxies</td>
       <td>HTTP proxies or static file serving for frontend projects.</td>
       <td>
-        See <a href="#">Frontend proxies</a> for details.
+        See <a href="#frontend-proxies">Frontend proxies</a> for details.
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Fix "Frontend proxies" link in "Core Service" page

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested locally. Clicking the link will now navigate to the related section
