### PR TITLE
fix: add title to api reference page

### DIFF
--- a/src/pages/api/index.tsx
+++ b/src/pages/api/index.tsx
@@ -5,7 +5,7 @@ import spec from './swagger.json';
 import './index.scss';
 
 const Api = () => (
-  <Layout>
+  <Layout title="API">
     <Redoc spec={spec} />
   </Layout>
 );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
         "./node_modules/@docusaurus/theme-classic/lib/theme/*",
         "./node_modules/docusaurus-theme-redoc/dist/theme/*",
       ]
-    }
+    },
+    "types": ["@docusaurus/theme-classic"]
   },
   "include": ["src", "docs", "i18n"]
 }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Add the title "API" to API Reference page

- The full title of API Reference page should `API | Logto Docs` (i.e. page title + ' | ' + website title)

---

Related problem:

After adding the title to the API Reference page, failed to pass `tsc -p tsconfig.json`.
![image](https://user-images.githubusercontent.com/10594507/181476618-0510aa9b-3405-49ad-ba99-38c59152c127.png)

Resolved it by adding `"types": ["@docusaurus/theme-classic"]` in `tsconfig.ts`.
![image](https://user-images.githubusercontent.com/10594507/181476645-f68485c3-1c50-4d47-84a8-e9dfbaad4f32.png)

Thanks for the help from @demonzoo 

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally tested.

<img width="1151" alt="image" src="https://user-images.githubusercontent.com/10594507/181475652-66fd72e3-0d78-4815-82ca-a480bde49121.png">

