### PR TITLE
fix(docs): fix spacing in _configure-redirect-uri.mdx

### DIFF
--- a/docs/docs/recipes/integrate-logto/fragments/_configure-redirect-uri.mdx
+++ b/docs/docs/recipes/integrate-logto/fragments/_configure-redirect-uri.mdx
@@ -1,7 +1,6 @@
 <p>
   Let&apos;s switch to the Application details page of Admin Console in this section. Add a Redirect
-  URI
-  <code>{props.redirectUri}</code> and click &quot;Save Changes&quot;.
+  URI <code>{props.redirectUri}</code> and click &quot;Save Changes&quot;.
 </p>
 
 <img alt="Redirect URI in Admin Console" src={props.figureSrc} width="600px" />


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Add whitespace between the `Redirect URI` text and the following code snippet.

Before

<img width="1140" alt="image" src="https://user-images.githubusercontent.com/10594507/186121780-6ec72fca-929a-41cd-83ec-ef0c5c2d81af.png">

After

<img width="1136" alt="image" src="https://user-images.githubusercontent.com/10594507/186121765-33f71938-7505-4b63-b0d9-49cf6c5c8b6b.png">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Locally preview & tested.
