### PR TITLE
refactor(doc): extract client token request guide to SDK

### DIFF
--- a/docs/docs/recipes/configure-connectors/_category_.json
+++ b/docs/docs/recipes/configure-connectors/_category_.json
@@ -1,4 +1,4 @@
 {
-  "collapsible": false,
-  "collapsed": false
+  "collapsible": true,
+  "collapsed": true
 }

--- a/docs/docs/recipes/create-your-connector/_category_.json
+++ b/docs/docs/recipes/create-your-connector/_category_.json
@@ -1,4 +1,4 @@
 {
-  "collapsible": false,
-  "collapsed": false
+  "collapsible": true,
+  "collapsed": true
 }

--- a/docs/docs/recipes/customize-sie/_category_.json
+++ b/docs/docs/recipes/customize-sie/_category_.json
@@ -1,4 +1,4 @@
 {
-  "collapsible": false,
-  "collapsed": false
+  "collapsible": true,
+  "collapsed": true
 }

--- a/docs/docs/recipes/integrate-logto/_category_.json
+++ b/docs/docs/recipes/integrate-logto/_category_.json
@@ -1,4 +1,4 @@
 {
-  "collapsible": false,
-  "collapsed": false
+  "collapsible": true,
+  "collapsed": true
 }

--- a/docs/docs/recipes/integrate-logto/android.mdx
+++ b/docs/docs/recipes/integrate-logto/android.mdx
@@ -9,8 +9,10 @@ import redirectUriFigure from './assets/android-redirect-uri.png';
 import JavaSetupCode from './fragments/_android_sdk_setup_code_java.md';
 import KotlinSetupCode from './fragments/_android_sdk_setup_code_kotlin.md';
 import AppNote from './fragments/_app-note.mdx';
+import ApplyAuthorizationToken from './fragments/_apply_authorization_token.md';
 import ConfigureRedirectUri from './fragments/_configure-redirect-uri.mdx';
 import FurtherReadings from './fragments/_further-readings.md';
+import GetAuthorizationToken from './fragments/_get_authorization_token.md';
 import SignInNote from './fragments/_sign-in-note.mdx';
 
 # Android: Integrate Logto Android SDK
@@ -157,6 +159,88 @@ logtoClient.signOut(logtoException -> {
 
 </Tabs>
 
+## Backend API Authorization
+
+<GetAuthorizationToken />
+
+Add your API resource indicators to the Logto SDK configs.
+
+<Tabs>
+<TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+// with all the required LogtoConfig listed above
+
+override fun onCreate(savedInstanceState: Bundle?) {
+  val logtoConfig = LogtoConfig(
+    endpoint = "<your-logto-endpoint>",
+    appId = "<your-app-id>",
+    scopes = null,
+     // List all your API resources willing to access
+    resources = listOf("<your-resource-indicators>"),
+    usingPersistStorage = true,
+    prompt = PromptValue.CONSENT,
+  )
+
+  logtoClient = LogtoClient(logtoConfig, application)
+}
+
+```
+
+</TabItem>
+<TabItem value="java" label="Java">
+
+```java
+// with all the required LogtoConfig listed above
+
+@Override
+protected void onCreate(Bundle savedInstanceState) {
+    // List all your API resources willing to access
+    ArrayList<String> resources = new ArrayList<String>(Arrays.asList("<your-resource-indicators>"));
+
+    LogtoConfig logtoConfig = new LogtoConfig(
+        "<your-logto-endpoint>",  // E.g. http://localhost:3001
+        "<your-app-id>",
+        null,
+        resources,
+        true,
+        PromptValue.CONSENT
+    );
+
+    logtoClient = new LogtoClient(logtoConfig, getApplication());
+}
+```
+
+</TabItem>
+</Tabs>
+
+Claim an authorization token from Logto before making your API request.
+
+<Tabs>
+<TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+logtoClient.getAccessToken("<resource-indicator>", { logtoException, accessToken ->
+    // custom logic
+})
+```
+
+</TabItem>
+<TabItem value="java" label="Java">
+
+```java
+logtoClient.getAccessToken("<resource-indicator>", (logtoException, accessToken) -> {
+    // custom logic
+});
+```
+
+</TabItem>
+
+</Tabs>
+
+<ApplyAuthorizationToken />
+
 ## Further readings
 
 <FurtherReadings />
+```

--- a/docs/docs/recipes/integrate-logto/fragments/_apply_authorization_token.md
+++ b/docs/docs/recipes/integrate-logto/fragments/_apply_authorization_token.md
@@ -1,0 +1,16 @@
+With the user's authorization status, a [JWT](https://datatracker.ietf.org/doc/html/rfc7519) format `access_token` will be granted and issued by Logto, specifically for the requested API resource. Encrypted and audience-restricted with an expiration time. The token carries all the necessary info to represent the authority of this request.
+
+Append the token to your request's Authorization header as the Bearer token:
+
+:::note
+The Bearer token's integration flow may vary based on the framework or requester you are using. Choose your own way to apply the request Authorization header.
+:::
+
+e.g.
+
+```bash
+GET https://logto.dev/api/users
+
+--header Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiYXVkIjoiaHR0cHM6Ly9sb2d0by5kZXYvYXBpL3VzZXJzIiwiaXNzIjoiaHR0cHM6Ly9sb2d0by5kZXYvb2lkYyIsIm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMiwiZXhwIjoxNTE2MzI1NDIyfQ.PjIJl00YNC84EPNYLEdpEEAdAxqhekCYhFEckvRokek
+
+```

--- a/docs/docs/recipes/integrate-logto/fragments/_further-readings.md
+++ b/docs/docs/recipes/integrate-logto/fragments/_further-readings.md
@@ -1,4 +1,3 @@
 - [Customize sign-in experience](../../customize-sie/README.md)
 - [Enable SMS or email passcode sign-in](../../../tutorials/get-started/enable-passcode-sign-in.mdx)
 - [Enable social sign-in](../../../tutorials/get-started/enable-social-sign-in.mdx)
-- [Protect your API](../../protect-your-api/README.mdx)

--- a/docs/docs/recipes/integrate-logto/fragments/_get_authorization_token.md
+++ b/docs/docs/recipes/integrate-logto/fragments/_get_authorization_token.md
@@ -1,0 +1,7 @@
+Logto also helps you apply authorization to your backend APIs . Please check our [Protect your API](../../protect-your-api/README.mdx) see how to integrate Logto with your backend applications.
+
+You can claim an authorization token for a protected API resource request easily through Logto SDK.
+
+:::info
+In order to grant an audience restricted authorization token for your request, make sure the requested API resource is [registered in the Logto Admin Console](../../protect-your-api/#register-the-api-resources-through-logto-admin-console).
+:::

--- a/docs/docs/recipes/integrate-logto/fragments/_get_authorization_token.md
+++ b/docs/docs/recipes/integrate-logto/fragments/_get_authorization_token.md
@@ -3,5 +3,5 @@ Logto also helps you apply authorization to your backend APIs . Please check our
 You can claim an authorization token for a protected API resource request easily through Logto SDK.
 
 :::info
-In order to grant an audience restricted authorization token for your request, make sure the requested API resource is [registered in the Logto Admin Console](../../protect-your-api/#register-the-api-resources-through-logto-admin-console).
+In order to grant an audience restricted authorization token for your request, make sure the requested API resource is [registered in the Logto Admin Console](../../protect-your-api//README.mdx#register-the-api-resources-through-logto-admin-console).
 :::

--- a/docs/docs/recipes/integrate-logto/ios.mdx
+++ b/docs/docs/recipes/integrate-logto/ios.mdx
@@ -4,8 +4,10 @@ sidebar_label: iOS
 
 import redirectUriFigure from './assets/ios-redirect-uri.png';
 import AppNote from './fragments/_app-note.mdx';
+import ApplyAuthorizationToken from './fragments/_apply_authorization_token.md';
 import ConfigureRedirectUri from './fragments/_configure-redirect-uri.mdx';
 import FurtherReadings from './fragments/_further-readings.md';
+import GetAuthorizationToken from './fragments/_get_authorization_token.md';
 import SignInNote from './fragments/_sign-in-note.mdx';
 
 # iOS: Integrate Logto Swift SDK
@@ -96,6 +98,38 @@ Calling `.signOut()` will clean all the Logto data in Keychain, if it has.
 
 ```swift
 await client.signOut()
+```
+
+## Backend API Authorization
+
+<GetAuthorizationToken />
+
+Add your API resource indicators to the Logto SDK configs:
+
+```swift
+let config = try? LogtoConfig(
+  endpoint: "<your-logto-endpoint>", // E.g. http://localhost:3001
+  appId: "<your-app-id>",
+  resources: ["<your-resource-indicators>"]
+)
+let client = LogtoClient(useConfig: config)
+```
+
+Claim an authorization token from Logto before making your API request:
+
+```swift
+  let accessToken = try await client.getAccessToken(for: "<your-target-api-resource>")
+  // custom logic
+```
+
+<ApplyAuthorizationToken />
+
+```swift
+await LogtoRequest.get(
+  useSession: session,
+  endpoint: userInfoEndpoint,
+  headers: ["Authorization": "Bearer \(accessToken)"]
+)
 ```
 
 ## Further readings

--- a/docs/docs/recipes/integrate-logto/react.mdx
+++ b/docs/docs/recipes/integrate-logto/react.mdx
@@ -7,8 +7,10 @@ import Tabs from '@theme/Tabs';
 
 import redirectUriFigure from './assets/web-redirect-uri.png';
 import AppNote from './fragments/_app-note.mdx';
+import ApplyAuthorizationToken from './fragments/_apply_authorization_token.md';
 import ConfigureRedirectUri from './fragments/_configure-redirect-uri.mdx';
 import FurtherReadings from './fragments/_further-readings.md';
+import GetAuthorizationToken from './fragments/_get_authorization_token.md';
 import SignInNote from './fragments/_sign-in-note.mdx';
 import AssumingUrl from './fragments/_web-assuming-url.md';
 import SignInFlowSummary from './fragments/_web-sign-in-flow-summary.mdx';
@@ -138,6 +140,34 @@ const SignOut = () => {
   return <button onClick={() => signOut('http://localhost:3000')}>Sign out</button>;
 };
 ```
+
+## Backend API Authorization
+
+<GetAuthorizationToken />
+
+Add your API resource indicators to the Logto SDK configs:
+
+```js
+import { LogtoProvider, LogtoConfig } from '@logto/react';
+
+const config: LogtoConfig = {
+  appId: '<your-application-id>',
+  endpoint: '<your-logto-endpoint>',
+  resources: ['<your-api-resource>'],
+};
+
+const App = () => <LogtoProvider config={config}>{/* Your app content */}</LogtoProvider>;
+```
+
+Claim an authorization token from Logto before making your API request:
+
+```js
+const { getAccessToken } = useLogto();
+const token = await getAccessToken('<your-target-api-resource>');
+// custom logic
+```
+
+<ApplyAuthorizationToken />
 
 ## Further readings
 

--- a/docs/docs/recipes/integrate-logto/vanilla-js.mdx
+++ b/docs/docs/recipes/integrate-logto/vanilla-js.mdx
@@ -7,8 +7,10 @@ import Tabs from '@theme/Tabs';
 
 import redirectUriFigure from './assets/web-redirect-uri.png';
 import AppNote from './fragments/_app-note.mdx';
+import ApplyAuthorizationToken from './fragments/_apply_authorization_token.md';
 import ConfigureRedirectUri from './fragments/_configure-redirect-uri.mdx';
 import FurtherReadings from './fragments/_further-readings.md';
+import GetAuthorizationToken from './fragments/_get_authorization_token.md';
 import SignInNote from './fragments/_sign-in-note.mdx';
 import AssumingUrl from './fragments/_web-assuming-url.md';
 import SignInFlowSummary from './fragments/_web-sign-in-flow-summary.mdx';
@@ -107,6 +109,31 @@ Now you can test the sign-in flow.
 ```html
 <button onclick="logtoClient.signOut('http://localhost:3000')">Sign Out</button>
 ```
+
+## Backend API Authorization
+
+<GetAuthorizationToken />
+
+Add your API resource indicators to the Logto SDK configs:
+
+```js
+import LogtoClient from '@logto/browser';
+
+const logtoClient = new LogtoClient({
+  endpoint: '<your-logto-endpoint>', // E.g. http://localhost:3001
+  appId: '<your-application-id>',
+  resources: ['<your-api-resource>'],
+});
+```
+
+Claim an authorization token from Logto before making your API request:
+
+```js
+const token = await logtoClient.getAccessToken('<your-target-api-resource>');
+// custom logic
+```
+
+<ApplyAuthorizationToken />
 
 ## Further readings
 

--- a/docs/docs/recipes/integrate-logto/vue.mdx
+++ b/docs/docs/recipes/integrate-logto/vue.mdx
@@ -8,8 +8,10 @@ import Tabs from '@theme/Tabs';
 
 import redirectUriFigure from './assets/web-redirect-uri.png';
 import AppNote from './fragments/_app-note.mdx';
+import ApplyAuthorizationToken from './fragments/_apply_authorization_token.md';
 import ConfigureRedirectUri from './fragments/_configure-redirect-uri.mdx';
 import FurtherReadings from './fragments/_further-readings.md';
+import GetAuthorizationToken from './fragments/_get_authorization_token.md';
 import SignInNote from './fragments/_sign-in-note.mdx';
 import AssumingUrl from './fragments/_web-assuming-url.md';
 import SignInFlowSummary from './fragments/_web-sign-in-flow-summary.mdx';
@@ -156,6 +158,37 @@ const onClickSignOut = () => signOut('http://localhost:3000');
 ```html
 <button @click="onClickSignOut">Sign Out</button>
 ```
+
+## Backend API Authorization
+
+<GetAuthorizationToken />
+
+Add your API resource indicators to the Logto SDK configs:
+
+```js
+import { createLogto, LogtoConfig } from '@logto/vue';
+
+const config: LogtoConfig = {
+  appId: '<your-application-id>',
+  endpoint: '<your-logto-endpoint>',
+  resources: ['<your-api-resource>'],
+};
+
+const app = createApp(App);
+
+app.use(createLogto, config);
+app.mount('#app');
+```
+
+Claim an authorization token from Logto before making your API request:
+
+```js
+const { getAccessToken } = useLogto();
+const token = await getAccessToken('<your-target-api-resource>');
+// custom logic
+```
+
+<ApplyAuthorizationToken />
 
 ## Further readings
 

--- a/docs/docs/recipes/manage-users/_category_.json
+++ b/docs/docs/recipes/manage-users/_category_.json
@@ -1,4 +1,4 @@
 {
-  "collapsible": false,
-  "collapsed": false
+  "collapsible": true,
+  "collapsed": true
 }

--- a/docs/docs/recipes/protect-your-api/README.mdx
+++ b/docs/docs/recipes/protect-your-api/README.mdx
@@ -2,11 +2,6 @@
 sidebar_position: 2
 ---
 
-import TabItem from '@theme/TabItem';
-import Tabs from '@theme/Tabs';
-
-import JavaSetupCode from '../integrate-logto/fragments/_android_sdk_setup_code_java.md';
-import KotlinSetupCode from '../integrate-logto/fragments/_android_sdk_setup_code_kotlin.md';
 import CreateApiResource from './assets/create-api-resource.png';
 import SecretKey from './fragments/_secret_key.md';
 import TokenExtract from './fragments/_token_extract.mdx';
@@ -14,195 +9,38 @@ import TokenValidation from './fragments/_token_validation.mdx';
 
 # ⚔️ Protect your API
 
-With a fluent user sign-in experience, by default, Logto comes with the [API resources](../../references/resources/README.md) authorization service. It will help you protect your APIs resources from anonymous identities. Let's walk through the following steps and implement the API resource authorization guard of your own using Logto.
+As an out-of-the-box authorization service, Logto allows you to apply authorization to your backend [API resources](../../references/resources/README.md) for better privacy protection.
 
 ## Register the API resources through Logto **Admin Console**
 
-Logto will identify the registered [API resources](../../references/resources/README.md) from an authorization request and issue an audience-restricted `access_token` accordingly.
+First, you will need to register your backend endpoints in Admin Console. Logto will identify those registered [API resources](../../references/resources/README.md) from an authorization request and grant an audience-restricted `access_token` accordingly.
 
-Go to the **API Resources** section in **Admin Console**. You will notice a build-in resource listed with the API identifier as `https://api.logto.io`. This resource indicates all the management APIs you may use to maintain the Logto service. It will guarantee all our APIs are under protection and restricted to the Logto authorized users with Admin Role.
+Go to the **API Resources** section in **Admin Console**. You will notice a build-in resource listed with the API identifier shown as `https://api.logto.io`. This resource indicates all the management APIs of Logto. It guarantees all our APIs are under the protection and restricted to those Logto authorized users only.
 
 ![API resources](./assets/api-resources.png)
 
-Next, click on the **Create API Resource** button and fill out the form to register your API resource:
+Next, click on the **Create API Resource** button and fill out the form fields to register your private API resources:
 
 - A human-readable **API Name** that may better helps you to identify this entity.
-- A unique **API Identifier** (a.k.a. [Resource Indicator](../../references/resources/README.md#resource-indicator)) variable in URI format. It represents the resource's identity you'd like to guard.
+- A unique **API Identifier** (a.k.a. [Resource Indicator](../../references/resources/README.md#resource-indicator)) in URI format. It represents the identity of the API resource.
 
 <img src={CreateApiResource} alt="Create API resource" width="700px" />
 <br />
 <br />
 
 :::caution
-The API Identifier is unique and used as the single source of truth of resource indicator for Logto. **NOT** editable once created. Be careful when you make it.
+The API Identifier is unique and used as the single source of truth of the resource indicator for Logto. **NOT** editable once created. Be careful when you create it.
 :::
 
-The new API will show up on the list once created. You may manage or delete it on the API details page by clicking on the entity row.
+The new API will show up on the list once created. You may manage or delete it at the API details page by clicking on the entity.
 
 ![API resource details](./assets/api-resource-details.png)
 
 See [API Resource Logto Schema](../../references/resources/README.md#logto-api-resource-schema) for detailed API setting definitions.
 
 :::info
-All the API Resources record registered in Logto **Admin Console** will be shared across all your applications.
+The API Resources data registered in Logto **Admin Console** will be shared across all your applications.
 :::
-
-## Integrate the resources authorization flow into your client application
-
-Once we have your API resource well registered at the Logto server, we may move forward to your applications and see how Logto SDK works.
-
-:::note
-If you haven't integrated Logto SDK with your application yet, we highly recommend you to go through our SDK's [**Integration Guide**](../integrate-logto/README.md). Logto has various SDKs developed for you. Stick with your business, and let us do the "heavy-duty."
-:::
-
-With Logto SDK, all you need is to pass those resource indicators to the SDK configs when it is initiated.
-
-<Tabs>
-
-<TabItem value="kotlin" label="Kotlin">
-
-<KotlinSetupCode />
-
-</TabItem>
-
-<TabItem value="java" label="Java">
-
-<JavaSetupCode />
-
-</TabItem>
-
-<TabItem value="react" label="React">
-
-```js
-import { LogtoProvider, LogtoConfig } from '@logto/react';
-
-const config: LogtoConfig = {
-  appId: '<your-application-id>',
-  endpoint: '<your-logto-endpoint>',
-  resources: ['<your-api-resource>'],
-};
-
-const App = () => <LogtoProvider config={config}>{/* Your app content */}</LogtoProvider>;
-```
-
-</TabItem>
-<TabItem value="vue" label="Vue">
-
-```js
-import { createLogto, LogtoConfig } from '@logto/vue';
-
-const config: LogtoConfig = {
-  appId: '<your-application-id>',
-  endpoint: '<your-logto-endpoint>',
-  resources: ['<your-api-resource>'],
-};
-
-const app = createApp(App);
-
-app.use(createLogto, config);
-app.mount('#app');
-```
-
-</TabItem>
-<TabItem value="js" label="VanillaJs">
-
-```js
-import LogtoClient from '@logto/browser';
-
-const logtoClient = new LogtoClient({
-  endpoint: '<your-logto-endpoint>', // E.g. http://localhost:3001
-  appId: '<your-application-id>',
-});
-```
-
-</TabItem>
-</Tabs>
-
-Take a breath here. Your application is almost ready 😊. We have Logto SDK well configured at this point. Users could sign in / sign up through the Logto UI flow now.
-
-After end-users successfully log in, they may try to get access to some of your backend API resources through the client application upon their request. We'll need to loop Logto in again at this point. Call the Logto server through our SDK to request an `access_token` before making your API request.
-
-:::note
-
-The requested target resource should be:
-
-1. Registered in Logto server.
-2. Initiated as configs into the Logto SDK at your application.
-
-:::
-
-<Tabs>
-<TabItem value="kotlin" label="Kotlin">
-
-```kotlin
-logtoClient.getAccessToken("<your-target-api-resource>", { logtoException, accessToken ->
-    // custom logic
-})
-```
-
-</TabItem>
-<TabItem value="java" label="Java">
-
-```java
-logtoClient.getAccessToken("<your-target-api-resource>", (logtoException, accessToken) -> {
-    // custom logic
-});
-```
-
-</TabItem>
-<TabItem value="swift" label="Swift">
-
-```swift
-  let token = try await client.getAccessToken(for: "<your-target-api-resource>")
-  // custom logic
-```
-
-</TabItem>
-<TabItem value="react" label="React">
-
-```js
-const { getAccessToken } = useLogto();
-const token = await getAccessToken('<your-target-api-resource>');
-// custom logic
-```
-
-</TabItem>
-
-<TabItem value="vue" label="Vue">
-
-```js
-const { getAccessToken } = useLogto();
-const token = await getAccessToken('<your-target-api-resource>');
-// custom logic
-```
-
-</TabItem>
-
-<TabItem value="js" label="VanillaJs">
-
-```js
-const token = await logtoClient.getAccessToken('<your-target-api-resource>');
-// custom logic
-```
-
-</TabItem>
-
-</Tabs>
-
-If the client is well-authorized, a [JWT](https://datatracker.ietf.org/doc/html/rfc7519) format `access_token` will be granted and issued by Logto, specifically for the requested resource entity, encrypted, audience-restricted, and with an expiration time. Carry all the necessary info that can represent the authority of this request.
-
-Append the token to your request's Authorization header as the Bearer token:
-
-i.e.
-
-```bash
-GET https://logto.dev/api/users
-
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiYXVkIjoiaHR0cHM6Ly9sb2d0by5kZXYvYXBpL3VzZXJzIiwiaXNzIjoiaHR0cHM6Ly9sb2d0by5kZXYvb2lkYyIsIm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMiwiZXhwIjoxNTE2MzI1NDIyfQ.PjIJl00YNC84EPNYLEdpEEAdAxqhekCYhFEckvRokek
-
-```
-
-Now you have your application well equipped. All the requests from a sign-in user through your application will be well-authorized. Let's go back to your server-side and block out those anonymous attempts.
 
 ## Parse and Validate the API request's authorization token
 

--- a/docs/docs/recipes/protect-your-api/_category_.json
+++ b/docs/docs/recipes/protect-your-api/_category_.json
@@ -1,4 +1,4 @@
 {
-  "collapsible": false,
-  "collapsed": false
+  "collapsible": true,
+  "collapsed": true
 }

--- a/docs/docs/references/resources/README.md
+++ b/docs/docs/references/resources/README.md
@@ -6,11 +6,11 @@ import APIResourceSchema from './fragments/\_api_resource_schema.mdx';
 
 ### What is an API resource?
 
-API resources, a.k.a. [Resource Indicators](https://www.rfc-editor.org/rfc/rfc8707.html), indicate the target services or resources to be requested. Usually in a URI format variable, representing the resource's identity.
+API resources, a.k.a. [Resource Indicators](https://www.rfc-editor.org/rfc/rfc8707.html), indicate the target services or resources to be requested, usually, a URI format variable representing the resource's identity.
 
 ### Why is API resource needed?
 
-Logto, as an authorization server, is designed to serve a large number of diverse resources and APIs. By indicating which API resource an end-user intends to request, Logto will be able to determine the type and content of authorization tokens to be issued, how tokens are encrypted, and apply audience restrictions accordingly.
+Logto, as an authorization server, is designed to serve a large number of services and APIs. By indicating which API resource an end-user intends to access, Logto can issue a private encrypted authorization token and apply audience restrictions accordingly.
 
 A guarded request with an authorization token provided will help you protect your private resources from being accessed and attacked by anonymous identities.
 
@@ -24,15 +24,15 @@ A guarded request with an authorization token provided will help you protect you
 - It **SHOULD NOT** include a query component.
 - You **SHOULD** provide the most specific URI it can for the complete API or set of resources it intends to access.
 
-In practice, a client may know a base URI for the application or resource to interact with. It would be appropriate to use it as the value of the resource parameter.
+In practice, a client may know a base URI or the application or resource to interact with. It would be appropriate to use it as the value of the resource parameter.
 
-I.e., Logto management API base URI
+E.g., Logto management API base URI.
 
 ```
 https://api.logto.io
 ```
 
-By default, this API resource is pre-registered. All the management APIs under this URI are protected by Logto server.
+By default, this API resource is pre-registered to your Logto service. All the management APIs under this URI are protected by Logto.
 
 ### Logto API Resource Schema
 
@@ -42,7 +42,7 @@ By default, this API resource is pre-registered. All the management APIs under t
 
 ### 1. Authorization request
 
-When the resource parameter is used in an authorization request to the authorization endpoint, it indicates the identity of the protected resource(s) to which access is being requested.
+Provide a list of resource indicator parameters in an authorization request. It will indicate all the protected resource(s) that the user may request.
 
 ```bash
 GET https://logto.dev/oidc/auth?response_type=code
@@ -53,11 +53,11 @@ GET https://logto.dev/oidc/auth?response_type=code
     &resource=https%3A%2F%2Flogto.dev%2Fapi%2Fusers
 ```
 
-Logto will validate and process these resource indicators and grant the `authorization_code`.
+Logto will validate and store these resource indicators. An `authorization_code` will be granted and returned with scopes restricted to these specified resources.
 
 ### 2. Access Token request
 
-When the resource parameter is used on an access token request made to the token endpoint, it indicates the target service or protected resource where the client intends to use the requested access token.
+When the resource parameter is present on an access token request along with the `authorization_code` granted above, it will specify the target API resource audience of the access token is requested.
 
 ```bash
 POST https://logto.dev/oidc/token HTTP/1.1
@@ -68,11 +68,11 @@ POST https://logto.dev/oidc/token HTTP/1.1
     resource=https%3A%2F%2Flogto.test.dev%2Fusers
 ```
 
-An access token with the audience restricted to the requested resource will be granted by Logto.
+An encrypted access token with the audience restricted to this requested resource will be granted by Logto. The token carries all the data you will need to represent the authorization status of the request. E.g., the request user's identity and role, the token's audience and expiration time.
 
 ### 3. API resource request
 
-Client sent a request to the API resource with `access_token` provided in the Authorization header. Audience info and token expiration time are encoded in the encrypted `access_token`.
+The client user sent a request to the API resource by presenting the given `access_token` in the Authorization header.
 
 ```bash
 GET https://logto.dev/api/users


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Extract client token request guide from protecting your API to SDK

This PR includes following updates:
1. Make all docs under recipes collapsible as we will show all the language integration guide as subcategories.
<img width="329" alt="image" src="https://user-images.githubusercontent.com/36393111/188438067-78639c67-a1f6-4120-a41e-0db9c620f66b.png">

2. Refine and simplify some content in API resource and API protection docs.

3. Extract the `Integrate the resources authorization flow into your client application` section from Protect Your API

move the content under each client SDK integration guide.
<img width="1794" alt="image" src="https://user-images.githubusercontent.com/36393111/188438930-685e0de3-c33d-4bc4-90fc-687524a0c2c7.png">


Next Steps:

2/3:  Extract backend API protection guide to subcategories


3/3: Reorg document structure of integrating Logto with  applications:
- client
- traditional web
- backend

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
test locally
@logto-io/eng @logto-io/mandatory-reviewers 
