### PR TITLE
docs: add docker host static ip for platforms that do not support host domain

### DIFF
--- a/docs/docs/tutorials/get-started/README.mdx
+++ b/docs/docs/tutorials/get-started/README.mdx
@@ -113,7 +113,7 @@ ghcr.io/logto-io/logto:prerelease
 :::tip
 
 - If you are using Docker Hub, use `svhd/logto:prerelease` instead of `ghcr.io/logto-io/logto:prerelease`.
-- Use `host.docker.internal` in `DB_URL` to refer to the host IP.
+- Use `host.docker.internal` or `172.17.0.1` in `DB_URL` to refer to the host IP.
 
 :::
 

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/docs/tutorials/get-started/README.mdx
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/docs/tutorials/get-started/README.mdx
@@ -111,7 +111,7 @@ ghcr.io/logto-io/logto:prerelease
 :::tip
 
 - 如果你使用的是 Docker Hub，请将 `ghcr.io/logto-io/logto:prerelease` 替换成 `svhd/logto:prerelease`
-- 在 `DB_URL` 中使用 `host.docker.internal` 来指向主机 IP
+- 在 `DB_URL` 中使用 `host.docker.internal` 或 `172.17.0.1` 来指向主机 IP
 
 :::
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Add docker host static ip `172.17.0.1` for platforms that doesn't support host domain `host.docker.internal`, e.g. Ubuntu.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A
