### PR TITLE
docs(en): add backend authentication section to next.js instructions

### DIFF
--- a/docs/docs/recipes/integrate-logto/next-js.mdx
+++ b/docs/docs/recipes/integrate-logto/next-js.mdx
@@ -7,9 +7,11 @@ import Tabs from '@theme/Tabs';
 
 import redirectUriFigure from './assets/next-redirect-uri.png';
 import AppNote from './fragments/_app-note.mdx';
+import ApplyAuthorizationToken from './fragments/_apply_authorization_token.md';
 import ConfigureRedirectUri from './fragments/_configure-redirect-uri.mdx';
 import FurtherReadings from './fragments/_further-readings.md';
 import GetAppSecret from './fragments/_get-app-secret.mdx';
+import GetAuthorizationToken from './fragments/_get_authorization_token.md';
 import AssumingUrl from './fragments/_web-assuming-url.md';
 import SignInFlowSummary from './fragments/_web-sign-in-flow-summary.mdx';
 
@@ -54,7 +56,7 @@ pnpm add @logto/next
 Import and initialize LogtoClient:
 
 ```ts
-// libraries/logto.js
+// libraries/logto.ts
 import LogtoClient from '@logto/next';
 
 export const logtoClient = new LogtoClient({
@@ -121,11 +123,11 @@ There are two ways to get user profile.
 You can fetch user info by calling `/api/logto/user`
 
 ```tsx
-import { LogtoUser } from '@logto/next';
+import { LogtoContext } from '@logto/next';
 import useSWR from 'swr';
 
 const Home = () => {
-  const { data } = useSWR<LogtoUser>('/api/logto/user');
+  const { data } = useSWR<LogtoContext>('/api/logto/user');
 
   return <div>userId: {data?.claims?.sub}</div>;
 };
@@ -138,11 +140,11 @@ Check [this guide](https://swr.vercel.app/docs/getting-started) to learn more ab
 ### Through `getServerSideProps`
 
 ```tsx
-import { LogtoUser } from '@logto/next';
+import { LogtoContext } from '@logto/next';
 import { logtoClient } from '../libraries/logto';
 
 type Props = {
-  user: LogtoUser;
+  user: LogtoContext;
 };
 
 const Profile = ({ user }: Props) => {
@@ -227,6 +229,92 @@ After signing out, it'll be great to redirect your user back to your website. Le
 ```tsx
 <button onClick={() => push('/api/logto/sign-out')}>Sign Out</button>
 ```
+
+## Backend API Authorization
+
+<GetAuthorizationToken />
+
+Add your API resource indicators to the Logto SDK configs:
+
+```ts
+// libraries/logto.ts
+import LogtoClient from '@logto/next';
+
+export const logtoClient = new LogtoClient({
+  appId: '<your-application-id>',
+  appSecret: '<your-app-secret-copied-from-console>',
+  endpoint: '<your-logto-endpoint>', // E.g. http://localhost:3001
+  baseUrl: '<your-nextjs-app-base-url>', // E.g. http://localhost:3000
+  cookieSecret: 'complex_password_at_least_32_characters_long',
+  cookieSecure: process.env.NODE_ENV === 'production',
+  resources: ['<your-api-resource>'],
+});
+```
+
+Specify the resource when creating the API routes:
+
+```ts
+// pages/api/logto/[action].ts
+import { logtoClient } from '../../../libraries/logto';
+
+export default logtoClient.handleAuthRoutes({ resource: '<your-target-api-resource>' });
+```
+
+Claim an authorization token from inside wrapper withLogtoApiRoute:
+
+```ts
+// pages/api/protected-resource.ts
+import { logtoClient } from '../../libraries/logto';
+
+export default logtoClient.withLogtoApiRoute(
+  (request, response) => {
+    if (!request.user.isAuthenticated) {
+      response.status(401).json({ message: 'Unauthorized' });
+
+      return;
+    }
+
+    // Access token can be obtained from request.user.accessToken
+
+    response.json({
+      data: 'this_is_protected_resource',
+    });
+  },
+  { getAccessToken: true, resource: '<your-target-api-resource>' }
+);
+```
+
+You can also get the access token from inside getServerSideProps:
+
+```tsx
+import { LogtoContext } from '@logto/next';
+import { logtoClient } from '../libraries/logto';
+
+type Props = {
+  user: LogtoContext;
+};
+
+const Profile = ({ user }: Props) => {
+  return <div>User ID: {user.claims?.sub}</div>;
+};
+
+export default Profile;
+
+export const getServerSideProps = logtoClient.withLogtoSsr(
+  async function ({ req }) {
+    const { user } = req;
+
+    // Access token can be obtained from user.accessToken
+
+    return {
+      props: { user },
+    };
+  },
+  { getAccessToken: true, resource: '<your-target-api-resource>' }
+);
+```
+
+<ApplyAuthorizationToken />
 
 ## Further readings
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Add a section to Next.js SDK instructions for Backend Authorization. It is missing from this SDK's documentation. It follows the same structure as the other ones that already have it explicity documented (React, Vue, Android, VanillaJS, etc.).

![Next.js SDK New Section (1)](https://user-images.githubusercontent.com/22751806/202820849-3da5f9b0-4de6-406a-a0a0-94e96a5c3002.png)
![Next.js SDK New Section (2)](https://user-images.githubusercontent.com/22751806/202820847-b3af5ca4-a6d2-43f4-bc0b-72898ffc116b.png)
![Next.js SDK New Section (3)](https://user-images.githubusercontent.com/22751806/202820846-e83142e2-1263-4f1c-8051-86909bb5486a.png)


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
No testing needed.
