### PR TITLE
refactor: redirect to the new blog url

### DIFF
--- a/docs/docs/recipes/configure-connectors/configure-email-connector.md
+++ b/docs/docs/recipes/configure-connectors/configure-email-connector.md
@@ -16,7 +16,7 @@ Logto has some built-in email connectors which allow out-of-box usage:
 
 :::tip
 We're still working on more connectors! But If you don't see the connector you want, just let us know your needs in Discord or file a Feature Request on GitHub.
-For those using the Logto Open-Source Version, we offer the flexibility to [create your own connector](../create-your-connector/) to extend.
+For those using the Logto Open-Source Version, we offer the flexibility to [create your own connector](../create-your-connector/README.md) to extend.
 :::
 
 ## Configure steps

--- a/docs/docs/recipes/configure-connectors/configure-sms-connector.md
+++ b/docs/docs/recipes/configure-connectors/configure-sms-connector.md
@@ -15,7 +15,7 @@ Logto has some built-in SMS connectors which allow out-of-box usage:
 
 :::tip
 We're still working on more connectors! But If you don't see the connector you want, just let us know your needs in Discord or file a Feature Request on GitHub.
-For those using the Logto Open-Source Version, we offer the flexibility to [create your own connector](../create-your-connector/) to extend.
+For those using the Logto Open-Source Version, we offer the flexibility to [create your own connector](../create-your-connector/README.md) to extend.
 :::
 
 ## Configure steps

--- a/docs/docs/recipes/configure-connectors/configure-social-connector.md
+++ b/docs/docs/recipes/configure-connectors/configure-social-connector.md
@@ -14,7 +14,7 @@ Logto offers two types of social connectors:
 
 :::tip
 If the social connector you need isn't among our Common Social Connectors, you can create your own using the Standard Connector protocol. Check out our “[Custom Social Connector with Standard Protocol](./custom-social-connector-with-standard-protocols.md)” guide to learn more.
-If the Standard Connector still doesn't meet your needs, don't hesitate to contact us. For those using the Logto Open-Source Version, you can even [Write your connector (OSS)](../create-your-connector/).
+If the Standard Connector still doesn't meet your needs, don't hesitate to contact us. For those using the Logto Open-Source Version, you can even [Write your connector (OSS)](../create-your-connector/README.md).
 :::
 
 ## Types of common Social Connectors
@@ -35,7 +35,7 @@ Follow the README to compose the connector config with little effort.
 - **Microsoft Azure AD** [Universal connector](https://github.com/logto-io/logto/tree/master/packages/connectors/connector-azuread)
 
 :::info About the platform of Social connector
-You may find that some connectors do not have a secondary choice of platform, such as Google, Facebook, and GitHub. These connectors' _platform_ are _Universal_. Explore [_platform_](https://docs.logto.io/docs/references/connectors/#platform) to know more.
+You may find that some connectors do not have a secondary choice of platform, such as Google, Facebook, and GitHub. These connectors' _platform_ are _Universal_. Explore [_platform_](https://docs.logto.io/docs/references/connectors/README.mdx#platform) to know more.
 
 Choose a proper _platform_ from either _Web_ or _Native_ for connectors to fit your use case. You can set up a single _Native_ connector w/o adding a _Web_ connector if you only provide native mobile apps and vice versa.
 :::
@@ -56,4 +56,4 @@ Note that **each type of common social connector can only create one instance** 
 
 ## **Related Readings**
 
-- See [Configure sign-in method](../customize-sie/configure-sign-in-methods/) by adding connectors to bring your social connector into use.
+- See [Configure sign-in method](../customize-sie/configure-sign-in-methods.mdx) by adding connectors to bring your social connector into use.

--- a/docs/docs/recipes/configure-connectors/custom-social-connector-with-standard-protocols.md
+++ b/docs/docs/recipes/configure-connectors/custom-social-connector-with-standard-protocols.md
@@ -15,7 +15,7 @@ Follow the README to compose the connector config with little effort.
 
 :::tip
 We highly recommend using Logto's preinstalled social connectors, including Google, Apple, Facebook, GitHub, Discord, Wechat, Alipay, Kakao, Naver, and Microsoft Azure AD, as they are simple to configure and highly stable.
-Our standard connectors can meet most custom requirements, but if you need a specific connector beyond these, feel free to contact us. For those using the Logto Open-Source Version, you can even [Write your connector](../create-your-connector/).
+Our standard connectors can meet most custom requirements, but if you need a specific connector beyond these, feel free to contact us. For those using the Logto Open-Source Version, you can even [Write your connector](../create-your-connector/README.md).
 :::
 
 ## Configure steps
@@ -33,7 +33,7 @@ When customizing a standard connector, you will need to configure more general s
 3. **Identity provider (IdP) name**: IdP name is a unique identifier for each social connector and cannot be changed after it's built.
    1. When configuring a new Standard connector with a new Identity Provider, you just need to enter a unique "IdP name" that hasn't been used before. This will allow you to distinguish the new social connector from others that have been created.
    2. If you need to replace an existing social connector with the same identity provider, you must delete the old one and create a new one with the same “IdP name”.
-   3. You can learn more about usage cases of IdP name by visiting the “[Recipe: IdP name](../../references/connectors/)”.
+   3. You can learn more about usage cases of IdP name by visiting the “[Recipe: IdP name](../../references/connectors/README.mdx)”.
 4. Standard Connector also can choose how to “**sync user profiles**” (such as avatars and usernames). The default setting is to only sync at registration. Still, you can also choose to always sync at each sign-in, but be careful that this may overwrite customized information in your application at user each social sign-in.
 5. Finally, note that different standard connectors require different configuration parameters. You can refer to the left **README** for guidance on filling out the forms.
 
@@ -41,4 +41,4 @@ When customizing a standard connector, you will need to configure more general s
 
 ## Related Readings
 
-- See [Configure sign-in method](../customize-sie/configure-sign-in-methods/) by adding connectors to bring your social connector into use.
+- See [Configure sign-in method](../customize-sie/configure-sign-in-methods.mdx) by adding connectors to bring your social connector into use.

--- a/docs/docs/recipes/create-your-connector/connector-file-structure.mdx
+++ b/docs/docs/recipes/create-your-connector/connector-file-structure.mdx
@@ -45,7 +45,7 @@ Based on the connector file structure, let's go through each file and figure out
 `logo-dark.svg` file contains vector graphic of connector's dark mode logo.
 
 :::note
-See [connector logo](../../references/connectors/#logo) to know more about the relationship between `logo.svg` and `logo-dark.svg`.
+See [connector logo](../../references/connectors/README.mdx#logo) to know more about the relationship between `logo.svg` and `logo-dark.svg`.
 :::
 
 ## index.ts

--- a/docs/docs/recipes/create-your-connector/connector-implementation-guide.mdx
+++ b/docs/docs/recipes/create-your-connector/connector-implementation-guide.mdx
@@ -270,7 +270,7 @@ For more details on configurable parameters, see Aliyun direct mail connector RE
 
 ## What's more?
 
-To see connector methods' definition and build a picture of connector interface design, see [`@logto/connector-kit`](https://github.com/logto-io/logto/tree/master/packages/toolkit/connector-kit). You can also find _ConnectorMetadata_ reference at "[Connectors - ConnectorMetadata](../../references/connectors/#connectors-local-storage-connectormetadata)" and "[Connector file structure](./connector-file-structure.mdx)" can help you figure out how to organize your implementation.
+To see connector methods' definition and build a picture of connector interface design, see [`@logto/connector-kit`](https://github.com/logto-io/logto/tree/master/packages/toolkit/connector-kit). You can also find _ConnectorMetadata_ reference at "[Connectors - ConnectorMetadata](../../references/connectors/README.mdx#connectors-local-storage-connectormetadata)" and "[Connector file structure](./connector-file-structure.mdx)" can help you figure out how to organize your implementation.
 
 - A connector's config [_Zod_](https://github.com/colinhacks/zod) schema is obligatory for all connectors. This is quite important since we do type check before saving `config` to DB and calling APIs which requires `config` information.
 - All _SMS Connectors_ and _Email Connectors_ require a `sendMessage` method to call service providers message sending APIs using configs from the database. Developers can also reuse this method to send a testing message with unsaved config while setting connectors up in Admin Console.
@@ -289,4 +289,4 @@ We assume that you have already finished building your own connector. Go through
 
 You can now test and try out your connector to see whether it works as expected.
 
-If you want to add connectors that have already been published to NPM or Logto official connectors, you may check out [Using Logto CLI - Manage connectors](../../tutorials/using-cli/manage-connectors#add-connectors).
+If you want to add connectors that have already been published to NPM or Logto official connectors, you may check out [Using Logto CLI - Manage connectors](../../tutorials/using-cli/manage-connectors.mdx#add-connectors).

--- a/docs/docs/recipes/interact-with-management-api/README.md
+++ b/docs/docs/recipes/interact-with-management-api/README.md
@@ -45,7 +45,7 @@ Our developers have implemented many additional features using our management AP
 
 ## How to?
 
-1. Follow the tutorial [Create and integrate the first application](../../tutorials/get-started/create-and-integrate-the-first-app/) to create a Machine to Machine app in Admin Console.
+1. Follow the tutorial [Create and integrate the first application](../../tutorials/get-started/create-and-integrate-the-first-app.mdx) to create a Machine to Machine app in Admin Console.
 2. Follow the guide [Machine to Machine: Auth with Logto](../integrate-logto/machine-to-machine.mdx) to fetch an Access Token for the API identifier `https://tenantid.logto.app/api` (indicates Management API) and scope `all` (all permissions).
 3. Interact with Management API with Bearer authorization using the Access Token.
 

--- a/docs/docs/tutorials/get-started/explore-management-api.md
+++ b/docs/docs/tutorials/get-started/explore-management-api.md
@@ -16,7 +16,7 @@ Before calling and using the management API, it's important to create a **machin
 
 ## Guide
 
-1. To create a Machine to Machine app in the Admin Console, follow the tutorial [Create and integrate the first application](./create-and-integrate-the-first-app/).
+1. To create a Machine to Machine app in the Admin Console, follow the tutorial [Create and integrate the first application](./create-and-integrate-the-first-app.mdx).
 2. To obtain an access token for the `https://tenantid.logto.app/api` Management API and the `all` scope (which grants all permissions), follow the instructions in the [Machine to Machine: Auth with Logto](../../recipes/integrate-logto/machine-to-machine.mdx) guide.
 3. Interact with the Management API using Bearer authorization and the Access Token.
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -63,6 +63,8 @@ const config = {
     mermaid: true,
   },
 
+  trailingSlash: true,
+
   presets: [
     [
       'classic',
@@ -104,7 +106,7 @@ const config = {
             label: 'Docs',
           },
           {
-            to: 'blog',
+            href: 'https://blog.logto.io/',
             position: 'left',
             label: 'Blog',
           },

--- a/src/theme/BlogPostItem/Header/Title/index.tsx
+++ b/src/theme/BlogPostItem/Header/Title/index.tsx
@@ -2,6 +2,7 @@ import Link from '@docusaurus/Link';
 import { useBlogPost } from '@docusaurus/theme-common/internal';
 import type { Props } from '@theme/BlogPostItem/Header/Title';
 import clsx from 'clsx';
+import { useEffect } from 'react';
 
 import styles from './styles.module.css';
 
@@ -9,6 +10,22 @@ const Title = ({ className }: Props): JSX.Element => {
   const { metadata, isBlogPostPage } = useBlogPost();
   const { permalink, title } = metadata;
   const TitleHeading = isBlogPostPage ? 'h1' : 'h2';
+
+  // Redirect to the new blog. The whole component will be removed later.
+  useEffect(() => {
+    const url = new URL(
+      isBlogPostPage ? window.location.pathname.replace(/^\/blog/, '') : '/',
+      'https://blog.logto.io'
+    );
+    const parameters = new URLSearchParams(window.location.search);
+
+    for (const [key, value] of parameters.entries()) {
+      url.searchParams.append(key, value);
+    }
+
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    window.location.href = url.href;
+  }, [isBlogPostPage]);
 
   return (
     <TitleHeading

--- a/versioned_docs/version-1.x/docs/recipes/configure-connectors/configure-email-connector.md
+++ b/versioned_docs/version-1.x/docs/recipes/configure-connectors/configure-email-connector.md
@@ -16,7 +16,7 @@ Logto has some built-in email connectors which allow out-of-box usage:
 
 :::tip
 We're still working on more connectors! But If you don't see the connector you want, just let us know your needs in Discord or file a Feature Request on GitHub.
-For those using the Logto Open-Source Version, we offer the flexibility to [create your own connector](../create-your-connector/) to extend.
+For those using the Logto Open-Source Version, we offer the flexibility to [create your own connector](../create-your-connector/README.md) to extend.
 :::
 
 ## Configure steps

--- a/versioned_docs/version-1.x/docs/recipes/configure-connectors/configure-sms-connector.md
+++ b/versioned_docs/version-1.x/docs/recipes/configure-connectors/configure-sms-connector.md
@@ -15,7 +15,7 @@ Logto has some built-in SMS connectors which allow out-of-box usage:
 
 :::tip
 We're still working on more connectors! But If you don't see the connector you want, just let us know your needs in Discord or file a Feature Request on GitHub.
-For those using the Logto Open-Source Version, we offer the flexibility to [create your own connector](../create-your-connector/) to extend.
+For those using the Logto Open-Source Version, we offer the flexibility to [create your own connector](../create-your-connector/README.md) to extend.
 :::
 
 ## Configure steps

--- a/versioned_docs/version-1.x/docs/recipes/configure-connectors/configure-social-connector.md
+++ b/versioned_docs/version-1.x/docs/recipes/configure-connectors/configure-social-connector.md
@@ -14,7 +14,7 @@ Logto offers two types of social connectors:
 
 :::tip
 If the social connector you need isn't among our Common Social Connectors, you can create your own using the Standard Connector protocol. Check out our “[Custom Social Connector with Standard Protocol](./custom-social-connector-with-standard-protocols.md)” guide to learn more.
-If the Standard Connector still doesn't meet your needs, don't hesitate to contact us. For those using the Logto Open-Source Version, you can even [Write your connector (OSS)](../create-your-connector/).
+If the Standard Connector still doesn't meet your needs, don't hesitate to contact us. For those using the Logto Open-Source Version, you can even [Write your connector (OSS)](../create-your-connector/README.md).
 :::
 
 ## Types of common Social Connectors
@@ -35,7 +35,7 @@ Follow the README to compose the connector config with little effort.
 - **Microsoft Azure AD** [Universal connector](https://github.com/logto-io/logto/tree/master/packages/connectors/connector-azuread)
 
 :::info About the platform of Social connector
-You may find that some connectors do not have a secondary choice of platform, such as Google, Facebook, and GitHub. These connectors' _platform_ are _Universal_. Explore [_platform_](https://docs.logto.io/docs/references/connectors/#platform) to know more.
+You may find that some connectors do not have a secondary choice of platform, such as Google, Facebook, and GitHub. These connectors' _platform_ are _Universal_. Explore [_platform_](https://docs.logto.io/docs/references/connectors/README.mdx#platform) to know more.
 
 Choose a proper _platform_ from either _Web_ or _Native_ for connectors to fit your use case. You can set up a single _Native_ connector w/o adding a _Web_ connector if you only provide native mobile apps and vice versa.
 :::
@@ -56,4 +56,4 @@ Note that **each type of common social connector can only create one instance** 
 
 ## **Related Readings**
 
-- See [Configure sign-in method](../customize-sie/configure-sign-in-methods/) by adding connectors to bring your social connector into use.
+- See [Configure sign-in method](../customize-sie/configure-sign-in-methods.mdx) by adding connectors to bring your social connector into use.

--- a/versioned_docs/version-1.x/docs/recipes/configure-connectors/custom-social-connector-with-standard-protocols.md
+++ b/versioned_docs/version-1.x/docs/recipes/configure-connectors/custom-social-connector-with-standard-protocols.md
@@ -15,7 +15,7 @@ Follow the README to compose the connector config with little effort.
 
 :::tip
 We highly recommend using Logto's preinstalled social connectors, including Google, Apple, Facebook, GitHub, Discord, Wechat, Alipay, Kakao, Naver, and Microsoft Azure AD, as they are simple to configure and highly stable.
-Our standard connectors can meet most custom requirements, but if you need a specific connector beyond these, feel free to contact us. For those using the Logto Open-Source Version, you can even [Write your connector](../create-your-connector/).
+Our standard connectors can meet most custom requirements, but if you need a specific connector beyond these, feel free to contact us. For those using the Logto Open-Source Version, you can even [Write your connector](../create-your-connector/README.md).
 :::
 
 ## Configure steps
@@ -33,7 +33,7 @@ When customizing a standard connector, you will need to configure more general s
 3. **Identity provider (IdP) name**: IdP name is a unique identifier for each social connector and cannot be changed after it's built.
    1. When configuring a new Standard connector with a new Identity Provider, you just need to enter a unique "IdP name" that hasn't been used before. This will allow you to distinguish the new social connector from others that have been created.
    2. If you need to replace an existing social connector with the same identity provider, you must delete the old one and create a new one with the same “IdP name”.
-   3. You can learn more about usage cases of IdP name by visiting the “[Recipe: IdP name](../../references/connectors/)”.
+   3. You can learn more about usage cases of IdP name by visiting the “[Recipe: IdP name](../../references/connectors/README.mdx)”.
 4. Standard Connector also can choose how to “**sync user profiles**” (such as avatars and usernames). The default setting is to only sync at registration. Still, you can also choose to always sync at each sign-in, but be careful that this may overwrite customized information in your application at user each social sign-in.
 5. Finally, note that different standard connectors require different configuration parameters. You can refer to the left **README** for guidance on filling out the forms.
 
@@ -41,4 +41,4 @@ When customizing a standard connector, you will need to configure more general s
 
 ## Related Readings
 
-- See [Configure sign-in method](../customize-sie/configure-sign-in-methods/) by adding connectors to bring your social connector into use.
+- See [Configure sign-in method](../customize-sie/configure-sign-in-methods.mdx) by adding connectors to bring your social connector into use.

--- a/versioned_docs/version-1.x/docs/recipes/create-your-connector/connector-file-structure.mdx
+++ b/versioned_docs/version-1.x/docs/recipes/create-your-connector/connector-file-structure.mdx
@@ -45,7 +45,7 @@ Based on the connector file structure, let's go through each file and figure out
 `logo-dark.svg` file contains vector graphic of connector's dark mode logo.
 
 :::note
-See [connector logo](../../references/connectors/#logo) to know more about the relationship between `logo.svg` and `logo-dark.svg`.
+See [connector logo](../../references/connectors/README.mdx#logo) to know more about the relationship between `logo.svg` and `logo-dark.svg`.
 :::
 
 ## index.ts

--- a/versioned_docs/version-1.x/docs/recipes/create-your-connector/connector-implementation-guide.mdx
+++ b/versioned_docs/version-1.x/docs/recipes/create-your-connector/connector-implementation-guide.mdx
@@ -270,7 +270,7 @@ For more details on configurable parameters, see Aliyun direct mail connector RE
 
 ## What's more?
 
-To see connector methods' definition and build a picture of connector interface design, see [`@logto/connector-kit`](https://github.com/logto-io/logto/tree/master/packages/toolkit/connector-kit). You can also find _ConnectorMetadata_ reference at "[Connectors - ConnectorMetadata](../../references/connectors/#connectors-local-storage-connectormetadata)" and "[Connector file structure](./connector-file-structure.mdx)" can help you figure out how to organize your implementation.
+To see connector methods' definition and build a picture of connector interface design, see [`@logto/connector-kit`](https://github.com/logto-io/logto/tree/master/packages/toolkit/connector-kit). You can also find _ConnectorMetadata_ reference at "[Connectors - ConnectorMetadata](../../references/connectors/README.mdx#connectors-local-storage-connectormetadata)" and "[Connector file structure](./connector-file-structure.mdx)" can help you figure out how to organize your implementation.
 
 - A connector's config [_Zod_](https://github.com/colinhacks/zod) schema is obligatory for all connectors. This is quite important since we do type check before saving `config` to DB and calling APIs which requires `config` information.
 - All _SMS Connectors_ and _Email Connectors_ require a `sendMessage` method to call service providers message sending APIs using configs from the database. Developers can also reuse this method to send a testing message with unsaved config while setting connectors up in Admin Console.
@@ -289,4 +289,4 @@ We assume that you have already finished building your own connector. Go through
 
 You can now test and try out your connector to see whether it works as expected.
 
-If you want to add connectors that have already been published to NPM or Logto official connectors, you may check out [Using Logto CLI - Manage connectors](../../tutorials/using-cli/manage-connectors#add-connectors).
+If you want to add connectors that have already been published to NPM or Logto official connectors, you may check out [Using Logto CLI - Manage connectors](../../tutorials/using-cli/manage-connectors.mdx#add-connectors).

--- a/versioned_docs/version-1.x/docs/recipes/interact-with-management-api/README.md
+++ b/versioned_docs/version-1.x/docs/recipes/interact-with-management-api/README.md
@@ -45,7 +45,7 @@ Our developers have implemented many additional features using our management AP
 
 ## How to?
 
-1. Follow the tutorial [Create and integrate the first application](../../tutorials/get-started/create-and-integrate-the-first-app/) to create a Machine to Machine app in Admin Console.
+1. Follow the tutorial [Create and integrate the first application](../../tutorials/get-started/create-and-integrate-the-first-app.mdx) to create a Machine to Machine app in Admin Console.
 2. Follow the guide [Machine to Machine: Auth with Logto](../integrate-logto/machine-to-machine.mdx) to fetch an Access Token for the API identifier `https://tenantid.logto.app/api` (indicates Management API) and scope `all` (all permissions).
 3. Interact with Management API with Bearer authorization using the Access Token.
 

--- a/versioned_docs/version-1.x/docs/tutorials/get-started/explore-management-api.md
+++ b/versioned_docs/version-1.x/docs/tutorials/get-started/explore-management-api.md
@@ -16,7 +16,7 @@ Before calling and using the management API, it's important to create a **machin
 
 ## Guide
 
-1. To create a Machine to Machine app in the Admin Console, follow the tutorial [Create and integrate the first application](./create-and-integrate-the-first-app/).
+1. To create a Machine to Machine app in the Admin Console, follow the tutorial [Create and integrate the first application](./create-and-integrate-the-first-app.mdx).
 2. To obtain an access token for the `https://tenantid.logto.app/api` Management API and the `all` scope (which grants all permissions), follow the instructions in the [Machine to Machine: Auth with Logto](../../recipes/integrate-logto/machine-to-machine.mdx) guide.
 3. Interact with the Management API using Bearer authorization and the Access Token.
 


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

- try to fix sitemap issue by adopting https://github.com/facebook/docusaurus/issues/2134#issuecomment-858475670
- redirect to the new blog address before completely remove the component

## Testing

### Redirecting

```
http://localhost:3000/blog/releases/2023-feb-extended?foo=bar&bar=baz
```

redirects to

```
https://blog.logto.io/releases/2023-feb-extended/?foo=bar&bar=baz
```

### Sitemap

- [x] no client redirect URLs in sitemap