### PR TITLE
docs: remove message id from webhook docs

### DIFF
--- a/docs/docs/recipes/webhooks/webhook-request.md
+++ b/docs/docs/recipes/webhooks/webhook-request.md
@@ -16,7 +16,6 @@ Once a valid hook event is emitted, Logto will find corresponding webhooks and s
 | user-agent              | ✅           | `Logto (https://logto.io/)` by default                                                            |
 | content-type            | ✅           | `application/json` by default                                                                     |
 | logto-signature-sha-256 |              | the signature of the request body, refer to [Securing your webhooks](./securing-your-webhooks.md) |
-| logto-message-id        |              | a unique message ID                                                                               |
 
 You can overwrite customizable headers by [customizing request](./configure-webhooks-in-console.md#secure-webhook) headers with the same key.
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Remove message id from webhook docs.
Related PR: https://github.com/logto-io/logto/pull/3979
