### PR TITLE
fix: the express cookie maxage should be in miliseconds

### DIFF
--- a/docs/docs/recipes/integrate-logto/express/_init_client.mdx
+++ b/docs/docs/recipes/integrate-logto/express/_init_client.mdx
@@ -27,5 +27,10 @@ import cookieParser from 'cookie-parser';
 import session from 'express-session';
 
 app.use(cookieParser());
-app.use(session({ secret: 'random_session_key', cookie: { maxAge: 14 * 24 * 60 * 60 } }));
+app.use(
+  session({
+    secret: 'random_session_key',
+    cookie: { maxAge: 14 * 24 * 60 * 60 * 1000 }, // In miliseconds
+  })
+);
 ```

--- a/versioned_docs/version-1.x/docs/recipes/integrate-logto/express/_init_client.mdx
+++ b/versioned_docs/version-1.x/docs/recipes/integrate-logto/express/_init_client.mdx
@@ -27,5 +27,10 @@ import cookieParser from 'cookie-parser';
 import session from 'express-session';
 
 app.use(cookieParser());
-app.use(session({ secret: 'random_session_key', cookie: { maxAge: 14 * 24 * 60 * 60 } }));
+app.use(
+  session({
+    secret: 'random_session_key',
+    cookie: { maxAge: 14 * 24 * 60 * 60 * 1000 }, // In miliseconds
+  })
+);
 ```


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
The "maxAge" in express integration tutorial should be in miliseconds.
