### PR TITLE
docs: fix code error for API protection with node(express)

### DIFF
--- a/docs/docs/recipes/protect-your-api/fragments/_token_extract.mdx
+++ b/docs/docs/recipes/protect-your-api/fragments/_token_extract.mdx
@@ -13,11 +13,13 @@ The request should contain an `Authorization` header with a `Bearer <access_toke
 import { IncomingHttpHeaders } from 'http';
 
 const extractBearerTokenFromHeaders = ({ authorization }: IncomingHttpHeaders) => {
+  const bearerTokenIdentifier = 'Bearer';
+
   if (!authorization) {
     throw new Error({ code: 'auth.authorization_header_missing', status: 401 });
   }
 
-  if (!authorization.startsWith('Bearer')) {
+  if (!authorization.startsWith(bearerTokenIdentifier)) {
     throw new Error({ code: 'auth.authorization_token_type_not_supported', status: 401 });
   }
 

--- a/docs/docs/recipes/protect-your-api/node.mdx
+++ b/docs/docs/recipes/protect-your-api/node.mdx
@@ -22,11 +22,13 @@ A authorized request should contain an `Authorization` header with `Bearer <acce
 import { IncomingHttpHeaders } from 'http';
 
 const extractBearerTokenFromHeaders = ({ authorization }: IncomingHttpHeaders) => {
+  const bearerTokenIdentifier = 'Bearer';
+
   if (!authorization) {
     throw new Error({ code: 'auth.authorization_header_missing', status: 401 });
   }
 
-  if (!authorization.startsWith('Bearer')) {
+  if (!authorization.startsWith(bearerTokenIdentifier)) {
     throw new Error({ code: 'auth.authorization_token_type_not_supported', status: 401 });
   }
 

--- a/versioned_docs/version-1.x/docs/recipes/protect-your-api/fragments/_token_extract.mdx
+++ b/versioned_docs/version-1.x/docs/recipes/protect-your-api/fragments/_token_extract.mdx
@@ -13,11 +13,13 @@ The request should contain an `Authorization` header with a `Bearer <access_toke
 import { IncomingHttpHeaders } from 'http';
 
 const extractBearerTokenFromHeaders = ({ authorization }: IncomingHttpHeaders) => {
+  const bearerTokenIdentifier = 'Bearer';
+
   if (!authorization) {
     throw new Error({ code: 'auth.authorization_header_missing', status: 401 });
   }
 
-  if (!authorization.startsWith('Bearer')) {
+  if (!authorization.startsWith(bearerTokenIdentifier)) {
     throw new Error({ code: 'auth.authorization_token_type_not_supported', status: 401 });
   }
 

--- a/versioned_docs/version-1.x/docs/recipes/protect-your-api/node.mdx
+++ b/versioned_docs/version-1.x/docs/recipes/protect-your-api/node.mdx
@@ -22,11 +22,13 @@ A authorized request should contain an `Authorization` header with `Bearer <acce
 import { IncomingHttpHeaders } from 'http';
 
 const extractBearerTokenFromHeaders = ({ authorization }: IncomingHttpHeaders) => {
+  const bearerTokenIdentifier = 'Bearer';
+
   if (!authorization) {
     throw new Error({ code: 'auth.authorization_header_missing', status: 401 });
   }
 
-  if (!authorization.startsWith('Bearer')) {
+  if (!authorization.startsWith(bearerTokenIdentifier)) {
     throw new Error({ code: 'auth.authorization_token_type_not_supported', status: 401 });
   }
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Just fix some simple code error for API protection docs with node(express).

**Note**

The code 

```js
    throw new Error({ code: 'auth.authorization_header_missing', status: 401 });
```

will result in a typescript warning:

![image](https://github.com/logto-io/docs/assets/1164623/9ebd3cc6-5cb3-4c77-a35f-7f3d97dc9772)

From what I can see in the [core repo](https://github.com/logto-io/logto/blob/7c09ac850f9d9edabee67bc0d44c991a0d54d0c4/packages/core/src/middleware/koa-auth/index.ts#L30-L44), the code has been improved and get rid of the TypeScript error.

Not sure whether you guys would fix this typescript warning in docs code snippet.
