### PR TITLE
docs: add python/php tutorial template

### DIFF
--- a/tutorial/build-with-logto/_integrate-sdk-php.mdx
+++ b/tutorial/build-with-logto/_integrate-sdk-php.mdx
@@ -1,0 +1,31 @@
+import ImplementCallbackRoute from '../../docs/sdk/php/_implement_callback_route.md';
+import ImplementSignInRoute from '../../docs/sdk/php/_implement_sign_in_route.mdx';
+import ImplementSignOutRoute from '../../docs/sdk/php/_implement_sign_out_route.mdx';
+import InitLogtoClient from '../../docs/sdk/php/_init_logto_client.mdx';
+import Installation from '../../docs/sdk/php/_installation.md';
+import PhpTutorialTip from '../../docs/sdk/php/_php_tutorial_tip.md';
+import TestYourIntegration from './fragments/_test-your-integration.mdx';
+
+<PhpTutorialTip />
+
+### Installation
+
+<Installation />
+
+### Init LogtoClient
+
+<InitLogtoClient />
+
+### Implement sign-in route
+
+<ImplementSignInRoute />
+
+### Implement the callback route
+
+<ImplementCallbackRoute />
+
+### Implement sign-out route
+
+<ImplementSignOutRoute />
+
+<TestYourIntegration sdk="PHP" />

--- a/tutorial/build-with-logto/_integrate-sdk-python.mdx
+++ b/tutorial/build-with-logto/_integrate-sdk-python.mdx
@@ -1,0 +1,31 @@
+import ImplementCallbackRoute from '../../docs/sdk/python/_implement_callback_route.md';
+import ImplementSignInRoute from '../../docs/sdk/python/_implement_sign_in_route.mdx';
+import ImplementSignOutRoute from '../../docs/sdk/python/_implement_sign_out_route.mdx';
+import InitLogtoClient from '../../docs/sdk/python/_init_logto_client.mdx';
+import Installation from '../../docs/sdk/python/_installation.md';
+import PythonTutorialTip from '../../docs/sdk/python/_python_tutorial_tip.md';
+import TestYourIntegration from './fragments/_test-your-integration.mdx';
+
+<PythonTutorialTip />
+
+### Installation
+
+<Installation />
+
+### Init LogtoClient
+
+<InitLogtoClient />
+
+### Implement sign-in route
+
+<ImplementSignInRoute />
+
+### Implement the callback route
+
+<ImplementCallbackRoute />
+
+### Implement sign-out route
+
+<ImplementSignOutRoute />
+
+<TestYourIntegration sdk="Python" />

--- a/tutorial/build-with-logto/fragments/_intro.mdx
+++ b/tutorial/build-with-logto/fragments/_intro.mdx
@@ -1,28 +1,18 @@
+{/* `prettier` formats the react components and breaks lines into pieces which makes the content ugly and hard to read. */}
+{/* eslint-disable prettier/prettier */}
 :::info For our new friends
 [Logto](https://logto.io) is a cost-effective open-source alternative to Auth0. It offers OpenId Connect (OIDC) based authentication and authorization, with modern features like passwordless sign-in and role-based access control.
 :::
 
 <p>
   In this article, we will go through the steps to quickly build the {props.connector} sign-in
-  experience (user authentication) with{' '}
-  <a href={props.link} target="_blank" rel="noopener">
-    {props.sdk}
-  </a>
-  <span> and </span>
-  <a href="https://logto.io" target="_blank" rel="noopener">
-    Logto
-  </a>
-  .
+  experience (user authentication) with <a href={props.link} target="_blank" rel="noopener">{props.sdk}</a> and&nbsp;
+  <a href="https://logto.io" target="_blank" rel="noopener">Logto</a>.
 </p>
 
 **Prerequisites**
 
 - A running Logto instance. Check out the [get started page](/docs/tutorials/get-started/) if you don't have one.
-- <span>
-    Basic knowledge of{' '}
-    <a href={props.link} target="_blank" rel="noopener">
-      {props.sdk}
-    </a>
-    .
-  </span>
+- <span>Basic knowledge of <a href={props.link} target="_blank" rel="noopener">{props.sdk}</a>.</span>
 - <span>A usable {props.connector} account.</span>
+{/* eslint-enable prettier/prettier */}

--- a/tutorial/build-with-logto/generate.js
+++ b/tutorial/build-with-logto/generate.js
@@ -75,6 +75,20 @@ const sdks = [
     appType: 'Traditional Web',
     framework: 'Express',
   },
+  {
+    name: 'Python',
+    language: 'python',
+    officialLink: 'https://www.python.org/',
+    appType: 'Traditional Web',
+    framework: 'Flask',
+  },
+  {
+    name: 'PHP',
+    language: 'php',
+    officialLink: 'https://www.php.net/',
+    appType: 'Traditional Web',
+    framework: 'Laravel',
+  },
 ];
 
 /**


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
1. Add Python/PHP tutorial template.
2. Fix the unexpected newlines in the tutorial template "_intro.mdx".
Before:
<img width="993" alt="image" src="https://github.com/logto-io/docs/assets/15182327/800c069f-8ad4-4013-8ff7-23a5125fd752">
Now:
<img width="1047" alt="image" src="https://github.com/logto-io/docs/assets/15182327/60238306-d67d-4a1d-b9d4-d4c826699ecd">

