### PR TITLE
refactor: reorg get user information section

### DIFF
--- a/docs/sdk/fragments/_get-user-info-apis.mdx
+++ b/docs/sdk/fragments/_get-user-info-apis.mdx
@@ -1,0 +1,10 @@
+You can use Logto API to retrieve user information:
+
+- <code>{props.getIdTokenClaimsApi}</code>: get user information from ID token.
+- <code>{props.fetchUserInfoApi}</code>: fetch user information from the OIDC [Userinfo
+  Endpoint](https://openid.net/specs/openid-connect-core-1_0.html#UserInfo) provided by Logto.
+
+It's important to note that the user information claims that can be retrieved depending on the
+scopes used by the user during signing-in, and considering performance and data size, the ID token
+may not contain all user claims, some user claims are only available in the userinfo endpoint (see
+the related list below).

--- a/docs/sdk/fragments/_scopes-and-claims.mdx
+++ b/docs/sdk/fragments/_scopes-and-claims.mdx
@@ -1,18 +1,10 @@
 import ScopeClaimList from './_scope-claim-list.md';
 
-Both of "scope" and "claim" are terms from the OAuth 2.0 and OpenID Connect (OIDC) specifications. In OIDC, there are some optional [scopes and claims conventions](https://openid.net/specs/openid-connect-core-1_0.html#Claims) to follow. Logto uses these conventions to define the scopes and claims for the ID token.
+Logto uses OIDC [scopes and claims conventions](https://openid.net/specs/openid-connect-core-1_0.html#Claims) to define the scopes and claims for retrieving user information from the ID token and OIDC <a href="https://openid.net/specs/openid-connect-core-1_0.html#UserInfo">Userinfo Endpoint</a>. Both of the "scope" and the "claim" are terms from the OAuth 2.0 and OpenID Connect (OIDC) specifications.
 
-In short, when you request a scope, you will get the corresponding claims in the ID token. For example, if you request the `email` scope, you will get the `email` and `email_verified` claims in the ID token.
+In short, when you request a scope, you will get the corresponding claims in the user information. For example, if you request the `email` scope, you will get the `email` and `email_verified` data of the user.
 
-{props.fetchUserInfoApi &&
-
-<>
-
-And this mechanism is also applied to the OIDC <a href="https://openid.net/specs/openid-connect-core-1_0.html#UserInfo">Userinfo Endpoint</a>, you can fetch the user information from the &quot;Userinfo Endpoint&quot; by calling <code>{props.fetchUserInfoApi}</code> API in Logto SDK.
-
-</>}
-
-By default, Logto SDK will always requests three scopes: `openid`, `profile`, and `offline_access`, and there is no way to remove these default scopes. But you can add more scopes when configuring the Logto:
+By default, Logto SDK will always request three scopes: `openid`, `profile`. And `offline_access`, and there is no way to remove these default scopes. But you can add more scopes when configuring Logto:
 
 {props.configScopesCode}
 

--- a/docs/sdk/native/android/README.mdx
+++ b/docs/sdk/native/android/README.mdx
@@ -5,6 +5,7 @@ sidebar_label: Android (Kotlin / Java)
 
 import ApiResourcesDescription from '../../fragments/_api-resources-description.md';
 import FurtherReadings from '../../fragments/_further-readings.md';
+import GetUserInfoApis from '../../fragments/_get-user-info-apis.mdx';
 
 import CheckIntegration from './_check-integration.md';
 import AndroidGuideTip from './_guide-tip.md';
@@ -56,7 +57,9 @@ This guide will show you how to integrate Logto into your Android application.
 
 <CheckIntegration />
 
-## Scopes and claims
+## Get user information
+
+<GetUserInfoApis getIdTokenClaimsApi="getIdTokenClaims" fetchUserInfoApi="fetchUserInfo" />
 
 <ScopesAndClaims />
 

--- a/docs/sdk/native/android/scopes-and-claims/_scopes-and-claims.mdx
+++ b/docs/sdk/native/android/scopes-and-claims/_scopes-and-claims.mdx
@@ -2,4 +2,4 @@ import ScopesAndClaims from '../../../fragments/_scopes-and-claims.mdx';
 
 import ScopesAndClaimsCode from './_scopes-and-claims-code.md';
 
-<ScopesAndClaims fetchUserInfoApi="fetchUserInfo" configScopesCode={<ScopesAndClaimsCode />} />
+<ScopesAndClaims configScopesCode={<ScopesAndClaimsCode />} />

--- a/docs/sdk/native/flutter/README.mdx
+++ b/docs/sdk/native/flutter/README.mdx
@@ -7,10 +7,10 @@ import FurtherReadings from '../../fragments/_further-readings.md';
 
 import ApiResources from './_api-resources.mdx';
 import Dependency from './_dependency.mdx';
+import GetUserInfo from './_get-user-info.mdx';
 import Installation from './_installation.mdx';
 import Integration from './_integration.mdx';
 import Organization from './_organization.mdx';
-import ScopesAndClaims from './_scopes-and-claims.mdx';
 import Tip from './_tip.md';
 
 # Flutter SDK tutorial
@@ -38,9 +38,9 @@ This tutorial will show you how to integrate Logto into your Flutter application
 
 <Integration />
 
-## Scopes and user claims
+## Get user information
 
-<ScopesAndClaims />
+<GetUserInfo />
 
 ## API resources
 

--- a/docs/sdk/native/flutter/_get-user-info.mdx
+++ b/docs/sdk/native/flutter/_get-user-info.mdx
@@ -2,10 +2,6 @@ import ScopesAndClaims from '../../fragments/_scopes-and-claims.mdx';
 
 import ScopesAndClaimsCode from './code-snippets/_scopes-code.mdx';
 
-<ScopesAndClaims fetchUserInfoApi="fetchUserInfo" configScopesCode={<ScopesAndClaimsCode />} />
-
-### Get user info after authentication
-
 Once you have successfully authenticated the user, you can get the user's information by calling the `fetchUserInfo` method.
 
 ```dart
@@ -44,4 +40,4 @@ class _MyHomePageState extends State<MyHomePage> {
 
 ```
 
-Based on the scopes you have configured, the `fetchUserInfo` method will return the user's information. For example, if you have configured the `email` and `phone` scopes, the `fetchUserInfo` method will return the user's email and phone number.
+<ScopesAndClaims configScopesCode={<ScopesAndClaimsCode />} />

--- a/docs/sdk/spa/react/README.mdx
+++ b/docs/sdk/spa/react/README.mdx
@@ -6,6 +6,7 @@ sidebar_label: React
 
 import ApiResourcesDescription from '../../fragments/_api-resources-description.md';
 import FurtherReadings from '../../fragments/_further-readings.md';
+import GetUserInfoApis from '../../fragments/_get-user-info-apis.mdx';
 import ScopesAndClaims from '../../fragments/_scopes-and-claims.mdx';
 
 import CheckIntegration from './_check-integration.mdx';
@@ -58,9 +59,11 @@ This guide will show you how to integrate Logto into your React application.
 
 <CheckIntegration />
 
-## Scopes and claims
+## Get user information
 
-<ScopesAndClaims fetchUserInfoApi="fetchUserInfo" configScopesCode={<ScopesAndClaimsCode />} />
+<GetUserInfoApis getIdTokenClaimsApi="getIdTokenClaims" fetchUserInfoApi="fetchUserInfo" />
+
+<ScopesAndClaims configScopesCode={<ScopesAndClaimsCode />} />
 
 ## API resources
 

--- a/docs/sdk/spa/vue/README.mdx
+++ b/docs/sdk/spa/vue/README.mdx
@@ -6,6 +6,7 @@ sidebar_label: Vue
 
 import ApiResourcesDescription from '../../fragments/_api-resources-description.md';
 import FurtherReadings from '../../fragments/_further-readings.md';
+import GetUserInfoApis from '../../fragments/_get-user-info-apis.mdx';
 import ScopesAndClaims from '../../fragments/_scopes-and-claims.mdx';
 
 import CheckIntegration from './_check-integration.mdx';
@@ -58,9 +59,11 @@ This guide will show you how to integrate Logto into your Vue 3 application.
 
 <CheckIntegration />
 
-## Scopes and claims
+## Get user information
 
-<ScopesAndClaims fetchUserInfoApi="fetchUserInfo" configScopesCode={<ScopesAndClaimsCode />} />
+<GetUserInfoApis getIdTokenClaimsApi="getIdTokenClaims" fetchUserInfoApi="fetchUserInfo" />
+
+<ScopesAndClaims configScopesCode={<ScopesAndClaimsCode />} />
 
 ## API resources
 

--- a/docs/sdk/web/express/_scopes-and-claims.mdx
+++ b/docs/sdk/web/express/_scopes-and-claims.mdx
@@ -2,4 +2,4 @@ import ScopesAndClaims from '../../fragments/_scopes-and-claims.mdx';
 
 import ScopesAndClaimsCode from './_scopes-and-claims-code.md';
 
-<ScopesAndClaims fetchUserInfoApi="fetchUserInfo" configScopesCode={<ScopesAndClaimsCode />} />
+<ScopesAndClaims configScopesCode={<ScopesAndClaimsCode />} />

--- a/docs/sdk/web/go/README.mdx
+++ b/docs/sdk/web/go/README.mdx
@@ -5,6 +5,7 @@ sidebar_label: Go
 
 import ApiResourcesDescription from '../../fragments/_api-resources-description.md';
 import FurtherReadings from '../../fragments/_further-readings.md';
+import GetUserInfoApis from '../../fragments/_get-user-info-apis.mdx';
 
 import CreateSessionStorage from './_create-session-storage.md';
 import GoGuideTip from './_guide-tip.md';
@@ -60,7 +61,9 @@ This guide will show you how to integrate Logto into your Go web application.
 
 <TestYourApplication />
 
-## Scopes and claims
+## Get user information
+
+<GetUserInfoApis getIdTokenClaimsApi="GetIdTokenClaims" fetchUserInfoApi="FetchUserInfo" />
 
 <ScopesAndClaims />
 

--- a/docs/sdk/web/go/scopes-and-claims/_scopes-and-claims.mdx
+++ b/docs/sdk/web/go/scopes-and-claims/_scopes-and-claims.mdx
@@ -2,4 +2,4 @@ import ScopesAndClaims from '../../../fragments/_scopes-and-claims.mdx';
 
 import ScopesAndClaimsCode from './_scopes-and-claims-code.md';
 
-<ScopesAndClaims fetchUserInfoApi="FetchUserInfo" configScopesCode={<ScopesAndClaimsCode />} />
+<ScopesAndClaims configScopesCode={<ScopesAndClaimsCode />} />

--- a/docs/sdk/web/php/README.mdx
+++ b/docs/sdk/web/php/README.mdx
@@ -5,6 +5,7 @@ sidebar_label: PHP
 
 import ApiResourcesDescription from '../../fragments/_api-resources-description.md';
 import FurtherReadings from '../../fragments/_further-readings.md';
+import GetUserInfoApis from '../../fragments/_get-user-info-apis.mdx';
 
 import PhpGuideTip from './_guide-tip.md';
 import ImplementCallbackRoute from './_implement-callback-route.md';
@@ -53,7 +54,9 @@ import ScopesAndClaims from './scopes-and-claims/_scopes-and-claims.mdx';
 
 <TestYourApplication />
 
-## Scopes and claims
+## Get user information
+
+<GetUserInfoApis getIdTokenClaimsApi="GetIdTokenClaims" fetchUserInfoApi="FetchUserInfo" />
 
 <ScopesAndClaims />
 

--- a/docs/sdk/web/php/_implement-sign-in-route.mdx
+++ b/docs/sdk/web/php/_implement-sign-in-route.mdx
@@ -62,4 +62,4 @@ Note that a field (claim) with `null` value doesn't mean the field is set. The r
 
 For example, if we didn't request the `email` scope when signing in, and the `email` field will be `null`. However, if we requested the `email` scope, the `email` field will be the user's email address if available.
 
-To learn more about scopes and claims, see [Scopes and claims](#scopes-and-claims).
+To learn more about scopes and claims, see [Get user information](#get-user-information).

--- a/docs/sdk/web/php/scopes-and-claims/_scopes-and-claims.mdx
+++ b/docs/sdk/web/php/scopes-and-claims/_scopes-and-claims.mdx
@@ -2,4 +2,4 @@ import ScopesAndClaims from '../../../fragments/_scopes-and-claims.mdx';
 
 import ScopesAndClaimsCode from './_scopes-and-claims-code.md';
 
-<ScopesAndClaims fetchUserInfoApi="FetchUserInfo" configScopesCode={<ScopesAndClaimsCode />} />
+<ScopesAndClaims configScopesCode={<ScopesAndClaimsCode />} />

--- a/docs/sdk/web/python/README.mdx
+++ b/docs/sdk/web/python/README.mdx
@@ -5,6 +5,7 @@ sidebar_label: Python
 
 import ApiResourcesDescription from '../../fragments/_api-resources-description.md';
 import FurtherReadings from '../../fragments/_further-readings.md';
+import GetUserInfoApis from '../../fragments/_get-user-info-apis.mdx';
 
 import PythonGuideTip from './_guide-tip.md';
 import ImplementCallbackRoute from './_implement-callback-route.md';
@@ -55,7 +56,9 @@ This guide will show you how to integrate Logto into your Python web application
 
 <TestYourApplication />
 
-## Scopes and claims
+## Get user information
+
+<GetUserInfoApis getIdTokenClaimsApi="GetIdTokenClaims" fetchUserInfoApi="FetchUserInfo" />
 
 <ScopesAndClaims />
 

--- a/docs/sdk/web/python/_implement-sign-in-route.mdx
+++ b/docs/sdk/web/python/_implement-sign-in-route.mdx
@@ -67,4 +67,4 @@ Adding `exclude_unset=True` will exclude unset fields from the JSON output, whic
 
 For example, if we didn't request the `email` scope when signing in, and the `email` field will be excluded from the JSON output. However, if we requested the `email` scope, but the user doesn't have an email address, the `email` field will be included in the JSON output with a `null` value.
 
-To learn more about scopes and claims, see [Scopes and claims](#scopes-and-claims).
+To learn more about scopes and claims, see [Get user information](#get-user-information).

--- a/docs/sdk/web/python/scopes-and-claims/_scopes-and-claims.mdx
+++ b/docs/sdk/web/python/scopes-and-claims/_scopes-and-claims.mdx
@@ -2,4 +2,4 @@ import ScopesAndClaims from '../../../fragments/_scopes-and-claims.mdx';
 
 import ScopesAndClaimsCode from './_scopes-and-claims-code.md';
 
-<ScopesAndClaims fetchUserInfoApi="FetchUserInfo" configScopesCode={<ScopesAndClaimsCode />} />
+<ScopesAndClaims configScopesCode={<ScopesAndClaimsCode />} />


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Split the original "Scopes and claims" section into to"Get user info APIs" and  "Scopes and claims" and update some "scopes and claims" section to "Get user information"

<img width="998" alt="image" src="https://github.com/logto-io/docs/assets/10806653/d06a2f50-2513-4351-aa67-718dc911fff3">

<img width="719" alt="image" src="https://github.com/logto-io/docs/assets/10806653/49ab7a1f-54aa-4ea6-b708-af833373c1dd">


### Test

Go through all SDK pages and everything work well.
