### PR TITLE
fix: correct invalid get-started page links

### DIFF
--- a/docs/sdk/spa/vanilla-js/README.mdx
+++ b/docs/sdk/spa/vanilla-js/README.mdx
@@ -21,7 +21,7 @@ Vanilla JS: Integrate `@logto/browser`
 
 ## Prerequisites
 
-- A [Logto Cloud](https://cloud.logto.io) account or a self-hosted Logto (Check out the [⚡ Get started](https://docs.logto.io/docs/guides/get-started/) guide to create one if you don't have).
+- A [Logto Cloud](https://cloud.logto.io) account or a self-hosted Logto (Check out the [⚡ Get started](/docs/tutorials/get-started/) guide to create one if you don't have).
 - A single-page application (SPA) created in Logto console.
 - A vanilla JS app project.
 

--- a/docs/sdk/web/sveltekit/README.mdx
+++ b/docs/sdk/web/sveltekit/README.mdx
@@ -17,7 +17,7 @@ import ApiResources from './api-resources/_index.mdx';
 
 ## Prerequisites
 
-- A [Logto Cloud](https://cloud.logto.io) account or a self-hosted Logto (Check out the [⚡ Get started](https://docs.logto.io/docs/guides/get-started/) guide to create one if you don't have).
+- A [Logto Cloud](https://cloud.logto.io) account or a self-hosted Logto (Check out the [⚡ Get started](/docs/tutorials/get-started/) guide to create one if you don't have).
 - A Logto traditional web application created.
 
 ## Installation


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Correct invalid get-started page links.

Related issue: https://github.com/logto-io/logto/issues/5633
