### PR TITLE
fix(docs): use URL object for `createRemoteJWKSet`

### DIFF
--- a/docs/docs/recipes/protect-your-api/node.mdx
+++ b/docs/docs/recipes/protect-your-api/node.mdx
@@ -69,7 +69,7 @@ export const verifyAuthFromRequest = async (req, res, next) => {
 
   const { payload } = await jwtVerify(
     token, // The raw Bearer Token extracted from the request header
-    createRemoteJWKSet('https://<your-logto-domain>/oidc/jwks'), // generate a jwks using jwks_uri inquired from Logto server
+    createRemoteJWKSet(new URL('https://<your-logto-domain>/oidc/jwks')), // generate a jwks using jwks_uri inquired from Logto server
     {
       // expected issuer of the token, should be issued by the Logto server
       issuer: 'https://<your-logto-domain>/oidc',


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Correct the url param for `createRemoteJWKSet` since the url param should be an URL object.
<img width="1023" alt="image" src="https://github.com/logto-io/docs/assets/10806653/2fcb2d48-3f85-4277-bc22-82bcadbabcd0">

