### PR TITLE
chore: redirect legacy sdk urls to quick start

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -233,6 +233,19 @@ const config = {
         feedOptions: {},
       },
     ],
+    [
+      '@docusaurus/plugin-client-redirects',
+      {
+        createRedirects(existingPath) {
+          if (existingPath.includes('/sdk/')) {
+            // Redirect from /sdk/foo to /quick-start/foo
+            return [existingPath.replace('/sdk/', '/quick-start/')];
+          }
+          // eslint-disable-next-line unicorn/no-useless-undefined
+          return undefined; // Return a falsy value: no redirect created
+        },
+      },
+    ],
   ],
   themes: ['@docusaurus/theme-mermaid'],
 };

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@commitlint/types": "^18.0.0",
     "@docusaurus/core": "3.3.2",
     "@docusaurus/module-type-aliases": "3.3.2",
+    "@docusaurus/plugin-client-redirects": "3.3.2",
     "@docusaurus/preset-classic": "3.3.2",
     "@docusaurus/theme-classic": "3.3.2",
     "@docusaurus/theme-common": "3.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,34 +28,37 @@ importers:
         version: 18.4.3
       '@docusaurus/core':
         specifier: 3.3.2
-        version: 3.3.2(@docusaurus/types@3.3.2)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+        version: 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
       '@docusaurus/module-type-aliases':
         specifier: 3.3.2
-        version: 3.3.2(react-dom@18.2.0)(react@18.2.0)
+        version: 3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/plugin-client-redirects':
+        specifier: 3.3.2
+        version: 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
       '@docusaurus/preset-classic':
         specifier: 3.3.2
-        version: 3.3.2(@algolia/client-search@4.13.1)(@types/react@18.2.38)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(search-insights@2.11.0)(typescript@5.3.3)
+        version: 3.3.2(@algolia/client-search@4.13.1)(@types/react@18.2.38)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.11.0)(typescript@5.3.3)
       '@docusaurus/theme-classic':
         specifier: 3.3.2
-        version: 3.3.2(@types/react@18.2.38)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+        version: 3.3.2(@types/react@18.2.38)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
       '@docusaurus/theme-common':
         specifier: 3.3.2
-        version: 3.3.2(@docusaurus/types@3.3.2)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+        version: 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
       '@docusaurus/theme-mermaid':
         specifier: 3.3.2
-        version: 3.3.2(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+        version: 3.3.2(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
       '@docusaurus/types':
         specifier: 3.3.2
-        version: 3.3.2(react-dom@18.2.0)(react@18.2.0)
+        version: 3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@mdx-js/react':
         specifier: ^3.0.0
         version: 3.0.0(@types/react@18.2.38)(react@18.2.0)
       '@silverhand/eslint-config':
         specifier: ^6.0.0
-        version: 6.0.1(eslint@8.57.0)(prettier@3.2.5)(typescript@5.3.3)
+        version: 6.0.1(@types/eslint@8.4.3)(eslint@8.57.0)(prettier@3.2.5)(typescript@5.3.3)
       '@silverhand/eslint-config-react':
         specifier: ^6.0.0
-        version: 6.0.2(eslint@8.57.0)(postcss@8.4.31)(prettier@3.2.5)(stylelint@15.11.0)(typescript@5.3.3)
+        version: 6.0.2(@types/eslint@8.4.3)(eslint@8.57.0)(postcss@8.4.31)(prettier@3.2.5)(stylelint@15.11.0(typescript@5.3.3))(typescript@5.3.3)
       '@silverhand/ts-config':
         specifier: ^6.0.0
         version: 6.0.0(typescript@5.3.3)
@@ -79,7 +82,7 @@ importers:
         version: 3.23.0
       docusaurus-plugin-sass:
         specifier: ^0.2.5
-        version: 0.2.5(@docusaurus/core@3.3.2)(sass@1.52.3)(webpack@5.76.0)
+        version: 0.2.5(@docusaurus/core@3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3))(sass@1.52.3)(webpack@5.76.0)
       eslint:
         specifier: ^8.57.0
         version: 8.57.0
@@ -1073,6 +1076,13 @@ packages:
     peerDependencies:
       react: '*'
       react-dom: '*'
+
+  '@docusaurus/plugin-client-redirects@3.3.2':
+    resolution: {integrity: sha512-W8ueb5PaQ06oanatL+CzE3GjqeRBTzv3MSFqEQlBa8BqLyOomc1uHsWgieE3glHsckU4mUZ6sHnOfesAtYnnew==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
 
   '@docusaurus/plugin-content-blog@3.3.2':
     resolution: {integrity: sha512-fJU+dmqp231LnwDJv+BHVWft8pcUS2xVPZdeYH6/ibH1s2wQ/sLcmUrGWyIv/Gq9Ptj8XWjRPMghlxghuPPoxg==}
@@ -8009,7 +8019,7 @@ snapshots:
       '@types/node': 18.18.11
       chalk: 4.1.2
       cosmiconfig: 8.3.6(typescript@5.3.3)
-      cosmiconfig-typescript-loader: 5.0.0(@types/node@18.18.11)(cosmiconfig@8.3.6)(typescript@5.3.3)
+      cosmiconfig-typescript-loader: 5.0.0(@types/node@18.18.11)(cosmiconfig@8.3.6(typescript@5.3.3))(typescript@5.3.3)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -8066,7 +8076,7 @@ snapshots:
 
   '@csstools/css-tokenizer@2.2.3': {}
 
-  '@csstools/media-query-list-parser@2.1.7(@csstools/css-parser-algorithms@2.5.0)(@csstools/css-tokenizer@2.2.3)':
+  '@csstools/media-query-list-parser@2.1.7(@csstools/css-parser-algorithms@2.5.0(@csstools/css-tokenizer@2.2.3))(@csstools/css-tokenizer@2.2.3)':
     dependencies:
       '@csstools/css-parser-algorithms': 2.5.0(@csstools/css-tokenizer@2.2.3)
       '@csstools/css-tokenizer': 2.2.3
@@ -8079,20 +8089,21 @@ snapshots:
 
   '@docsearch/css@3.5.2': {}
 
-  '@docsearch/react@3.5.2(@algolia/client-search@4.13.1)(@types/react@18.2.38)(react-dom@18.2.0)(react@18.2.0)(search-insights@2.11.0)':
+  '@docsearch/react@3.5.2(@algolia/client-search@4.13.1)(@types/react@18.2.38)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.11.0)':
     dependencies:
       '@algolia/autocomplete-core': 1.9.3(@algolia/client-search@4.13.1)(algoliasearch@4.20.0)(search-insights@2.11.0)
       '@algolia/autocomplete-preset-algolia': 1.9.3(@algolia/client-search@4.13.1)(algoliasearch@4.20.0)
       '@docsearch/css': 3.5.2
-      '@types/react': 18.2.38
       algoliasearch: 4.20.0
+    optionalDependencies:
+      '@types/react': 18.2.38
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       search-insights: 2.11.0
     transitivePeerDependencies:
       - '@algolia/client-search'
 
-  '@docusaurus/core@3.3.2(@docusaurus/types@3.3.2)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)':
+  '@docusaurus/core@3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)':
     dependencies:
       '@babel/core': 7.23.3
       '@babel/generator': 7.23.4
@@ -8106,10 +8117,10 @@ snapshots:
       '@babel/traverse': 7.23.4
       '@docusaurus/cssnano-preset': 3.3.2
       '@docusaurus/logger': 3.3.2
-      '@docusaurus/mdx-loader': 3.3.2(@docusaurus/types@3.3.2)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.3.3)
-      '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2)
-      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.3.3)
+      '@docusaurus/mdx-loader': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)
+      '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)
       autoprefixer: 10.4.16(postcss@8.4.33)
       babel-loader: 9.1.3(@babel/core@7.23.3)(webpack@5.89.0)
       babel-plugin-dynamic-import-node: 2.3.3
@@ -8130,7 +8141,7 @@ snapshots:
       escape-html: 1.0.3
       eta: 2.2.0
       eval: 0.1.8
-      file-loader: 6.2.0(webpack@5.89.0)
+      file-loader: 6.2.0(webpack@5.76.0)
       fs-extra: 11.1.1
       html-minifier-terser: 7.2.0
       html-tags: 3.3.1
@@ -8145,11 +8156,11 @@ snapshots:
       react: 18.2.0
       react-dev-utils: 12.0.1(eslint@8.57.0)(typescript@5.3.3)(webpack@5.89.0)
       react-dom: 18.2.0(react@18.2.0)
-      react-helmet-async: 1.3.0(react-dom@18.2.0)(react@18.2.0)
+      react-helmet-async: 1.3.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@18.2.0)'
-      react-loadable-ssr-addon-v5-slorber: 1.0.1(@docusaurus/react-loadable@6.0.0)(webpack@5.89.0)
+      react-loadable-ssr-addon-v5-slorber: 1.0.1(@docusaurus/react-loadable@6.0.0(react@18.2.0))(webpack@5.89.0)
       react-router: 5.3.4(react@18.2.0)
-      react-router-config: 5.1.1(react-router@5.3.4)(react@18.2.0)
+      react-router-config: 5.1.1(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       react-router-dom: 5.3.4(react@18.2.0)
       rtl-detect: 1.0.4
       semver: 7.6.0
@@ -8158,7 +8169,7 @@ snapshots:
       terser-webpack-plugin: 5.3.9(webpack@5.89.0)
       tslib: 2.6.2
       update-notifier: 6.0.2
-      url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.89.0)
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.89.0))(webpack@5.89.0)
       webpack: 5.89.0
       webpack-bundle-analyzer: 4.10.1
       webpack-dev-server: 4.15.1(webpack@5.89.0)
@@ -8194,11 +8205,11 @@ snapshots:
       chalk: 4.1.2
       tslib: 2.6.2
 
-  '@docusaurus/mdx-loader@3.3.2(@docusaurus/types@3.3.2)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)':
+  '@docusaurus/mdx-loader@3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)':
     dependencies:
       '@docusaurus/logger': 3.3.2
-      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.3.3)
-      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.3.3)
+      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)
+      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)
       '@mdx-js/mdx': 3.0.0
       '@slorber/remark-comment': 1.0.0
       escape-html: 1.0.3
@@ -8219,7 +8230,7 @@ snapshots:
       tslib: 2.6.2
       unified: 11.0.4
       unist-util-visit: 5.0.0
-      url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.89.0)
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.89.0))(webpack@5.89.0)
       vfile: 6.0.1
       webpack: 5.89.0
     transitivePeerDependencies:
@@ -8231,16 +8242,16 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/module-type-aliases@3.3.2(react-dom@18.2.0)(react@18.2.0)':
+  '@docusaurus/module-type-aliases@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@docusaurus/types': 3.3.2(react-dom@18.2.0)(react@18.2.0)
+      '@docusaurus/types': 3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/history': 4.7.11
       '@types/react': 18.2.38
       '@types/react-router-config': 5.0.10
       '@types/react-router-dom': 5.3.3
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      react-helmet-async: 1.3.0(react-dom@18.2.0)(react@18.2.0)
+      react-helmet-async: 1.3.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@18.2.0)'
     transitivePeerDependencies:
       - '@swc/core'
@@ -8249,15 +8260,46 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/plugin-content-blog@3.3.2(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)':
+  '@docusaurus/plugin-client-redirects@3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)':
     dependencies:
-      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
       '@docusaurus/logger': 3.3.2
-      '@docusaurus/mdx-loader': 3.3.2(@docusaurus/types@3.3.2)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/types': 3.3.2(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.3.3)
-      '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2)
-      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.3.3)
+      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)
+      '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)
+      eta: 2.2.0
+      fs-extra: 11.1.1
+      lodash: 4.17.21
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - '@docusaurus/types'
+      - '@parcel/css'
+      - '@swc/core'
+      - '@swc/css'
+      - bufferutil
+      - csso
+      - debug
+      - esbuild
+      - eslint
+      - lightningcss
+      - supports-color
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+
+  '@docusaurus/plugin-content-blog@3.3.2(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)':
+    dependencies:
+      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/logger': 3.3.2
+      '@docusaurus/mdx-loader': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/types': 3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)
+      '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)
       cheerio: 1.0.0-rc.12
       feed: 4.2.2
       fs-extra: 11.1.1
@@ -8287,16 +8329,16 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-docs@3.3.2(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)':
+  '@docusaurus/plugin-content-docs@3.3.2(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)':
     dependencies:
-      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
       '@docusaurus/logger': 3.3.2
-      '@docusaurus/mdx-loader': 3.3.2(@docusaurus/types@3.3.2)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/module-type-aliases': 3.3.2(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/types': 3.3.2(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.3.3)
-      '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2)
-      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.3.3)
+      '@docusaurus/mdx-loader': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/module-type-aliases': 3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/types': 3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)
+      '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)
       '@types/react-router-config': 5.0.10
       combine-promises: 1.1.0
       fs-extra: 11.1.1
@@ -8324,13 +8366,13 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-pages@3.3.2(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)':
+  '@docusaurus/plugin-content-pages@3.3.2(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)':
     dependencies:
-      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/mdx-loader': 3.3.2(@docusaurus/types@3.3.2)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/types': 3.3.2(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.3.3)
-      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.3.3)
+      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/mdx-loader': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/types': 3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)
+      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)
       fs-extra: 11.1.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -8353,11 +8395,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-debug@3.3.2(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)':
+  '@docusaurus/plugin-debug@3.3.2(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)':
     dependencies:
-      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/types': 3.3.2(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.3.3)
+      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/types': 3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)
       fs-extra: 11.1.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -8380,11 +8422,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-analytics@3.3.2(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)':
+  '@docusaurus/plugin-google-analytics@3.3.2(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)':
     dependencies:
-      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/types': 3.3.2(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.3.3)
+      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/types': 3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       tslib: 2.6.2
@@ -8405,11 +8447,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-gtag@3.3.2(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)':
+  '@docusaurus/plugin-google-gtag@3.3.2(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)':
     dependencies:
-      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/types': 3.3.2(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.3.3)
+      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/types': 3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)
       '@types/gtag.js': 0.0.12
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -8431,11 +8473,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-tag-manager@3.3.2(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)':
+  '@docusaurus/plugin-google-tag-manager@3.3.2(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)':
     dependencies:
-      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/types': 3.3.2(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.3.3)
+      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/types': 3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       tslib: 2.6.2
@@ -8456,14 +8498,14 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-sitemap@3.3.2(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)':
+  '@docusaurus/plugin-sitemap@3.3.2(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)':
     dependencies:
-      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
       '@docusaurus/logger': 3.3.2
-      '@docusaurus/types': 3.3.2(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.3.3)
-      '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2)
-      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.3.3)
+      '@docusaurus/types': 3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)
+      '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)
       fs-extra: 11.1.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -8486,21 +8528,21 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/preset-classic@3.3.2(@algolia/client-search@4.13.1)(@types/react@18.2.38)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(search-insights@2.11.0)(typescript@5.3.3)':
+  '@docusaurus/preset-classic@3.3.2(@algolia/client-search@4.13.1)(@types/react@18.2.38)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.11.0)(typescript@5.3.3)':
     dependencies:
-      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/plugin-content-blog': 3.3.2(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/plugin-content-docs': 3.3.2(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/plugin-content-pages': 3.3.2(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/plugin-debug': 3.3.2(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/plugin-google-analytics': 3.3.2(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/plugin-google-gtag': 3.3.2(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/plugin-google-tag-manager': 3.3.2(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/plugin-sitemap': 3.3.2(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/theme-classic': 3.3.2(@types/react@18.2.38)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/theme-common': 3.3.2(@docusaurus/types@3.3.2)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/theme-search-algolia': 3.3.2(@algolia/client-search@4.13.1)(@docusaurus/types@3.3.2)(@types/react@18.2.38)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(search-insights@2.11.0)(typescript@5.3.3)
-      '@docusaurus/types': 3.3.2(react-dom@18.2.0)(react@18.2.0)
+      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/plugin-content-blog': 3.3.2(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/plugin-content-docs': 3.3.2(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/plugin-content-pages': 3.3.2(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/plugin-debug': 3.3.2(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/plugin-google-analytics': 3.3.2(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/plugin-google-gtag': 3.3.2(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/plugin-google-tag-manager': 3.3.2(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/plugin-sitemap': 3.3.2(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/theme-classic': 3.3.2(@types/react@18.2.38)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/theme-common': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/theme-search-algolia': 3.3.2(@algolia/client-search@4.13.1)(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.2.38)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.11.0)(typescript@5.3.3)
+      '@docusaurus/types': 3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
@@ -8528,20 +8570,20 @@ snapshots:
       '@types/react': 18.2.38
       react: 18.2.0
 
-  '@docusaurus/theme-classic@3.3.2(@types/react@18.2.38)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)':
+  '@docusaurus/theme-classic@3.3.2(@types/react@18.2.38)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)':
     dependencies:
-      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/mdx-loader': 3.3.2(@docusaurus/types@3.3.2)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/module-type-aliases': 3.3.2(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/plugin-content-blog': 3.3.2(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/plugin-content-docs': 3.3.2(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/plugin-content-pages': 3.3.2(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/theme-common': 3.3.2(@docusaurus/types@3.3.2)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/mdx-loader': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/module-type-aliases': 3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/plugin-content-blog': 3.3.2(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/plugin-content-docs': 3.3.2(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/plugin-content-pages': 3.3.2(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/theme-common': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
       '@docusaurus/theme-translations': 3.3.2
-      '@docusaurus/types': 3.3.2(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.3.3)
-      '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2)
-      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.3.3)
+      '@docusaurus/types': 3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)
+      '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)
       '@mdx-js/react': 3.0.0(@types/react@18.2.38)(react@18.2.0)
       clsx: 2.0.0
       copy-text-to-clipboard: 3.2.0
@@ -8575,15 +8617,15 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/theme-common@3.3.2(@docusaurus/types@3.3.2)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)':
+  '@docusaurus/theme-common@3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)':
     dependencies:
-      '@docusaurus/mdx-loader': 3.3.2(@docusaurus/types@3.3.2)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/module-type-aliases': 3.3.2(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/plugin-content-blog': 3.3.2(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/plugin-content-docs': 3.3.2(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/plugin-content-pages': 3.3.2(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.3.3)
-      '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2)
+      '@docusaurus/mdx-loader': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/module-type-aliases': 3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/plugin-content-blog': 3.3.2(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/plugin-content-docs': 3.3.2(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/plugin-content-pages': 3.3.2(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)
+      '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       '@types/history': 4.7.11
       '@types/react': 18.2.38
       '@types/react-router-config': 5.0.10
@@ -8612,13 +8654,13 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/theme-mermaid@3.3.2(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)':
+  '@docusaurus/theme-mermaid@3.3.2(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)':
     dependencies:
-      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/module-type-aliases': 3.3.2(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/theme-common': 3.3.2(@docusaurus/types@3.3.2)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/types': 3.3.2(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.3.3)
+      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/module-type-aliases': 3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/theme-common': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/types': 3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)
       mermaid: 10.6.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -8640,16 +8682,16 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/theme-search-algolia@3.3.2(@algolia/client-search@4.13.1)(@docusaurus/types@3.3.2)(@types/react@18.2.38)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(search-insights@2.11.0)(typescript@5.3.3)':
+  '@docusaurus/theme-search-algolia@3.3.2(@algolia/client-search@4.13.1)(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.2.38)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.11.0)(typescript@5.3.3)':
     dependencies:
-      '@docsearch/react': 3.5.2(@algolia/client-search@4.13.1)(@types/react@18.2.38)(react-dom@18.2.0)(react@18.2.0)(search-insights@2.11.0)
-      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+      '@docsearch/react': 3.5.2(@algolia/client-search@4.13.1)(@types/react@18.2.38)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.11.0)
+      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
       '@docusaurus/logger': 3.3.2
-      '@docusaurus/plugin-content-docs': 3.3.2(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@docusaurus/theme-common': 3.3.2(@docusaurus/types@3.3.2)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/plugin-content-docs': 3.3.2(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/theme-common': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
       '@docusaurus/theme-translations': 3.3.2
-      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.3.3)
-      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.3.3)
+      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)
+      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)
       algoliasearch: 4.20.0
       algoliasearch-helper: 3.15.0(algoliasearch@4.20.0)
       clsx: 2.0.0
@@ -8686,7 +8728,7 @@ snapshots:
       fs-extra: 11.1.1
       tslib: 2.6.2
 
-  '@docusaurus/types@3.3.2(react-dom@18.2.0)(react@18.2.0)':
+  '@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@mdx-js/mdx': 3.0.0
       '@types/history': 4.7.11
@@ -8695,7 +8737,7 @@ snapshots:
       joi: 17.11.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      react-helmet-async: 1.3.0(react-dom@18.2.0)(react@18.2.0)
+      react-helmet-async: 1.3.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       utility-types: 3.10.0
       webpack: 5.89.0
       webpack-merge: 5.10.0
@@ -8706,16 +8748,17 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-common@3.3.2(@docusaurus/types@3.3.2)':
+  '@docusaurus/utils-common@3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
     dependencies:
-      '@docusaurus/types': 3.3.2(react-dom@18.2.0)(react@18.2.0)
       tslib: 2.6.2
+    optionalDependencies:
+      '@docusaurus/types': 3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
 
-  '@docusaurus/utils-validation@3.3.2(@docusaurus/types@3.3.2)(typescript@5.3.3)':
+  '@docusaurus/utils-validation@3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)':
     dependencies:
       '@docusaurus/logger': 3.3.2
-      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.3.3)
-      '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2)
+      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)
+      '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       joi: 17.11.0
       js-yaml: 4.1.0
       tslib: 2.6.2
@@ -8728,11 +8771,10 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils@3.3.2(@docusaurus/types@3.3.2)(typescript@5.3.3)':
+  '@docusaurus/utils@3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)':
     dependencies:
       '@docusaurus/logger': 3.3.2
-      '@docusaurus/types': 3.3.2(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2)
+      '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       '@svgr/webpack': 8.1.0(typescript@5.3.3)
       escape-string-regexp: 4.0.0
       file-loader: 6.2.0(webpack@5.89.0)
@@ -8748,8 +8790,10 @@ snapshots:
       resolve-pathname: 3.0.0
       shelljs: 0.8.5
       tslib: 2.6.2
-      url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.89.0)
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.89.0))(webpack@5.89.0)
       webpack: 5.89.0
+    optionalDependencies:
+      '@docusaurus/types': 3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -8943,17 +8987,17 @@ snapshots:
 
   '@sideway/pinpoint@2.0.0': {}
 
-  '@silverhand/eslint-config-react@6.0.2(eslint@8.57.0)(postcss@8.4.31)(prettier@3.2.5)(stylelint@15.11.0)(typescript@5.3.3)':
+  '@silverhand/eslint-config-react@6.0.2(@types/eslint@8.4.3)(eslint@8.57.0)(postcss@8.4.31)(prettier@3.2.5)(stylelint@15.11.0(typescript@5.3.3))(typescript@5.3.3)':
     dependencies:
-      '@silverhand/eslint-config': 6.0.1(eslint@8.57.0)(prettier@3.2.5)(typescript@5.3.3)
-      eslint-config-xo-react: 0.27.0(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react@7.34.1)(eslint@8.57.0)
+      '@silverhand/eslint-config': 6.0.1(@types/eslint@8.4.3)(eslint@8.57.0)(prettier@3.2.5)(typescript@5.3.3)
+      eslint-config-xo-react: 0.27.0(eslint-plugin-react-hooks@4.6.0(eslint@8.57.0))(eslint-plugin-react@7.34.1(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.0)
       eslint-plugin-react: 7.34.1(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.57.0)
       postcss-scss: 4.0.9(postcss@8.4.31)
       stylelint: 15.11.0(typescript@5.3.3)
-      stylelint-config-xo: 0.22.0(stylelint@15.11.0)
-      stylelint-scss: 6.2.1(stylelint@15.11.0)
+      stylelint-config-xo: 0.22.0(stylelint@15.11.0(typescript@5.3.3))
+      stylelint-scss: 6.2.1(stylelint@15.11.0(typescript@5.3.3))
     transitivePeerDependencies:
       - '@types/eslint'
       - eslint
@@ -8964,26 +9008,26 @@ snapshots:
       - supports-color
       - typescript
 
-  '@silverhand/eslint-config@6.0.1(eslint@8.57.0)(prettier@3.2.5)(typescript@5.3.3)':
+  '@silverhand/eslint-config@6.0.1(@types/eslint@8.4.3)(eslint@8.57.0)(prettier@3.2.5)(typescript@5.3.3)':
     dependencies:
       '@silverhand/eslint-plugin-fp': 2.5.0(eslint@8.57.0)
-      '@typescript-eslint/eslint-plugin': 7.7.0(@typescript-eslint/parser@7.7.0)(eslint@8.57.0)(typescript@5.3.3)
+      '@typescript-eslint/eslint-plugin': 7.7.0(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)(typescript@5.3.3)
       '@typescript-eslint/parser': 7.7.0(eslint@8.57.0)(typescript@5.3.3)
       eslint: 8.57.0
       eslint-config-prettier: 9.1.0(eslint@8.57.0)
       eslint-config-xo: 0.44.0(eslint@8.57.0)
-      eslint-config-xo-typescript: 4.0.0(@typescript-eslint/eslint-plugin@7.7.0)(@typescript-eslint/parser@7.7.0)(eslint@8.57.0)(typescript@5.3.3)
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.7.0)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+      eslint-config-xo-typescript: 4.0.0(@typescript-eslint/eslint-plugin@7.7.0(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)(typescript@5.3.3))(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)(typescript@5.3.3)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
       eslint-plugin-consistent-default-export-name: 0.0.15
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-n: 17.2.1(eslint@8.57.0)
       eslint-plugin-no-use-extend-native: 0.5.0
-      eslint-plugin-prettier: 5.1.3(eslint-config-prettier@9.1.0)(eslint@8.57.0)(prettier@3.2.5)
+      eslint-plugin-prettier: 5.1.3(@types/eslint@8.4.3)(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.2.5)
       eslint-plugin-promise: 6.1.1(eslint@8.57.0)
       eslint-plugin-sql: 2.1.0(eslint@8.57.0)
       eslint-plugin-unicorn: 52.0.0(eslint@8.57.0)
-      eslint-plugin-unused-imports: 3.1.0(@typescript-eslint/eslint-plugin@7.7.0)(eslint@8.57.0)
+      eslint-plugin-unused-imports: 3.1.0(@typescript-eslint/eslint-plugin@7.7.0(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)
       prettier: 3.2.5
     transitivePeerDependencies:
       - '@types/eslint'
@@ -9081,7 +9125,7 @@ snapshots:
       '@babel/types': 7.23.4
       entities: 4.5.0
 
-  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0)':
+  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.3.3))':
     dependencies:
       '@babel/core': 7.23.3
       '@svgr/babel-preset': 8.1.0(@babel/core@7.23.3)
@@ -9091,7 +9135,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0)(typescript@5.3.3)':
+  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(typescript@5.3.3))(typescript@5.3.3)':
     dependencies:
       '@svgr/core': 8.1.0(typescript@5.3.3)
       cosmiconfig: 8.3.6(typescript@5.3.3)
@@ -9108,8 +9152,8 @@ snapshots:
       '@babel/preset-react': 7.23.3(@babel/core@7.23.3)
       '@babel/preset-typescript': 7.23.3(@babel/core@7.23.3)
       '@svgr/core': 8.1.0(typescript@5.3.3)
-      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0)
-      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0)(typescript@5.3.3)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.3.3))
+      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.3.3))(typescript@5.3.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -9327,7 +9371,7 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@7.7.0(@typescript-eslint/parser@7.7.0)(eslint@8.57.0)(typescript@5.3.3)':
+  '@typescript-eslint/eslint-plugin@7.7.0(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)(typescript@5.3.3)':
     dependencies:
       '@eslint-community/regexpp': 4.10.0
       '@typescript-eslint/parser': 7.7.0(eslint@8.57.0)(typescript@5.3.3)
@@ -9342,6 +9386,7 @@ snapshots:
       natural-compare: 1.4.0
       semver: 7.6.0
       ts-api-utils: 1.3.0(typescript@5.3.3)
+    optionalDependencies:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
@@ -9354,6 +9399,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 7.7.0
       debug: 4.3.4
       eslint: 8.57.0
+    optionalDependencies:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
@@ -9370,6 +9416,7 @@ snapshots:
       debug: 4.3.4
       eslint: 8.57.0
       ts-api-utils: 1.3.0(typescript@5.3.3)
+    optionalDependencies:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
@@ -9386,6 +9433,7 @@ snapshots:
       minimatch: 9.0.4
       semver: 7.6.0
       ts-api-utils: 1.3.0(typescript@5.3.3)
+    optionalDependencies:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
@@ -9605,7 +9653,7 @@ snapshots:
       indent-string: 4.0.0
 
   ajv-formats@2.1.1(ajv@8.11.0):
-    dependencies:
+    optionalDependencies:
       ajv: 8.11.0
 
   ajv-keywords@3.5.2(ajv@6.12.6):
@@ -10271,7 +10319,7 @@ snapshots:
     dependencies:
       layout-base: 2.0.1
 
-  cosmiconfig-typescript-loader@5.0.0(@types/node@18.18.11)(cosmiconfig@8.3.6)(typescript@5.3.3):
+  cosmiconfig-typescript-loader@5.0.0(@types/node@18.18.11)(cosmiconfig@8.3.6(typescript@5.3.3))(typescript@5.3.3):
     dependencies:
       '@types/node': 18.18.11
       cosmiconfig: 8.3.6(typescript@5.3.3)
@@ -10292,6 +10340,7 @@ snapshots:
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
+    optionalDependencies:
       typescript: 5.3.3
 
   create-eslint-index@1.0.0:
@@ -10333,13 +10382,14 @@ snapshots:
   css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.2)(webpack@5.89.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.20
-      clean-css: 5.3.2
       cssnano: 6.1.2(postcss@8.4.33)
       jest-worker: 29.7.0
       postcss: 8.4.33
       schema-utils: 4.2.0
       serialize-javascript: 6.0.1
       webpack: 5.89.0
+    optionalDependencies:
+      clean-css: 5.3.2
 
   css-select@4.3.0:
     dependencies:
@@ -10803,9 +10853,9 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
-  docusaurus-plugin-sass@0.2.5(@docusaurus/core@3.3.2)(sass@1.52.3)(webpack@5.76.0):
+  docusaurus-plugin-sass@0.2.5(@docusaurus/core@3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3))(sass@1.52.3)(webpack@5.76.0):
     dependencies:
-      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(eslint@8.57.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
       sass: 1.52.3
       sass-loader: 10.2.1(sass@1.52.3)(webpack@5.76.0)
     transitivePeerDependencies:
@@ -11092,15 +11142,15 @@ snapshots:
     dependencies:
       eslint: 8.57.0
 
-  eslint-config-xo-react@0.27.0(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react@7.34.1)(eslint@8.57.0):
+  eslint-config-xo-react@0.27.0(eslint-plugin-react-hooks@4.6.0(eslint@8.57.0))(eslint-plugin-react@7.34.1(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       eslint: 8.57.0
       eslint-plugin-react: 7.34.1(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.57.0)
 
-  eslint-config-xo-typescript@4.0.0(@typescript-eslint/eslint-plugin@7.7.0)(@typescript-eslint/parser@7.7.0)(eslint@8.57.0)(typescript@5.3.3):
+  eslint-config-xo-typescript@4.0.0(@typescript-eslint/eslint-plugin@7.7.0(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)(typescript@5.3.3))(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)(typescript@5.3.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 7.7.0(@typescript-eslint/parser@7.7.0)(eslint@8.57.0)(typescript@5.3.3)
+      '@typescript-eslint/eslint-plugin': 7.7.0(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)(typescript@5.3.3)
       '@typescript-eslint/parser': 7.7.0(eslint@8.57.0)(typescript@5.3.3)
       eslint: 8.57.0
       typescript: 5.3.3
@@ -11118,13 +11168,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0)(eslint-plugin-import@2.29.1)(eslint@8.57.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0):
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.15.0
       eslint: 8.57.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.7.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.13.1
@@ -11155,13 +11205,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.7.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
-      '@typescript-eslint/parser': 7.7.0(eslint@8.57.0)(typescript@5.3.3)
       debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 7.7.0(eslint@8.57.0)(typescript@5.3.3)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.7.0)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11183,9 +11234,8 @@ snapshots:
       eslint: 8.57.0
       ignore: 5.3.1
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:
-      '@typescript-eslint/parser': 7.7.0(eslint@8.57.0)(typescript@5.3.3)
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
       array.prototype.flat: 1.3.2
@@ -11194,7 +11244,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.7.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -11204,6 +11254,8 @@ snapshots:
       object.values: 1.1.7
       semver: 6.3.1
       tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 7.7.0(eslint@8.57.0)(typescript@5.3.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -11269,13 +11321,15 @@ snapshots:
       is-obj-prop: 1.0.0
       is-proto-prop: 2.0.0
 
-  eslint-plugin-prettier@5.1.3(eslint-config-prettier@9.1.0)(eslint@8.57.0)(prettier@3.2.5):
+  eslint-plugin-prettier@5.1.3(@types/eslint@8.4.3)(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.2.5):
     dependencies:
       eslint: 8.57.0
-      eslint-config-prettier: 9.1.0(eslint@8.57.0)
       prettier: 3.2.5
       prettier-linter-helpers: 1.0.0
       synckit: 0.8.8
+    optionalDependencies:
+      '@types/eslint': 8.4.3
+      eslint-config-prettier: 9.1.0(eslint@8.57.0)
 
   eslint-plugin-promise@6.1.1(eslint@8.57.0):
     dependencies:
@@ -11340,11 +11394,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-unused-imports@3.1.0(@typescript-eslint/eslint-plugin@7.7.0)(eslint@8.57.0):
+  eslint-plugin-unused-imports@3.1.0(@typescript-eslint/eslint-plugin@7.7.0(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 7.7.0(@typescript-eslint/parser@7.7.0)(eslint@8.57.0)(typescript@5.3.3)
       eslint: 8.57.0
       eslint-rule-composer: 0.3.0
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 7.7.0(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)(typescript@5.3.3)
 
   eslint-rule-composer@0.3.0: {}
 
@@ -11585,6 +11640,12 @@ snapshots:
     dependencies:
       flat-cache: 3.2.0
 
+  file-loader@6.2.0(webpack@5.76.0):
+    dependencies:
+      loader-utils: 2.0.4
+      schema-utils: 3.3.0
+      webpack: 5.76.0
+
   file-loader@6.2.0(webpack@5.89.0):
     dependencies:
       loader-utils: 2.0.4
@@ -11667,7 +11728,6 @@ snapshots:
       chokidar: 3.5.3
       cosmiconfig: 6.0.0
       deepmerge: 4.2.2
-      eslint: 8.57.0
       fs-extra: 9.1.0
       glob: 7.2.3
       memfs: 3.4.4
@@ -11677,6 +11737,8 @@ snapshots:
       tapable: 1.1.3
       typescript: 5.3.3
       webpack: 5.89.0
+    optionalDependencies:
+      eslint: 8.57.0
 
   form-data-encoder@2.1.4: {}
 
@@ -12091,12 +12153,13 @@ snapshots:
 
   http-proxy-middleware@2.0.6(@types/express@4.17.13):
     dependencies:
-      '@types/express': 4.17.13
       '@types/http-proxy': 1.17.9
       http-proxy: 1.18.1
       is-glob: 4.0.3
       is-plain-obj: 3.0.0
       micromatch: 4.0.5
+    optionalDependencies:
+      '@types/express': 4.17.13
     transitivePeerDependencies:
       - debug
 
@@ -14331,8 +14394,9 @@ snapshots:
       shell-quote: 1.8.1
       strip-ansi: 6.0.1
       text-table: 0.2.0
-      typescript: 5.3.3
       webpack: 5.89.0
+    optionalDependencies:
+      typescript: 5.3.3
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -14348,7 +14412,7 @@ snapshots:
 
   react-fast-compare@3.2.0: {}
 
-  react-helmet-async@1.3.0(react-dom@18.2.0)(react@18.2.0):
+  react-helmet-async@1.3.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@babel/runtime': 7.23.4
       invariant: 2.2.4
@@ -14366,13 +14430,13 @@ snapshots:
     dependencies:
       react: 18.2.0
 
-  react-loadable-ssr-addon-v5-slorber@1.0.1(@docusaurus/react-loadable@6.0.0)(webpack@5.89.0):
+  react-loadable-ssr-addon-v5-slorber@1.0.1(@docusaurus/react-loadable@6.0.0(react@18.2.0))(webpack@5.89.0):
     dependencies:
       '@babel/runtime': 7.23.4
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@18.2.0)'
       webpack: 5.89.0
 
-  react-router-config@5.1.1(react-router@5.3.4)(react@18.2.0):
+  react-router-config@5.1.1(react-router@5.3.4(react@18.2.0))(react@18.2.0):
     dependencies:
       '@babel/runtime': 7.23.4
       react: 18.2.0
@@ -14733,14 +14797,16 @@ snapshots:
       klona: 2.0.5
       loader-utils: 2.0.4
       neo-async: 2.6.2
-      sass: 1.52.3
       schema-utils: 3.3.0
       semver: 7.5.4
       webpack: 5.76.0
+    optionalDependencies:
+      sass: 1.52.3
 
   sass-loader@14.1.0(sass@1.52.3)(webpack@5.76.0):
     dependencies:
       neo-async: 2.6.2
+    optionalDependencies:
       sass: 1.52.3
       webpack: 5.76.0
 
@@ -15172,23 +15238,23 @@ snapshots:
       postcss: 8.4.38
       postcss-selector-parser: 6.0.16
 
-  stylelint-config-xo@0.22.0(stylelint@15.11.0):
+  stylelint-config-xo@0.22.0(stylelint@15.11.0(typescript@5.3.3)):
     dependencies:
       stylelint: 15.11.0(typescript@5.3.3)
-      stylelint-declaration-block-no-ignored-properties: 2.8.0(stylelint@15.11.0)
-      stylelint-order: 6.0.4(stylelint@15.11.0)
+      stylelint-declaration-block-no-ignored-properties: 2.8.0(stylelint@15.11.0(typescript@5.3.3))
+      stylelint-order: 6.0.4(stylelint@15.11.0(typescript@5.3.3))
 
-  stylelint-declaration-block-no-ignored-properties@2.8.0(stylelint@15.11.0):
+  stylelint-declaration-block-no-ignored-properties@2.8.0(stylelint@15.11.0(typescript@5.3.3)):
     dependencies:
       stylelint: 15.11.0(typescript@5.3.3)
 
-  stylelint-order@6.0.4(stylelint@15.11.0):
+  stylelint-order@6.0.4(stylelint@15.11.0(typescript@5.3.3)):
     dependencies:
       postcss: 8.4.33
       postcss-sorting: 8.0.2(postcss@8.4.33)
       stylelint: 15.11.0(typescript@5.3.3)
 
-  stylelint-scss@6.2.1(stylelint@15.11.0):
+  stylelint-scss@6.2.1(stylelint@15.11.0(typescript@5.3.3)):
     dependencies:
       known-css-properties: 0.29.0
       postcss-media-query-parser: 0.2.3
@@ -15201,7 +15267,7 @@ snapshots:
     dependencies:
       '@csstools/css-parser-algorithms': 2.5.0(@csstools/css-tokenizer@2.2.3)
       '@csstools/css-tokenizer': 2.2.3
-      '@csstools/media-query-list-parser': 2.1.7(@csstools/css-parser-algorithms@2.5.0)(@csstools/css-tokenizer@2.2.3)
+      '@csstools/media-query-list-parser': 2.1.7(@csstools/css-parser-algorithms@2.5.0(@csstools/css-tokenizer@2.2.3))(@csstools/css-tokenizer@2.2.3)
       '@csstools/selector-specificity': 3.0.1(postcss-selector-parser@6.0.15)
       balanced-match: 2.0.0
       colord: 2.9.3
@@ -15603,13 +15669,14 @@ snapshots:
     dependencies:
       punycode: 2.1.1
 
-  url-loader@4.1.1(file-loader@6.2.0)(webpack@5.89.0):
+  url-loader@4.1.1(file-loader@6.2.0(webpack@5.89.0))(webpack@5.89.0):
     dependencies:
-      file-loader: 6.2.0(webpack@5.89.0)
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
       webpack: 5.89.0
+    optionalDependencies:
+      file-loader: 6.2.0(webpack@5.76.0)
 
   util-deprecate@1.0.2: {}
 
@@ -15749,9 +15816,10 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.89.0
       webpack-dev-middleware: 5.3.4(webpack@5.89.0)
       ws: 8.14.2
+    optionalDependencies:
+      webpack: 5.89.0
     transitivePeerDependencies:
       - bufferutil
       - debug


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Redirect legacy `/sdk` url access to the new `/quick-start` page
