### PR TITLE
fix: dart sdk package name

### DIFF
--- a/docs/quick-starts/framework/flutter/_integration.mdx
+++ b/docs/quick-starts/framework/flutter/_integration.mdx
@@ -7,7 +7,7 @@ import ConfigureRedirectUri from '../../fragments/_configure-redirect-uri.mdx';
 Import the `logto_dart_sdk` package and initialize the `LogtoClient` instance at the root of your application.
 
 ```dart
-import 'package:logto_dart_quick-starts/logto_dart_sdk.dart';
+import 'package:logto_dart_sdk/logto_dart_sdk.dart';
 import 'package:http/http.dart' as http;
 
 void main() async {

--- a/docs/quick-starts/framework/flutter/_tip.md
+++ b/docs/quick-starts/framework/flutter/_tip.md
@@ -2,7 +2,7 @@
 
 - Flutter SDK is written based on [Dart](https://dart.dev/).
 - The SDK dart package is available on [pub.dev](https://pub.dev/packages/logto_dart_sdk) and Logto [github repository](https://github.com/logto-io/dart).
-- The example is written using the [Flutter material](https://flutter.dev). The sample project is available on [pub.dev](https://pub.dev/packages/logto_dart_quick-starts/example) and our [github repository](https://github.com/logto-io/dart).
+- The example is written using the [Flutter material](https://flutter.dev). The sample project is available on [pub.dev](https://pub.dev/packages/logto_dart_sdk/example) and our [github repository](https://github.com/logto-io/dart).
 - Supported
 - The SDK is suitable for Android and iOS platforms only.
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix dark SDK package name, which was replaced mistakenly when refactoring the "Quick starts" page
