### PR TITLE
fix: add old link redirect for configure mfa page

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -250,6 +250,10 @@ const config = {
             to: '/docs/references/tenants/#tenant-type',
             from: ['/docs/recipes/tenant-type', '/docs/references/tenant-type'],
           },
+          {
+            to: '/docs/recipes/multi-factor-auth/configure-mfa',
+            from: '/docs/recipes/multi-factor-auth/config-mfa',
+          },
         ],
         // `existingPath` is the path `to`, the return value is the path `from`.
         createRedirects(existingPath) {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add old link redirect for configure mfa page
