### PR TITLE
fix(docs): fix expo SDK sample code

### DIFF
--- a/docs/quick-starts/framework/expo/README.mdx
+++ b/docs/quick-starts/framework/expo/README.mdx
@@ -6,12 +6,12 @@ sidebar_custom_props:
 ---
 
 import FurtherReadings from '../../fragments/_further-readings.md';
-import GetUserInformation from '../react/_get-user-information.mdx';
-import ApiResources from '../react/api-resources/_index.mdx';
 
 import GuideTip from './_guide-tip.md';
 import Installation from './_installation.mdx';
 import Integration from './_integration.mdx';
+import ApiResources from './api-resources/_index.mdx';
+import GetUserInformation from './get-user-information/_index.mdx';
 
 # Integrate Logto with Expo (React Native)
 

--- a/docs/quick-starts/framework/expo/api-resources/_config-api-resources.mdx
+++ b/docs/quick-starts/framework/expo/api-resources/_config-api-resources.mdx
@@ -1,0 +1,11 @@
+import ConfigApiResources from '../../../fragments/_config-api-resources.mdx';
+
+import ConfigResourcesCode from './code/_config-resources-code.md';
+import ConfigResourcesWithScopesCode from './code/_config-resources-with-scopes-code.md';
+import ConfigResourcesWithSharedScopesCode from './code/_config-resources-with-shared-scopes-code.md';
+
+<ConfigApiResources
+  configResourcesCode={<ConfigResourcesCode />}
+  configResourcesWithScopesCode={<ConfigResourcesWithScopesCode />}
+  configResourcesWithSharedScopesCode={<ConfigResourcesWithSharedScopesCode />}
+/>

--- a/docs/quick-starts/framework/expo/api-resources/_fetch-access-token-for-api-resources.mdx
+++ b/docs/quick-starts/framework/expo/api-resources/_fetch-access-token-for-api-resources.mdx
@@ -1,0 +1,8 @@
+import FetchAccessTokenForApiResources from '../../../fragments/_fetch-access-token-for-api-resources.mdx';
+
+import GetAccessTokenCode from './code/_get-access-token-code.md';
+
+<FetchAccessTokenForApiResources
+  getAccessTokenApi="getAccessToken"
+  getAccessTokenCode={<GetAccessTokenCode />}
+/>

--- a/docs/quick-starts/framework/expo/api-resources/_fetch-organization-token-for-user.mdx
+++ b/docs/quick-starts/framework/expo/api-resources/_fetch-organization-token-for-user.mdx
@@ -1,0 +1,10 @@
+import FetchOrganizationTokenForUser from '../../../fragments/_fetch-organization-token-for-user.mdx';
+
+import ConfigOrganizationCode from './code/_config-organization-code.md';
+import GetOrganizationAccessTokenCode from './code/_get-organization-access-token-code.md';
+
+<FetchOrganizationTokenForUser
+  organizationScope="UserScope.Organizations"
+  configOrganizationCode={<ConfigOrganizationCode />}
+  getOrganizationAccessTokenCode={<GetOrganizationAccessTokenCode />}
+/>

--- a/docs/quick-starts/framework/expo/api-resources/_index.mdx
+++ b/docs/quick-starts/framework/expo/api-resources/_index.mdx
@@ -1,0 +1,19 @@
+import ApiResourcesDescription from '../../../fragments/_api-resources-description.md';
+
+import ConfigApiResources from './_config-api-resources.mdx';
+import FetchAccessTokenForApiResources from './_fetch-access-token-for-api-resources.mdx';
+import FetchOrganizationTokenForUser from './_fetch-organization-token-for-user.mdx';
+
+<ApiResourcesDescription />
+
+### Configure Logto client
+
+<ConfigApiResources />
+
+### Fetch access token for the API resource
+
+<FetchAccessTokenForApiResources />
+
+### Fetch organization token for user
+
+<FetchOrganizationTokenForUser />

--- a/docs/quick-starts/framework/expo/api-resources/code/_config-organization-code.md
+++ b/docs/quick-starts/framework/expo/api-resources/code/_config-organization-code.md
@@ -1,0 +1,8 @@
+```ts
+import { LogtoConfig, UserScope } from '@logto/rn';
+
+const config: LogtoConfig = {
+  // ...other configs
+  scopes: [UserScope.Organizations],
+};
+```

--- a/docs/quick-starts/framework/expo/api-resources/code/_config-resources-code.md
+++ b/docs/quick-starts/framework/expo/api-resources/code/_config-resources-code.md
@@ -1,0 +1,9 @@
+```tsx
+import { LogtoConfig } from '@logto/rn';
+
+const config: LogtoConfig = {
+  appId: '<your-application-id>',
+  endpoint: '<your-logto-endpoint>',
+  resources: ['https://shopping.your-app.com/api', 'https://store.your-app.com/api'], // Add API resources
+};
+```

--- a/docs/quick-starts/framework/expo/api-resources/code/_config-resources-with-scopes-code.md
+++ b/docs/quick-starts/framework/expo/api-resources/code/_config-resources-with-scopes-code.md
@@ -1,0 +1,10 @@
+```tsx
+import { LogtoConfig } from '@logto/rn';
+
+const config: LogtoConfig = {
+  appId: '<your-application-id>',
+  endpoint: '<your-logto-endpoint>',
+  scopes: ['shopping:read', 'shopping:write', 'store:read', 'store:write'],
+  resources: ['https://shopping.your-app.com/api', 'https://store.your-app.com/api'],
+};
+```

--- a/docs/quick-starts/framework/expo/api-resources/code/_config-resources-with-shared-scopes-code.md
+++ b/docs/quick-starts/framework/expo/api-resources/code/_config-resources-with-shared-scopes-code.md
@@ -1,0 +1,10 @@
+```tsx
+import { LogtoConfig } from '@logto/rn';
+
+const config: LogtoConfig = {
+  appId: '<your-application-id>',
+  endpoint: '<your-logto-endpoint>',
+  scopes: ['read', 'write'],
+  resources: ['https://shopping.your-app.com/api', 'https://store.your-app.com/api'],
+};
+```

--- a/docs/quick-starts/framework/expo/api-resources/code/_get-access-token-code.md
+++ b/docs/quick-starts/framework/expo/api-resources/code/_get-access-token-code.md
@@ -1,0 +1,19 @@
+```tsx
+import { useLogto } from '@logto/rn';
+
+const Home = () => {
+  const { isAuthenticated, getAccessToken } = useLogto();
+  const [accessToken, setAccessToken] = useState('');
+
+  useEffect(() => {
+    (async () => {
+      if (isAuthenticated) {
+        const token = await getAccessToken('https://shopping.your-app.com/api');
+        setAccessToken(token);
+      }
+    })();
+  }, [isAuthenticated, getAccessToken]);
+
+  return <p>{{ accessToken }}</p>;
+};
+```

--- a/docs/quick-starts/framework/expo/api-resources/code/_get-organization-access-token-code.md
+++ b/docs/quick-starts/framework/expo/api-resources/code/_get-organization-access-token-code.md
@@ -1,0 +1,45 @@
+```tsx
+import { useLogto } from '@logto/rn';
+import { useEffect, useState } from 'react';
+
+const Organizations = () => {
+  const { isAuthenticated, getOrganizationToken, getIdTokenClaims } = useLogto();
+  const [organizationIds, setOrganizationIds] = useState<string[]>();
+
+  useEffect(() => {
+    (async () => {
+      if (!isAuthenticated) {
+        return;
+      }
+      const claims = await getIdTokenClaims();
+
+      console.log('ID token claims', claims);
+      setOrganizationIds(claims?.organizations);
+    })();
+  }, [isAuthenticated, getIdTokenClaims]);
+
+  return (
+    <section>
+      <ul>
+        {organizationIds?.map((organizationId) => {
+          return (
+            <li key={organizationId}>
+              <span>{organizationId}</span>
+              <button
+                type="button"
+                onClick={async () => {
+                  console.log('raw token', await getOrganizationToken(organizationId));
+                }}
+              >
+                fetch token (see console)
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+};
+
+export default Organizations;
+```

--- a/docs/quick-starts/framework/expo/get-user-information/_index.mdx
+++ b/docs/quick-starts/framework/expo/get-user-information/_index.mdx
@@ -1,0 +1,8 @@
+import GetUserInfoApis from '../../../fragments/_get-user-info-apis.mdx';
+import ScopesAndClaims from '../../../fragments/_scopes-and-claims.mdx';
+
+import ScopesAndClaimsCode from './_scopes-and-claims-code.mdx';
+
+<GetUserInfoApis getIdTokenClaimsApi="getIdTokenClaims" fetchUserInfoApi="fetchUserInfo" />
+
+<ScopesAndClaims configScopesCode={<ScopesAndClaimsCode />} />

--- a/docs/quick-starts/framework/expo/get-user-information/_scopes-and-claims-code.mdx
+++ b/docs/quick-starts/framework/expo/get-user-information/_scopes-and-claims-code.mdx
@@ -1,0 +1,17 @@
+```tsx
+import { LogtoProvider, LogtoConfig, UserScope } from '@logto/rn';
+
+const config: LogtoConfig = {
+  appId: '<your-application-id>',
+  endpoint: '<your-logto-endpoint>',
+  scopes: [
+    UserScope.Email,
+    UserScope.Phone,
+    UserScope.CustomData,
+    UserScope.Identities,
+    UserScope.Organizations,
+  ],
+};
+
+const App = () => <LogtoProvider config={config}>{/* Your app content */}</LogtoProvider>;
+```


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix the Expo SDK sample code. 

Previously, our Expo SDK guide referenced the get-user-information and API-resources sections directly from the React SDK, with all sample code using @logto/react. This pull request updates the guide by forking these sections and modifying the sample code to import methods from @logto/rn instead.

