### PR TITLE
fix: fix field key name for user migration

### DIFF
--- a/docs/docs/recipes/migrations/README.mdx
+++ b/docs/docs/recipes/migrations/README.mdx
@@ -36,13 +36,13 @@ You should first export the user data from your existing platform, and then map 
 [
   {
     "username": "user1",
-    "passwordEncrypted": "password-encrypted",
-    "passwordEncryptionMethod": "SHA256"
+    "passwordDigest": "password-encrypted",
+    "passwordAlgorithm": "SHA256"
   },
   {
     "username": "user2",
-    "passwordEncrypted": "password-encrypted",
-    "passwordEncryptionMethod": "SHA256"
+    "passwordDigest": "password-encrypted",
+    "passwordAlgorithm": "SHA256"
   }
 ]
 ```


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Fix field key name for user migration, it should be `passwordDigest`.