### PR TITLE
fix: typo `soken` => `token`

### DIFF
--- a/docs/docs/recipes/impersonation/README.mdx
+++ b/docs/docs/recipes/impersonation/README.mdx
@@ -108,7 +108,7 @@ TechCorp's server should then return this subject token to Sarah's application.
 }
 ```
 
-## Step 3: Exchanging the subject soken for an access token
+## Step 3: Exchanging the subject token for an access token
 
 Now, Sarah's application exchanges this subject token for an access token representing Alex, specifying the resource where the token will be used.
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix a typo `soken` to `token` in chapter `Recipes - User impersonation`
