### PR TITLE
fix(docs): update build connector command in connector implementation guide

### DIFF
--- a/docs/docs/recipes/configure-connectors/create-your-connector/connector-implementation-guide.mdx
+++ b/docs/docs/recipes/configure-connectors/create-your-connector/connector-implementation-guide.mdx
@@ -283,7 +283,7 @@ We assume that you have already finished building your own connector. Go through
 
 1. Copy the connector folder you implemented to directory `/packages/connectors` of [`logto-io/logto`](https://github.com/logto-io/logto).
 2. Install connector repository's dependencies by typing `pnpm pnpm:devPreinstall && pnpm i` at root path of logto folder.
-3. Build connector with `pnpm connectors:build`.
+3. Build connector with `pnpm connectors build`.
 4. Link local connectors using `pnpm cli connector link`.
 5. Restart Logto instance with `pnpm dev` at root directory of `logto-io/logto`, and you can find connectors successfully installed.
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Update build connector command in the connector implementation guide, since it has been changed by https://github.com/logto-io/logto/pull/5526/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R18
