### PR TITLE
refactor: define RP and OP abbreviations with parentheses

### DIFF
--- a/docs/docs/references/applications/README.mdx
+++ b/docs/docs/references/applications/README.mdx
@@ -59,7 +59,7 @@ You can check out the [Redirection Endpoint](https://datatracker.ietf.org/doc/ht
 
 _Post Sign-out Redirect URIs_ are a list of valid URIs that have been pre-configured for an application to redirect the user after they have signed out from Logto.
 
-The use of Allowed _Post Sign-out Redirect URIs_ for Logout is part of the RP-Initiated Logout specification in OIDC. This specification provides a standardized method for applications to initiate a logout request for a user, which includes redirecting the user to a pre-configured endpoint after they have signed out.
+The use of Allowed _Post Sign-out Redirect URIs_ for Logout is part of the RP-Initiated (Relying Party Initiated) Logout specification in OIDC. This specification provides a standardized method for applications to initiate a logout request for a user, which includes redirecting the user to a pre-configured endpoint after they have signed out.
 
 When a user signs out of Logto, their session is terminated and they are redirected to one of the allowed URIs specified in the application settings. This ensures that the user is directed only to authorized and valid endpoints after they have signed out, helping to prevent unauthorized access and security risks associated with redirecting users to unknown or unverified endpoints.
 

--- a/docs/docs/references/openid-connect/backchannel-logout/README.md
+++ b/docs/docs/references/openid-connect/backchannel-logout/README.md
@@ -4,7 +4,7 @@ import Availability from '@components/Availability';
 
 <Availability cloud oss={{ major: 1, minor: 18 }} />
 
-Logto supports the backchannel logout mechanism as defined in the [OpenID Connect Back-Channel Logout 1.0](https://openid.net/specs/openid-connect-backchannel-1_0.html) specification. This mechanism allows the RP to receive logout notifications from the OP when a user logs out from the OP.
+Logto supports the backchannel logout mechanism as defined in the [OpenID Connect Back-Channel Logout 1.0](https://openid.net/specs/openid-connect-backchannel-1_0.html) specification. This mechanism allows the RP (Relying Party) to receive logout notifications from the OP (OpenID Provider) when a user logs out from the OP.
 
 ## How it works
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

I was reading the docs when I didn't understand some of the abbreviations. So I added brackets to the first occurrence of the terms RP and OP that I didn't understand. According to this guide for writing <https://www.mcc.gov/resources/story/section-writing-guide-good-grammar/>

Idea: a glossary of terms used in the docs

