### PR TITLE
refactor: use nuxt-link instead of anchor tag

### DIFF
--- a/docs/quick-starts/framework/nuxt/_get-user-information.mdx
+++ b/docs/quick-starts/framework/nuxt/_get-user-information.mdx
@@ -22,7 +22,7 @@ When user is signed in, the return value of `useLogtoUser()` will be an object c
   </ul>
   <!-- highlight-end -->
   <!-- Simplified button for sign-in and sign-out -->
-  <a :href="`/sign-${ user ? 'out' : 'in' }`"> Sign {{ user ? 'out' : 'in' }} </a>
+  <nuxt-link :to="`/sign-${ user ? 'out' : 'in' }`"> Sign {{ user ? 'out' : 'in' }} </nuxt-link>
 </template>
 ```
 

--- a/docs/quick-starts/framework/nuxt/_integration.mdx
+++ b/docs/quick-starts/framework/nuxt/_integration.mdx
@@ -84,7 +84,7 @@ Since Nuxt pages will be hydrated and become a single-page application (SPA) aft
 </script>
 <template>
   <!-- Simplified button for sign-in and sign-out -->
-  <a :href="`/sign-${ user ? 'out' : 'in' }`"> Sign {{ user ? 'out' : 'in' }} </a>
+  <nuxt-link :to="`/sign-${ user ? 'out' : 'in' }`"> Sign {{ user ? 'out' : 'in' }} </nuxt-link>
 </template>
 ```
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary

When routing within a nuxt app, the "nuxt-link" component should always be used instead of the regular anchor tag to make sure the page isn't refreshed but is rendered using SPA.

See https://nuxt.com/docs/api/components/nuxt-link for more details.
<!-- Provide detailed PR description below -->

