### PR TITLE
fix: remove duplicated section titles from generated docs

### DIFF
--- a/tutorial/build-with-logto/_integrate-sdk-react.mdx
+++ b/tutorial/build-with-logto/_integrate-sdk-react.mdx
@@ -15,8 +15,6 @@ import TestYourIntegration from './fragments/_test-your-integration.mdx';
 
 <InitClient />
 
-### Implement sign-in and sign-out
-
 <ImplementSignInAndSignOut />
 
 <TestYourIntegration sdk="React" />

--- a/tutorial/build-with-logto/_integrate-sdk-vue.mdx
+++ b/tutorial/build-with-logto/_integrate-sdk-vue.mdx
@@ -15,8 +15,6 @@ import TestYourIntegration from './fragments/_test-your-integration.mdx';
 
 <InitClient />
 
-### Implement sign-in and sign-out
-
 <ImplementSignInAndSignOut />
 
 <TestYourIntegration sdk="Vue" />


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Remove duplicated "Implement sign-in and sign-out" section title from generated "build-with-logto" guides.
