### PR TITLE
feat: add cloud console link component

### DIFF
--- a/docs/get-started/invite-team-members.mdx
+++ b/docs/get-started/invite-team-members.mdx
@@ -2,6 +2,8 @@
 sidebar_position: 2
 ---
 
+import CloudLink from '@mdx-components/CloudLink';
+
 # Invite your team members
 
 Logto lets you invite team members to your tenant with two different roles in Logto Cloud:
@@ -23,7 +25,7 @@ Logto lets you invite team members to your tenant with two different roles in Lo
 
 ## Invite team members
 
-Go to **_Tenant Settings → Members_**. You'll see your current members and can invite more. Enter email addresses and assign roles (you can do this in bulk) and then send.
+Go to <CloudLink to="/tenant-settings/members">Tenant Settings > Members</CloudLink>. You'll see your current members and can invite more. Enter email addresses and assign roles (you can do this in bulk) and then send.
 
 You can't invite people who already have pending invitations or are members.
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -17,6 +17,7 @@ const addAliasPlugin: PluginConfig = () => ({
     resolve: {
       alias: {
         '@components': path.resolve(__dirname, './src/components'),
+        '@mdx-components': path.resolve(__dirname, './src/mdx-components'),
         '@scss': path.resolve(__dirname, './src/scss'),
       },
     },

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@mdx-js/react": "^3.1.0",
     "@silverhand/eslint-config": "^6.0.0",
     "@silverhand/eslint-config-react": "^6.0.0",
+    "@silverhand/essentials": "^2.9.2",
     "@silverhand/ts-config": "^6.0.0",
     "@silverhand/ts-config-react": "^6.0.0",
     "@types/node": "^22.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       '@silverhand/eslint-config-react':
         specifier: ^6.0.0
         version: 6.0.2(@types/eslint@9.6.1)(eslint@9.13.0(jiti@1.21.6))(postcss@8.4.47)(prettier@3.3.3)(stylelint@16.10.0(typescript@5.6.3))(typescript@5.6.3)
+      '@silverhand/essentials':
+        specifier: ^2.9.2
+        version: 2.9.2
       '@silverhand/ts-config':
         specifier: ^6.0.0
         version: 6.0.0(typescript@5.6.3)
@@ -1352,6 +1355,10 @@ packages:
     engines: {node: '>=14.15.0'}
     peerDependencies:
       eslint: ^8.1.0
+
+  '@silverhand/essentials@2.9.2':
+    resolution: {integrity: sha512-bD+82D9Dfa1F5xX1kfdR5ODIoJS41NOxTuHx4shVS5A4/ayEG+ZplpDDjB19fsa7kZXgSgD75R4sUCXjm88x6w==}
+    engines: {node: ^18.12.0 || ^20.9.0 || ^22.0.0, pnpm: ^9.0.0}
 
   '@silverhand/ts-config-react@6.0.0':
     resolution: {integrity: sha512-eEB8TwGzw5kJTKcuHtvifpcs6p8ZDNRFWH2W7ZM4Rf7DsFBQtXkYpwQFQvZ9UVOAs4YCIeSY4OJCjtaY0fUp8g==}
@@ -8994,10 +9001,10 @@ snapshots:
       eslint-config-prettier: 9.1.0(eslint@9.13.0(jiti@1.21.6))
       eslint-config-xo: 0.44.0(eslint@9.13.0(jiti@1.21.6))
       eslint-config-xo-typescript: 4.0.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3))(@typescript-eslint/parser@7.18.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3)
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.18.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import@2.31.0)(eslint@9.13.0(jiti@1.21.6))
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.18.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.13.0(jiti@1.21.6)))(eslint@9.13.0(jiti@1.21.6))
       eslint-plugin-consistent-default-export-name: 0.0.15
       eslint-plugin-eslint-comments: 3.2.0(eslint@9.13.0(jiti@1.21.6))
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@9.13.0(jiti@1.21.6))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.13.0(jiti@1.21.6)))(eslint@9.13.0(jiti@1.21.6)))(eslint@9.13.0(jiti@1.21.6))
       eslint-plugin-n: 17.11.1(eslint@9.13.0(jiti@1.21.6))
       eslint-plugin-no-use-extend-native: 0.5.0
       eslint-plugin-prettier: 5.2.1(@types/eslint@9.6.1)(eslint-config-prettier@9.1.0(eslint@9.13.0(jiti@1.21.6)))(eslint@9.13.0(jiti@1.21.6))(prettier@3.3.3)
@@ -9021,6 +9028,8 @@ snapshots:
       eslint-ast-utils: 1.1.0
       import-modules: 2.1.0
       lodash: 4.17.21
+
+  '@silverhand/essentials@2.9.2': {}
 
   '@silverhand/ts-config-react@6.0.0(typescript@5.6.3)':
     dependencies:
@@ -10932,19 +10941,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import@2.31.0)(eslint@9.13.0(jiti@1.21.6)):
+  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.13.0(jiti@1.21.6)))(eslint@9.13.0(jiti@1.21.6)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.3.7
       enhanced-resolve: 5.17.1
       eslint: 9.13.0(jiti@1.21.6)
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.13.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.13.0(jiti@1.21.6)))(eslint@9.13.0(jiti@1.21.6)))(eslint@9.13.0(jiti@1.21.6))
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@9.13.0(jiti@1.21.6))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.13.0(jiti@1.21.6)))(eslint@9.13.0(jiti@1.21.6)))(eslint@9.13.0(jiti@1.21.6))
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
@@ -10972,14 +10981,14 @@ snapshots:
       - bluebird
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.18.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.13.0(jiti@1.21.6)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.18.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.13.0(jiti@1.21.6)))(eslint@9.13.0(jiti@1.21.6)))(eslint@9.13.0(jiti@1.21.6)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.18.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3)
       eslint: 9.13.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.18.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import@2.31.0)(eslint@9.13.0(jiti@1.21.6))
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.18.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.13.0(jiti@1.21.6)))(eslint@9.13.0(jiti@1.21.6))
     transitivePeerDependencies:
       - supports-color
 
@@ -11001,7 +11010,7 @@ snapshots:
       eslint: 9.13.0(jiti@1.21.6)
       ignore: 5.3.2
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@9.13.0(jiti@1.21.6)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.13.0(jiti@1.21.6)))(eslint@9.13.0(jiti@1.21.6)))(eslint@9.13.0(jiti@1.21.6)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -11012,7 +11021,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.13.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.13.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.13.0(jiti@1.21.6)))(eslint@9.13.0(jiti@1.21.6)))(eslint@9.13.0(jiti@1.21.6))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3

--- a/src/mdx-components/CloudLink/index.tsx
+++ b/src/mdx-components/CloudLink/index.tsx
@@ -1,0 +1,53 @@
+import { joinPath } from '@silverhand/essentials';
+import { type PropsWithChildren } from 'react';
+
+type Props = PropsWithChildren<{
+  /**
+   * The path to navigate to in the Cloud console. E.g., `to="applications"`.
+   * If the path is an absolute URL, it will be used as is.
+   */
+  readonly to: string;
+}>;
+
+const logtoCloudConsoleUrl = 'https://cloud.logto.io';
+const logtoCloudTenantIdWildcard = 'to';
+
+const isAbsoluteUrl = (url: string) => {
+  return url.startsWith('http://') || url.startsWith('https://');
+};
+
+const getCloudConsoleUrl = (path: string) => {
+  if (isAbsoluteUrl(path)) {
+    return path;
+  }
+
+  const baseUrl = new URL(logtoCloudConsoleUrl);
+  const pathname =
+    path.startsWith(`/${logtoCloudTenantIdWildcard}/`) ||
+    path.startsWith(`${logtoCloudTenantIdWildcard}/`)
+      ? path
+      : joinPath(logtoCloudTenantIdWildcard, path);
+
+  return new URL(pathname, baseUrl).toString();
+};
+
+/**
+ * Remove the possible leading slashes and capitalize the first letter
+ */
+const toTitleCaseLabel = (path: string) => {
+  const pathWithoutLeadingSlashes = path.replace(/^\/+/, '');
+  // Capitalize the first letter
+  return pathWithoutLeadingSlashes.charAt(0).toUpperCase() + pathWithoutLeadingSlashes.slice(1);
+};
+
+const CloudLink = ({ to, children }: Props) => {
+  const link = getCloudConsoleUrl(to);
+
+  return (
+    <a href={link} target="_blank" rel="noopener">
+      {children || toTitleCaseLabel(to)}
+    </a>
+  );
+};
+
+export default CloudLink;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add `<CloudLink>` component to support Cloud Console URL navigation.

You can use it in the following ways:

```html
<CloudLink to="applications" />
```

```html
<CloudLink to="/applications" />
```
These are equivalent to:
```md
[Applications](https://cloud.logto.io/to/applications)
```

Or specify a display text
```html
<CloudLink to="/sign-in-experience/sign-in-and-sign-out">
  Sign-in Experience > Sign-in and sign-out
</CloudLink>
```