### PR TITLE
feat: add NavGroup component

### DIFF
--- a/docs/introduction/README.mdx
+++ b/docs/introduction/README.mdx
@@ -1,3 +1,5 @@
+import CloudIcon from '@site/src/assets/cloud.svg';
+
 # Get started
 
 **[Logto](https://cloud.logto.io/) is a comprehensive identity solution** covering both the front and backend, complete with pre-built infrastructure and enterprise-grade solutions for what's often called "Customer Identity and Access Management" (CIAM).
@@ -21,3 +23,12 @@ This is what hyperlinks look like in plain mdx. E.g. [Invite team members](/intr
 <Url href="https://auth.wiki/redirect-uri">Redirect Uri</Url>
 
 This is internal links used as a reference.<Url href="/introduction/invite-team-members">Invite team members</Url>
+
+<NavGroup
+  label="This is a grouped nav items"
+  items={[
+    { icon: <CloudIcon />, docId: 'introduction/invite-team-members' },
+    { icon: <CloudIcon />, docId: 'introduction/invite-team-members' },
+    { icon: <CloudIcon />, docId: 'introduction/invite-team-members' },
+  ]}
+/>

--- a/src/components/NavGroup/index.module.scss
+++ b/src/components/NavGroup/index.module.scss
@@ -1,0 +1,25 @@
+.groupLabel {
+  color: var(--logto-color-text);
+  font: var(--font-title-2);
+  display: inline-block;
+  margin-bottom: 1rem;
+}
+
+.navItem {
+  display: inline-flex;
+  align-items: center;
+  gap: 20px;
+  color: var(--logto-color-text);
+  font: var(font-body-1);
+
+  &:hover {
+    color: var(--ifm-link-color);
+    text-decoration: none;
+  }
+
+  > svg {
+    width: 20px;
+    height: 20px;
+    color: var(--ifm-link-color);
+  }
+}

--- a/src/components/NavGroup/index.tsx
+++ b/src/components/NavGroup/index.tsx
@@ -1,0 +1,44 @@
+import Link from '@docusaurus/Link';
+import { useDocById, useLayoutDoc } from '@docusaurus/plugin-content-docs/client';
+import { type ReactNode } from 'react';
+
+import styles from './index.module.scss';
+
+type NavItem = {
+  readonly icon: ReactNode;
+  readonly docId: string;
+};
+
+type Props = {
+  readonly label: string;
+  readonly items: NavItem[];
+};
+
+const NavItem = ({ icon, docId }: NavItem) => {
+  const doc = useLayoutDoc(docId);
+  const { title } = useDocById(docId);
+
+  return (
+    <span className="col col--6 margin-bottom--md">
+      <Link className={styles.navItem} href={doc?.path}>
+        {icon}
+        {title}
+      </Link>
+    </span>
+  );
+};
+
+const NavGroup = ({ label, items }: Props) => {
+  return (
+    <>
+      <label className={styles.groupLabel}>{label}</label>
+      <div className="row">
+        {items.map((item) => (
+          <NavItem key={item.docId} {...item} />
+        ))}
+      </div>
+    </>
+  );
+};
+
+export default NavGroup;

--- a/src/components/Url/index.module.scss
+++ b/src/components/Url/index.module.scss
@@ -3,10 +3,6 @@
   align-items: center;
   margin-bottom: var(--ifm-leading);
 
-  + .linkWrapper {
-    margin-top: -1.25rem;
-  }
-
   .link {
     display: inline-flex;
     align-items: center;
@@ -32,8 +28,16 @@
     margin: 0;
   }
 
+  + .linkWrapper {
+    margin-top: -1.25rem;
+  }
+
   &.inline {
     display: inline-flex;
     margin-bottom: 0;
+
+    + .linkWrapper {
+      margin-top: 0;
+    }
   }
 }

--- a/src/components/Url/index.tsx
+++ b/src/components/Url/index.tsx
@@ -24,14 +24,17 @@ const isDocLink = (href?: string) =>
 export type Props = ComponentProps<'a'> & {
   readonly hasIcon?: boolean;
   readonly type?: 'block' | 'inline';
+  readonly wrapperClassName?: string;
 };
 
 const Url = (props: Props): JSX.Element => {
-  const { className, children, hasIcon = true, type = 'block', ...rest } = props;
+  const { className, wrapperClassName, children, hasIcon = true, type = 'block', ...rest } = props;
   const isInternal = isInternalUrl(props.href);
 
   return (
-    <span className={clsx(styles.linkWrapper, type === 'inline' && styles.inline)}>
+    <span
+      className={clsx(wrapperClassName, styles.linkWrapper, type === 'inline' && styles.inline)}
+    >
       <Link className={clsx(className, styles.link)} {...rest}>
         {hasIcon && isApiDocLink(props.href) && <ApiIcon className={styles.flexWidth} />}
         {hasIcon && isVideoLink(props.href) && <VideoIcon />}

--- a/src/theme/DocCardList/index.tsx
+++ b/src/theme/DocCardList/index.tsx
@@ -1,0 +1,30 @@
+import {
+  useCurrentSidebarCategory,
+  filterDocCardListItems,
+} from '@docusaurus/plugin-content-docs/client';
+import DocCard from '@theme/DocCard';
+import type { Props } from '@theme/DocCardList';
+import clsx from 'clsx';
+
+function DocCardListForCurrentSidebarCategory({ className }: Props) {
+  const category = useCurrentSidebarCategory();
+  return <DocCardList items={category.items} className={className} />;
+}
+
+export default function DocCardList(props: Props): JSX.Element {
+  const { items, className } = props;
+  if (!items) {
+    return <DocCardListForCurrentSidebarCategory {...props} />;
+  }
+  const filteredItems = filterDocCardListItems(items);
+  return (
+    <section className={clsx('row', className)}>
+      {filteredItems.map((item, index) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <article key={index} className="col col--6 margin-bottom--lg">
+          <DocCard item={item} />
+        </article>
+      ))}
+    </section>
+  );
+}

--- a/src/theme/MDXComponents/index.ts
+++ b/src/theme/MDXComponents/index.ts
@@ -1,11 +1,13 @@
 import MDXComponents from '@theme-original/MDXComponents';
 
 import CloudLink from '@site/src/components/CloudLink';
+import NavGroup from '@site/src/components/NavGroup';
 import Url from '@site/src/components/Url';
 
 const components = {
   ...MDXComponents,
   CloudLink,
+  NavGroup,
   Url,
 };
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add a new `<NavGroup />` component.

Design:
<img width="600" src="https://github.com/user-attachments/assets/a1c56407-3848-479d-80e2-7b66e5ef1be2" />

Example usage:
```
import Icon1 from '@site/src/assets/icon1.svg';
import Icon2 from '@site/src/assets/icon2.svg';
import Icon3 from '@site/src/assets/icon3.svg';

<NavGroup
  label="This is a grouped nav items"
  items={[
    { icon: <Icon1 />, docId: 'your-doc-id-1' },
    { icon: <Icon2 />, docId: 'your-doc-id-2' },
    { icon: <Icon3 />, docId: 'your-doc-id-3' },
  ]}
/>
```

![result](https://github.com/user-attachments/assets/e4bae1b4-1ece-4e85-bd6e-f4546d345e09)
