### PR TITLE
chore: temporarily disable crawling for v2

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,5 +1,5 @@
 User-agent: *
-Allow: /
+Disallow: /
 
 User-agent: Algolia Crawler
 Allow: /


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Temporarily disable crawling for V2, in order not to cause SEO problems due to duplicated contents.

Will enable it back once we add the canonical URLs correctly on V1 docs site.
