### PR TITLE
style: improve styles of language switch banner and feedback row

### DIFF
--- a/src/components/Banner/index.module.scss
+++ b/src/components/Banner/index.module.scss
@@ -1,12 +1,13 @@
 .banner {
-  position: absolute;
-  top: 18px;
+  position: fixed;
+  top: 16px;
   left: 50%;
   transform: translateX(-50%);
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 10px 18px;
+  padding-block: 7px;
+  padding-inline: 18px 12px;
   border-radius: 8px;
   border: 1px solid var(--logto-container-on-info);
   background: var(--logto-container-info-bg);

--- a/src/components/LanguageSwitchBanner/index.module.scss
+++ b/src/components/LanguageSwitchBanner/index.module.scss
@@ -1,4 +1,18 @@
+.message {
+  white-space: nowrap;
+}
+
+.link {
+  font: var(--font-label-2);
+}
+
 .link,
 .link:hover {
   text-decoration: none;
+}
+
+@media (max-width: 996px) {
+  .message {
+    white-space: normal;
+  }
 }

--- a/src/components/LanguageSwitchBanner/index.tsx
+++ b/src/components/LanguageSwitchBanner/index.tsx
@@ -47,7 +47,7 @@ const LanguageSwitchBanner = () => {
           setTargetLocale(undefined);
         }}
       >
-        <span>
+        <span className={styles.message}>
           {translate({
             id: 'theme.languageSwitchBanner.message',
             message: 'A version matching your device language is available. Switch to ',

--- a/src/theme/EditMetaRow/index.tsx
+++ b/src/theme/EditMetaRow/index.tsx
@@ -17,10 +17,16 @@ export default function EditMetaRow({ className, editUrl }: Props): JSX.Element 
   const [feedback, setFeedback] = useState('');
 
   return (
-    <div className={className}>
-      <div className={styles.container}>
-        <div className={styles.feedbackWrapper}>
-          <span className={styles.label}>Did you find what you needed?</span>
+    <div className={clsx(styles.container, className)}>
+      <div className={styles.flexRow}>
+        <div className={styles.feedback}>
+          <span className={styles.label}>
+            {translate({
+              id: 'theme.common.doYouFindThisPageHelpful',
+              message: 'Do you find this page helpful?',
+              description: 'The label for the docs helpfulness question',
+            })}
+          </span>
           {!showSuccessMessage && (
             <div className={styles.buttons}>
               <Button
@@ -52,40 +58,6 @@ export default function EditMetaRow({ className, editUrl }: Props): JSX.Element 
               </Button>
             </div>
           )}
-          {!showSuccessMessage && showTextarea && (
-            <>
-              <Textarea
-                className={styles.feedback}
-                placeholder={translate({
-                  id: 'theme.common.feedbackPlaceholder',
-                  message: "We'd love to hear your feedback!",
-                  description: 'The placeholder of the feedback textarea',
-                })}
-                value={feedback}
-                onChange={({ currentTarget }) => {
-                  setFeedback(currentTarget.value);
-                }}
-              />
-              <div className={styles.buttons}>
-                <Button
-                  className={styles.button}
-                  type="primary"
-                  onClick={() => {
-                    window.plausible?.('Docs Not Helpful', {
-                      properties: { feedback },
-                    });
-                    setShowSuccessMessage(true);
-                  }}
-                >
-                  {translate({
-                    id: 'theme.common.submit',
-                    message: 'Submit',
-                    description: 'The label of the submit button',
-                  })}
-                </Button>
-              </div>
-            </>
-          )}
           {showSuccessMessage && (
             <div className={styles.successMessage}>
               {translate({
@@ -112,6 +84,40 @@ export default function EditMetaRow({ className, editUrl }: Props): JSX.Element 
           </div>
         )}
       </div>
+      {!showSuccessMessage && showTextarea && (
+        <>
+          <Textarea
+            className={styles.feedbackInput}
+            placeholder={translate({
+              id: 'theme.common.feedbackPlaceholder',
+              message: "We'd love to hear your feedback!",
+              description: 'The placeholder of the feedback textarea',
+            })}
+            value={feedback}
+            onChange={({ currentTarget }) => {
+              setFeedback(currentTarget.value);
+            }}
+          />
+          <div className={styles.buttons}>
+            <Button
+              className={styles.button}
+              type="primary"
+              onClick={() => {
+                window.plausible?.('Docs Not Helpful', {
+                  properties: { feedback },
+                });
+                setShowSuccessMessage(true);
+              }}
+            >
+              {translate({
+                id: 'theme.common.submit',
+                message: 'Submit',
+                description: 'The label of the submit button',
+              })}
+            </Button>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/theme/EditMetaRow/styles.module.scss
+++ b/src/theme/EditMetaRow/styles.module.scss
@@ -1,10 +1,18 @@
 .container {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  gap: 12px;
+}
+
+.flexRow {
   width: 100%;
   display: flex;
   justify-content: space-between;
+  gap: 12px;
 }
 
-.feedbackWrapper {
+.feedback {
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -29,8 +37,9 @@
   }
 }
 
-.feedback {
-  width: 60%;
+.feedbackInput {
+  width: 100%;
+  max-width: 420px;
 }
 
 .successMessage {
@@ -50,18 +59,12 @@
 }
 
 @media (max-width: 996px) {
-  .container {
+  .flexRow {
     flex-direction: column;
-    gap: 12px;
   }
 
   .buttons {
     margin-bottom: 12px;
-  }
-
-  .feedback {
-    width: 100%;
-    max-width: 420px;
   }
 
   .successMessage {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Improve CSS styles of language switch banner and doc feedback component

<img width="668" alt="image" src="https://github.com/user-attachments/assets/0c9a8bb0-97a9-4f18-91f3-5fde7ff0e6fd">

<img width="708" alt="image" src="https://github.com/user-attachments/assets/a5f28e73-a175-41ee-9fef-4f9e94b306c6">
