### PR TITLE
fix: add missing i18n translation to the help us improve docs label

### DIFF
--- a/i18n/de/code.json
+++ b/i18n/de/code.json
@@ -449,6 +449,10 @@
     "message": "Finden Sie diese Seite hilfreich?",
     "description": "The label for the docs helpfulness question"
   },
+  "theme.common.helpUsImproveTheDocs": {
+    "message": "Helfen Sie uns, die Dokumentation zu verbessern!",
+    "description": "The label for the edit this page button"
+  },
   "theme.common.yes": {
     "message": "Ja",
     "description": "The label for the docs helpful button"

--- a/i18n/es/code.json
+++ b/i18n/es/code.json
@@ -449,6 +449,10 @@
     "message": "¿Te ha resultado útil esta página?",
     "description": "The label for the docs helpfulness question"
   },
+  "theme.common.helpUsImproveTheDocs": {
+    "message": "¡Ayúdanos a mejorar la documentación!",
+    "description": "The label for the edit this page button"
+  },
   "theme.common.yes": {
     "message": "Sí",
     "description": "The label for the docs helpful button"

--- a/i18n/fr/code.json
+++ b/i18n/fr/code.json
@@ -449,6 +449,10 @@
     "message": "Trouvez-vous cette page utile ?",
     "description": "The label for the docs helpfulness question"
   },
+  "theme.common.helpUsImproveTheDocs": {
+    "message": "Aidez-nous à améliorer la documentation !",
+    "description": "The label for the edit this page button"
+},
   "theme.common.yes": {
     "message": "Oui",
     "description": "The label for the docs helpful button"

--- a/i18n/pt-BR/code.json
+++ b/i18n/pt-BR/code.json
@@ -449,6 +449,10 @@
     "message": "Você achou esta página útil?",
     "description": "The label for the docs helpfulness question"
   },
+  "theme.common.helpUsImproveTheDocs": {
+    "message": "Ajude-nos a melhorar a documentação!",
+    "description": "The label for the edit this page button"
+  },
   "theme.common.yes": {
     "message": "Sim",
     "description": "The label for the docs helpful button"

--- a/i18n/zh-CN/code.json
+++ b/i18n/zh-CN/code.json
@@ -449,6 +449,10 @@
     "message": "当前页面对你是否有帮助？",
     "description": "The label for the docs helpfulness question"
   },
+  "theme.common.helpUsImproveTheDocs": {
+    "message": "帮助我们改进文档！",
+    "description": "The label for the edit this page button"
+  },
   "theme.common.yes": {
     "message": "是",
     "description": "The label for the docs helpful button"
@@ -466,7 +470,7 @@
     "description": "The label of the submit button"
   },
   "theme.common.thanksForTheFeedback": {
-    "message": "感谢你帮助我们改进 Logto 文档！ 💜 ",
+    "message": "感谢你帮助我们改进 Logto 文档！💜",
     "description": "The success message after submitting feedback"
   },
   "Hosted in 🇪🇺🇺🇸🇦🇺": {

--- a/src/theme/EditMetaRow/index.tsx
+++ b/src/theme/EditMetaRow/index.tsx
@@ -1,4 +1,4 @@
-import { translate } from '@docusaurus/Translate';
+import Translate, { translate } from '@docusaurus/Translate';
 import type { Props } from '@theme/EditMetaRow';
 import clsx from 'clsx';
 import { useState } from 'react';
@@ -70,7 +70,11 @@ export default function EditMetaRow({ className, editUrl }: Props): JSX.Element 
         </div>
         {editUrl && (
           <div className={styles.editUrlColumn}>
-            <span className={styles.label}>Help us improve the docs!</span>
+            <span className={styles.label}>
+              <Translate id="theme.common.helpUsImproveTheDocs">
+                Help us improve the docs!
+              </Translate>
+            </span>
             <div className={styles.buttons}>
               <Button className={styles.button} href={editUrl}>
                 <EditIcon />


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add missing i18n translation of the "Help us improve docs!" label.

<img width="1510" alt="image" src="https://github.com/user-attachments/assets/b443bb30-cfb9-4945-ba75-3c2bdc9c4cd7">
