### PR TITLE
fix: broken mermaid chart in zh-CN translation

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/integrate-logto/protected-app.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/integrate-logto/protected-app.mdx
@@ -18,7 +18,7 @@ sidebar_position: 2
 graph LR
   A("客户端<br/>(浏览器)") -->|请求| B(Logto<br/>受保护的应用程序)
   B --> Condition{{路由<br/>匹配吗？}}
-  Condition -->|是| Matched{{已认证 (Authentication) 吗？}}
+  Condition -->|是| Matched{{已认证 #40;Authentication#41; 吗？}}
   Matched -->|是| C(源服务器)
   Matched -->|否| D(Logto 登录)
   Condition -->|否| C


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix the broken mermaid chart found in "Integrate Logto - Protected app" in zh-CN locale

Before:
<img width="1509" alt="image" src="https://github.com/user-attachments/assets/4455cc2c-730a-4c58-aa8b-dd445f09b436">

After:
<img width="1495" alt="image" src="https://github.com/user-attachments/assets/df90ef4d-b48a-4ef6-879f-67c4101d189a">

