### PR TITLE
refactor: code block component styling

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -27,7 +27,7 @@ const getLogtoDocsUrl = () =>
     ? `https://${cfPagesBranch.substring(0, 28)}.logto-docs.pages.dev/`
     : 'https://docs.logto.io/';
 
-const { dracula: darkCodeTheme, github: lightCodeTheme } = themes;
+const { dracula } = themes;
 
 const addAliasPlugin: PluginConfig = () => ({
   name: 'add-alias-plugin',
@@ -322,8 +322,8 @@ const config: Config = {
       copyright: `Designed by Silverhand Inc.`,
     },
     prism: {
-      theme: lightCodeTheme,
-      darkTheme: darkCodeTheme,
+      theme: dracula,
+      darkTheme: dracula,
       additionalLanguages: [
         'swift',
         'kotlin',

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -41,6 +41,7 @@
   --doc-sidebar-section-title: #c9c5d0;
   --docusaurus-highlighted-code-line-bg: rgba(72, 77, 91, 12%);
   --docusaurus-details-decoration-color: var(var(--logto-line-divider));
+  --docusaurus-highlighted-code-line-bg: rgba(255, 255, 255, 8%);
 
   --padding-max-width: 100px;
 
@@ -121,7 +122,7 @@ html[data-theme='dark'] {
   --ifm-table-stripe-background: var(--logto-bg-light);
 
   --doc-sidebar-section-title: #777;
-  --docusaurus-highlighted-code-line-bg: rgba(100, 100, 100, 3%);
+  --docusaurus-highlighted-code-line-bg: rgba(255, 255, 255, 8%);
 
   --logto-link-color: #a38fff;
   --logto-color-text: #f7f8f8;
@@ -605,6 +606,7 @@ hr {
   background-color: var(--logto-border);
 }
 
+// Inline code
 code {
   tab-size: 4;
   font-size: 1em;

--- a/src/theme/CodeBlock/Content/String.tsx
+++ b/src/theme/CodeBlock/Content/String.tsx
@@ -1,0 +1,115 @@
+/**
+ * Charles note: Nothing is changed in this file. The component is swizzled
+ * as I need to override the `codeBlockTitle` class in the CSS.
+ */
+import { useThemeConfig, usePrismTheme } from '@docusaurus/theme-common';
+import {
+  parseCodeBlockTitle,
+  parseLanguage,
+  parseLines,
+  containsLineNumbers,
+  useCodeWordWrap,
+} from '@docusaurus/theme-common/internal';
+import Container from '@theme/CodeBlock/Container';
+import type { Props } from '@theme/CodeBlock/Content/String';
+import CopyButton from '@theme/CodeBlock/CopyButton';
+import Line from '@theme/CodeBlock/Line';
+import WordWrapButton from '@theme/CodeBlock/WordWrapButton';
+import clsx from 'clsx';
+import { Highlight } from 'prism-react-renderer';
+
+import styles from './styles.module.css';
+
+// Prism languages are always lowercase
+// We want to fail-safe and allow both "php" and "PHP"
+// See https://github.com/facebook/docusaurus/issues/9012
+function normalizeLanguage(language: string | undefined): string | undefined {
+  return language?.toLowerCase();
+}
+
+export default function CodeBlockString({
+  children,
+  className: blockClassName = '',
+  metastring,
+  title: titleProp,
+  showLineNumbers: showLineNumbersProp,
+  language: languageProp,
+}: Props): JSX.Element {
+  const {
+    prism: { defaultLanguage, magicComments },
+  } = useThemeConfig();
+  const language = normalizeLanguage(
+    languageProp ?? parseLanguage(blockClassName) ?? defaultLanguage
+  );
+
+  const prismTheme = usePrismTheme();
+  const wordWrap = useCodeWordWrap();
+
+  // We still parse the metastring in case we want to support more syntax in the
+  // future. Note that MDX doesn't strip quotes when parsing metastring:
+  // "title=\"xyz\"" => title: "\"xyz\""
+  const title = parseCodeBlockTitle(metastring) || titleProp;
+
+  const { lineClassNames, code } = parseLines(children, {
+    metastring,
+    language,
+    magicComments,
+  });
+  const showLineNumbers = showLineNumbersProp ?? containsLineNumbers(metastring);
+
+  return (
+    <Container
+      as="div"
+      className={clsx(
+        blockClassName,
+        language && !blockClassName.includes(`language-${language}`) && `language-${language}`
+      )}
+    >
+      {title && <div className={styles.codeBlockTitle}>{title}</div>}
+      <div className={styles.codeBlockContent}>
+        <Highlight theme={prismTheme} code={code} language={language ?? 'text'}>
+          {({ className, style, tokens, getLineProps, getTokenProps }) => (
+            <pre
+              ref={wordWrap.codeBlockRef}
+              // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+              tabIndex={0}
+              className={clsx(className, styles.codeBlock, 'thin-scrollbar')}
+              style={style}
+            >
+              <code
+                className={clsx(
+                  styles.codeBlockLines,
+                  showLineNumbers && styles.codeBlockLinesWithNumbering
+                )}
+              >
+                {tokens.map((line, i) => (
+                  <Line
+                    // eslint-disable-next-line react/no-array-index-key
+                    key={i}
+                    line={line}
+                    getLineProps={getLineProps}
+                    getTokenProps={getTokenProps}
+                    classNames={lineClassNames[i]}
+                    showLineNumbers={showLineNumbers}
+                  />
+                ))}
+              </code>
+            </pre>
+          )}
+        </Highlight>
+        <div className={styles.buttonGroup}>
+          {(wordWrap.isEnabled || wordWrap.isCodeScrollable) && (
+            <WordWrapButton
+              className={styles.codeButton}
+              isEnabled={wordWrap.isEnabled}
+              onClick={() => {
+                wordWrap.toggle();
+              }}
+            />
+          )}
+          <CopyButton className={styles.codeButton} code={code} />
+        </div>
+      </div>
+    </Container>
+  );
+}

--- a/src/theme/CodeBlock/Content/styles.module.css
+++ b/src/theme/CodeBlock/Content/styles.module.css
@@ -1,0 +1,82 @@
+.codeBlockContent {
+  position: relative;
+  /* rtl:ignore */
+  direction: ltr;
+  border-radius: inherit;
+}
+
+.codeBlockTitle {
+  /* Fix to gray-700 as we now use dracula theme for both light and dark modes */
+  border-bottom: 1px solid var(--ifm-color-gray-700);
+  /* border-bottom: 1px solid var(--ifm-color-emphasis-300); */
+  font-size: var(--ifm-code-font-size);
+  font-weight: 500;
+  padding: 0.75rem var(--ifm-pre-padding);
+  border-top-left-radius: inherit;
+  border-top-right-radius: inherit;
+}
+
+.codeBlock {
+  --ifm-pre-background: var(--prism-background-color);
+  margin: 0;
+  padding: 0;
+}
+
+.codeBlockTitle + .codeBlockContent .codeBlock {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.codeBlockStandalone {
+  padding: 0;
+}
+
+.codeBlockLines {
+  font: inherit;
+  /* rtl:ignore */
+  float: left;
+  min-width: 100%;
+  padding: var(--ifm-pre-padding);
+}
+
+.codeBlockLinesWithNumbering {
+  display: table;
+  padding: var(--ifm-pre-padding) 0;
+}
+
+@media print {
+  .codeBlockLines {
+    white-space: pre-wrap;
+  }
+}
+
+.buttonGroup {
+  display: flex;
+  column-gap: 0.2rem;
+  position: absolute;
+  /* rtl:ignore */
+  right: calc(var(--ifm-pre-padding) / 2);
+  top: calc(var(--ifm-pre-padding) / 2);
+}
+
+.buttonGroup button {
+  display: flex;
+  align-items: center;
+  background: var(--prism-background-color);
+  color: var(--prism-color);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: var(--ifm-global-radius);
+  padding: 0.4rem;
+  line-height: 0;
+  transition: opacity var(--ifm-transition-fast) ease-in-out;
+  opacity: 0;
+}
+
+.buttonGroup button:focus-visible,
+.buttonGroup button:hover {
+  opacity: 1 !important;
+}
+
+:global(.theme-code-block:hover) .buttonGroup button {
+  opacity: 0.4;
+}


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Ref-styling code block component. Force use the `Dracula` theme for both light and dark modes.
