### PR TITLE
refactor: improve mobile page performance

### DIFF
--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -260,6 +260,7 @@ body #__docusaurus {
     border-radius: 8px;
     padding-block: 7px;
     padding-inline: 12px 6px;
+    width: 173px;
     font: var(--font-label-2);
     position: relative;
     color: var(--logto-color-text-secondary);
@@ -288,7 +289,6 @@ body #__docusaurus {
       color: var(--logto-color-text-secondary);
       padding: 0;
       margin-inline-start: 8px;
-      width: 90px;
       text-align: start;
     }
 

--- a/src/theme/DocItem/Layout/index.module.scss
+++ b/src/theme/DocItem/Layout/index.module.scss
@@ -16,12 +16,12 @@
   }
 }
 
-.toc {
+.desktopToc {
   flex: 0 0 276px;
 }
 
-@media (min-width: 997px) {
-  .main.hasDocToc {
-    max-width: min(1000px, calc(100vw - 680px));
+@media (max-width: 996px) {
+  .desktopToc {
+    display: none;
   }
 }

--- a/src/theme/DocItem/Layout/index.tsx
+++ b/src/theme/DocItem/Layout/index.tsx
@@ -10,7 +10,6 @@ import DocItemTOCDesktop from '@theme/DocItem/TOC/Desktop';
 import DocItemTOCMobile from '@theme/DocItem/TOC/Mobile';
 import DocVersionBadge from '@theme/DocVersionBadge';
 import DocVersionBanner from '@theme/DocVersionBanner';
-import clsx from 'clsx';
 
 import styles from './index.module.scss';
 
@@ -43,7 +42,7 @@ export default function DocItemLayout({ children }: Props): JSX.Element {
   const { metadata } = useDoc();
   return (
     <div className={styles.layout}>
-      <div className={clsx(styles.main, docTOC.desktop && styles.hasDocToc)}>
+      <div className={styles.main}>
         <ContentVisibility metadata={metadata} />
         <DocVersionBanner />
         <div className={styles.docItemContainer}>
@@ -57,7 +56,7 @@ export default function DocItemLayout({ children }: Props): JSX.Element {
           <DocItemPaginator />
         </div>
       </div>
-      {docTOC.desktop && <div className={styles.toc}>{docTOC.desktop}</div>}
+      {docTOC.desktop && <div className={styles.desktopToc}>{docTOC.desktop}</div>}
     </div>
   );
 }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Improve mobile page performance on initial loading
- Hide right side doc TOC on mobile, as previously it would still impact the mobile layout on init, and the page jitters when its state gets updated

Growing from:
<img width="417" alt="image" src="https://github.com/user-attachments/assets/0c4a58f3-6bcd-46cf-9306-1ee6e2bf95b9" />

Back to 76-86-ish