### PR TITLE
chore: add i18n translation to sublist labels in end user flows

### DIFF
--- a/i18n/de/docusaurus-plugin-content-docs/current/end-user-flows/account-settings/README.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/end-user-flows/account-settings/README.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 7
+sidebar_custom_props:
+  sublist_label: Kontoabläufe
 ---
 
 import GearIcon from '@site/src/assets/gear.svg';

--- a/i18n/de/docusaurus-plugin-content-docs/current/end-user-flows/organization-experience/README.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/end-user-flows/organization-experience/README.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 9
+sidebar_custom_props:
+  sublist_label: Organisationsabläufe
 ---
 
 import GearIcon from '@site/src/assets/gear.svg';

--- a/i18n/de/docusaurus-plugin-content-docs/current/end-user-flows/sign-up-and-sign-in/README.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/end-user-flows/sign-up-and-sign-in/README.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 1
+sidebar_custom_props:
+  sublist_label: Authentifizierungsabläufe
 ---
 
 # Registrierung und Anmeldung

--- a/i18n/es/docusaurus-plugin-content-docs/current/end-user-flows/account-settings/README.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/current/end-user-flows/account-settings/README.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 7
+sidebar_custom_props:
+  sublist_label: Flujos de cuenta
 ---
 
 import GearIcon from '@site/src/assets/gear.svg';

--- a/i18n/es/docusaurus-plugin-content-docs/current/end-user-flows/organization-experience/README.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/current/end-user-flows/organization-experience/README.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 9
+sidebar_custom_props:
+  sublist_label: Flujos de organización
 ---
 
 import GearIcon from '@site/src/assets/gear.svg';

--- a/i18n/es/docusaurus-plugin-content-docs/current/end-user-flows/sign-up-and-sign-in/README.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/current/end-user-flows/sign-up-and-sign-in/README.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 1
+sidebar_custom_props:
+  sublist_label: Flujos de autenticación
 ---
 
 # Registro e inicio de sesión

--- a/i18n/fr/docusaurus-plugin-content-docs/current/end-user-flows/account-settings/README.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/end-user-flows/account-settings/README.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 7
+sidebar_custom_props:
+  sublist_label: Flux de compte
 ---
 
 import GearIcon from '@site/src/assets/gear.svg';

--- a/i18n/fr/docusaurus-plugin-content-docs/current/end-user-flows/organization-experience/README.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/end-user-flows/organization-experience/README.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 9
+sidebar_custom_props:
+  sublist_label: Flux d'organisation
 ---
 
 import GearIcon from '@site/src/assets/gear.svg';

--- a/i18n/fr/docusaurus-plugin-content-docs/current/end-user-flows/sign-up-and-sign-in/README.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/end-user-flows/sign-up-and-sign-in/README.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 1
+sidebar_custom_props:
+  sublist_label: Flujos de autenticación
 ---
 
 # Inscription et connexion

--- a/i18n/ja/docusaurus-plugin-content-docs/current/end-user-flows/account-settings/README.mdx
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/end-user-flows/account-settings/README.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 7
+sidebar_custom_props:
+  sublist_label: アカウントフロー
 ---
 
 import GearIcon from '@site/src/assets/gear.svg';

--- a/i18n/ja/docusaurus-plugin-content-docs/current/end-user-flows/organization-experience/README.mdx
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/end-user-flows/organization-experience/README.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 9
+sidebar_custom_props:
+  sublist_label: 組織フロー
 ---
 
 import GearIcon from '@site/src/assets/gear.svg';

--- a/i18n/ja/docusaurus-plugin-content-docs/current/end-user-flows/sign-up-and-sign-in/README.mdx
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/end-user-flows/sign-up-and-sign-in/README.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 1
+sidebar_custom_props:
+  sublist_label: 認証 (Authentication) フロー
 ---
 
 # サインアップとサインイン

--- a/i18n/pt-BR/docusaurus-plugin-content-docs/current/end-user-flows/account-settings/README.mdx
+++ b/i18n/pt-BR/docusaurus-plugin-content-docs/current/end-user-flows/account-settings/README.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 7
+sidebar_custom_props:
+  sublist_label: Fluxos de conta
 ---
 
 import GearIcon from '@site/src/assets/gear.svg';

--- a/i18n/pt-BR/docusaurus-plugin-content-docs/current/end-user-flows/organization-experience/README.mdx
+++ b/i18n/pt-BR/docusaurus-plugin-content-docs/current/end-user-flows/organization-experience/README.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 9
+sidebar_custom_props:
+  sublist_label: Fluxos de organização
 ---
 
 import GearIcon from '@site/src/assets/gear.svg';

--- a/i18n/pt-BR/docusaurus-plugin-content-docs/current/end-user-flows/sign-up-and-sign-in/README.mdx
+++ b/i18n/pt-BR/docusaurus-plugin-content-docs/current/end-user-flows/sign-up-and-sign-in/README.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 1
+sidebar_custom_props:
+  sublist_label: Fluxos de autenticação
 ---
 
 # Cadastro e login

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/end-user-flows/account-settings/README.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/end-user-flows/account-settings/README.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 7
+sidebar_custom_props:
+  sublist_label: 账户流程
 ---
 
 import GearIcon from '@site/src/assets/gear.svg';

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/end-user-flows/organization-experience/README.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/end-user-flows/organization-experience/README.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 9
+sidebar_custom_props:
+  sublist_label: 组织 (Organization) 流程
 ---
 
 import GearIcon from '@site/src/assets/gear.svg';

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/end-user-flows/sign-up-and-sign-in/README.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/end-user-flows/sign-up-and-sign-in/README.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 1
+sidebar_custom_props:
+  sublist_label: 认证 (Authentication) 流程
 ---
 
 # 注册和登录


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add i18n translations to the sublist labels in "End user flows" sidebar category.

<img width="298" alt="image" src="https://github.com/user-attachments/assets/1b949f15-371a-4f23-8893-ff303f72b254" />
