### PR TITLE
fix: page layout when code editor is presented

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -21,10 +21,16 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const cfPagesBranch = process.env.CF_PAGES_BRANCH;
 
+// https://community.cloudflare.com/t/algorithm-to-generate-a-preview-dns-subdomain-from-a-branch-name/477633/2
+const getCloudflareSubdomain = (branchName: string) =>
+  branchName
+    .replace(/[^a-z0-9-]/g, '-')
+    .substring(0, 28)
+    .replace(/^-|-$/, '');
+
 const getLogtoDocsUrl = () =>
   cfPagesBranch && cfPagesBranch !== 'master'
-    // https://community.cloudflare.com/t/algorithm-to-generate-a-preview-dns-subdomain-from-a-branch-name/477633/2
-    ? `https://${cfPagesBranch.substring(0, 28).replace(/[^a-z0-9-]/g, '-')}.logto-docs.pages.dev/`
+    ? `https://${getCloudflareSubdomain(cfPagesBranch)}.logto-docs.pages.dev/`
     : 'https://docs.logto.io/';
 
 const { dracula } = themes;

--- a/src/theme/CodeBlock/Content/styles.module.css
+++ b/src/theme/CodeBlock/Content/styles.module.css
@@ -35,7 +35,7 @@
   font: inherit;
   /* rtl:ignore */
   float: left;
-  min-width: 100%;
+  width: 100%;
   padding: var(--ifm-pre-padding);
 }
 

--- a/src/theme/DocItem/Layout/index.module.scss
+++ b/src/theme/DocItem/Layout/index.module.scss
@@ -17,11 +17,16 @@
 }
 
 .desktopToc {
-  flex: 0 0 276px;
+  display: none;
 }
 
-@media (max-width: 996px) {
+@media (min-width: 997px) {
   .desktopToc {
-    display: none;
+    display: block;
+    flex: 0 0 276px;
+  }
+
+  .main.hasDesktopToc {
+    max-width: min(1000px, calc(100vw - 680px));
   }
 }

--- a/src/theme/DocItem/Layout/index.tsx
+++ b/src/theme/DocItem/Layout/index.tsx
@@ -10,6 +10,7 @@ import DocItemTOCDesktop from '@theme/DocItem/TOC/Desktop';
 import DocItemTOCMobile from '@theme/DocItem/TOC/Mobile';
 import DocVersionBadge from '@theme/DocVersionBadge';
 import DocVersionBanner from '@theme/DocVersionBanner';
+import clsx from 'clsx';
 
 import styles from './index.module.scss';
 
@@ -38,25 +39,26 @@ function useDocTOC() {
 }
 
 export default function DocItemLayout({ children }: Props): JSX.Element {
-  const docTOC = useDocTOC();
+  const { hidden, mobile: mobileToc, desktop: desktopToc } = useDocTOC();
   const { metadata } = useDoc();
+  const hasDesktopToc = !hidden && !!desktopToc;
   return (
     <div className={styles.layout}>
-      <div className={styles.main}>
+      <div className={clsx(styles.main, hasDesktopToc && styles.hasDesktopToc)}>
         <ContentVisibility metadata={metadata} />
         <DocVersionBanner />
         <div className={styles.docItemContainer}>
           <article>
             <DocBreadcrumbs />
             <DocVersionBadge />
-            {docTOC.mobile}
+            {mobileToc}
             <DocItemContent>{children}</DocItemContent>
             <DocItemFooter />
           </article>
           <DocItemPaginator />
         </div>
       </div>
-      {docTOC.desktop && <div className={styles.desktopToc}>{docTOC.desktop}</div>}
+      {hasDesktopToc && <div className={styles.desktopToc}>{desktopToc}</div>}
     </div>
   );
 }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix a layout issue when code editor is presented in the docs.

As the code editor has `min-width: 100%`, it would take all the available horizontal space on the right side, pushing the right side TOC off the screen.

Therefore, we still need to limit the max-width of the `main` container element (which was removed by a previous PR).