### PR TITLE
fix: code editor styles in admonitions

### DIFF
--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -795,8 +795,14 @@ table {
     }
   }
 
-  code {
+  code:not(pre code) {
     background-color: var(--logto-container-neutral-bg);
+  }
+}
+
+html[data-theme='dark'] {
+  .alert pre code {
+    background-color: #181132;
   }
 }
 

--- a/src/theme/Admonition/Layout/styles.module.css
+++ b/src/theme/Admonition/Layout/styles.module.css
@@ -39,10 +39,10 @@
 
   > p:first-of-type {
     display: inline;
-  }
 
-  p + p {
-    margin-block: 1rem 0;
+    + * {
+      margin-block: 1rem;
+    }
   }
 
   .title {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix the styling issues for code block editors used inside admonition.

![image](https://github.com/user-attachments/assets/824fc151-8dc6-45a0-b8e5-89305d51fca3)
