### PR TITLE
fix: footer item style on mobile

### DIFF
--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -701,6 +701,10 @@ aside + main {
     margin-bottom: 0;
   }
 
+  .footer__link-item {
+    display: inline-flex;
+  }
+
   .footer__bottom {
     flex-direction: column;
     align-items: start;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Docusaurus will apply `display: block;` to footer items on smaller screen devices, which breaks the vertical center alignment of the icon and text. This PR fixes it by overriding it with `display: inline-flex;`.

Before:
<img width="297" alt="image" src="https://github.com/user-attachments/assets/3d4511ed-6668-48a7-93a5-34a1240ad36c" />

After:
<img width="278" alt="image" src="https://github.com/user-attachments/assets/f99f16ce-5230-401d-b0da-bd07b0d31067" />
