### PR TITLE
fix: add missing metadata to Go SDK guide

### DIFF
--- a/docs/quick-starts/framework/go/README.mdx
+++ b/docs/quick-starts/framework/go/README.mdx
@@ -6,6 +6,7 @@ sidebar_custom_props:
 language: go
 official_link: https://go.dev
 app_type: Traditional web
+framework: Go
 ---
 
 import ApiResourcesDescription from '../../fragments/_api-resources-description.md';

--- a/i18n/de/docusaurus-plugin-content-docs/current/quick-starts/framework/go/README.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/quick-starts/framework/go/README.mdx
@@ -6,6 +6,7 @@ sidebar_custom_props:
 language: go
 official_link: https://go.dev
 app_type: Traditionelle Webanwendung
+framework: Go
 ---
 
 import ApiResourcesDescription from '../../fragments/_api-resources-description.md';

--- a/i18n/es/docusaurus-plugin-content-docs/current/quick-starts/framework/go/README.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/current/quick-starts/framework/go/README.mdx
@@ -6,6 +6,7 @@ sidebar_custom_props:
 language: go
 official_link: https://go.dev
 app_type: Traditional web
+framework: Go
 ---
 
 import ApiResourcesDescription from '../../fragments/_api-resources-description.md';

--- a/i18n/fr/docusaurus-plugin-content-docs/current/quick-starts/framework/go/README.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/quick-starts/framework/go/README.mdx
@@ -6,6 +6,7 @@ sidebar_custom_props:
 language: go
 official_link: https://go.dev
 app_type: Traditional web
+framework: Go
 ---
 
 import ApiResourcesDescription from '../../fragments/_api-resources-description.md';

--- a/i18n/ja/docusaurus-plugin-content-docs/current/quick-starts/framework/go/README.mdx
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/quick-starts/framework/go/README.mdx
@@ -6,6 +6,7 @@ sidebar_custom_props:
 language: go
 official_link: https://go.dev
 app_type: Traditional web
+framework: Go
 ---
 
 import ApiResourcesDescription from '../../fragments/_api-resources-description.md';

--- a/i18n/pt-BR/docusaurus-plugin-content-docs/current/quick-starts/framework/go/README.mdx
+++ b/i18n/pt-BR/docusaurus-plugin-content-docs/current/quick-starts/framework/go/README.mdx
@@ -6,6 +6,7 @@ sidebar_custom_props:
 language: go
 official_link: https://go.dev
 app_type: Aplicação web tradicional
+framework: Go
 ---
 
 import ApiResourcesDescription from '../../fragments/_api-resources-description.md';

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/quick-starts/framework/go/README.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/quick-starts/framework/go/README.mdx
@@ -6,6 +6,7 @@ sidebar_custom_props:
 language: go
 official_link: https://go.dev
 app_type: 传统 Web
+framework: Go
 ---
 
 import ApiResourcesDescription from '../../fragments/_api-resources-description.md';


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add missing metadata for Go SDK guide, which is used for generating "Build X with Y" properties.
