### PR TITLE
fix: styles for code editor embedded in admonition

### DIFF
--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -809,7 +809,7 @@ table {
 }
 
 html[data-theme='dark'] {
-  .alert pre code {
+  .alert pre {
     background-color: #181132;
   }
 }

--- a/src/theme/Admonition/Layout/styles.module.css
+++ b/src/theme/Admonition/Layout/styles.module.css
@@ -36,6 +36,7 @@
 
 .content {
   display: inline-block;
+  width: 100%;
 
   > p:first-of-type {
     display: inline;

--- a/src/theme/CodeBlock/Content/String.tsx
+++ b/src/theme/CodeBlock/Content/String.tsx
@@ -68,13 +68,12 @@ export default function CodeBlockString({
       {title && <div className={styles.codeBlockTitle}>{title}</div>}
       <div className={styles.codeBlockContent}>
         <Highlight theme={prismTheme} code={code} language={language ?? 'text'}>
-          {({ className, style, tokens, getLineProps, getTokenProps }) => (
+          {({ className, tokens, getLineProps, getTokenProps }) => (
             <pre
               ref={wordWrap.codeBlockRef}
               // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
               tabIndex={0}
               className={clsx(className, styles.codeBlock, 'thin-scrollbar')}
-              style={style}
             >
               <code
                 className={clsx(

--- a/src/theme/CodeBlock/Content/styles.module.css
+++ b/src/theme/CodeBlock/Content/styles.module.css
@@ -3,6 +3,7 @@
   /* rtl:ignore */
   direction: ltr;
   border-radius: inherit;
+  width: 100%;
 }
 
 .codeBlockTitle {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix the styles for code editor that embedded in admonitions.

Before:
<img width="1127" alt="image" src="https://github.com/user-attachments/assets/7f1afc2e-7825-4d11-8914-765d0205ed79" />

After:
<img width="1046" alt="image" src="https://github.com/user-attachments/assets/746b36d3-8560-4f99-b2a1-cc2e2c61d250" />
