### PR TITLE
refactor: remove redundant sdk checkpoint sections from tutorials

### DIFF
--- a/docs/quick-starts/framework/dotnet-blazor-wasm/_for-tutorial.mdx
+++ b/docs/quick-starts/framework/dotnet-blazor-wasm/_for-tutorial.mdx
@@ -1,5 +1,3 @@
-import Checkpoint from '../../fragments/_checkpoint-test-your-application.md';
-
 import GuideTip from './_guide-tip.md';
 import Installation from './_installation.md';
 import Integration from './_integration.mdx';
@@ -11,5 +9,3 @@ import Integration from './_integration.mdx';
 <Installation />
 
 <Integration />
-
-<Checkpoint />

--- a/docs/quick-starts/framework/expo/_for-tutorial.mdx
+++ b/docs/quick-starts/framework/expo/_for-tutorial.mdx
@@ -1,5 +1,3 @@
-import Checkpoint from '../../fragments/_checkpoint-test-your-application.md';
-
 import GuideTip from './_guide-tip.md';
 import Installation from './_installation.mdx';
 import Integration from './_integration.mdx';
@@ -11,5 +9,3 @@ import Integration from './_integration.mdx';
 <Installation />
 
 <Integration />
-
-<Checkpoint />

--- a/docs/quick-starts/framework/next/_for-tutorial.mdx
+++ b/docs/quick-starts/framework/next/_for-tutorial.mdx
@@ -1,5 +1,3 @@
-import Checkpoint from '../../fragments/_checkpoint-test-your-application.md';
-
 import GuideTip from './_guide-tip.mdx';
 import Installation from './_installation.mdx';
 import Integration from './_integration.mdx';
@@ -13,5 +11,3 @@ import Integration from './_integration.mdx';
 ### Integration \{#integration}
 
 <Integration />
-
-<Checkpoint />

--- a/i18n/de/docusaurus-plugin-content-docs/current/quick-starts/framework/dotnet-blazor-wasm/_for-tutorial.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/quick-starts/framework/dotnet-blazor-wasm/_for-tutorial.mdx
@@ -1,5 +1,3 @@
-import Checkpoint from '../../fragments/_checkpoint-test-your-application.md';
-
 import GuideTip from './_guide-tip.md';
 import Installation from './_installation.md';
 import Integration from './_integration.mdx';
@@ -11,5 +9,3 @@ import Integration from './_integration.mdx';
 <Installation />
 
 <Integration />
-
-<Checkpoint />

--- a/i18n/de/docusaurus-plugin-content-docs/current/quick-starts/framework/expo/_for-tutorial.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/quick-starts/framework/expo/_for-tutorial.mdx
@@ -1,5 +1,3 @@
-import Checkpoint from '../../fragments/_checkpoint-test-your-application.md';
-
 import GuideTip from './_guide-tip.md';
 import Installation from './_installation.mdx';
 import Integration from './_integration.mdx';
@@ -11,5 +9,3 @@ import Integration from './_integration.mdx';
 <Installation />
 
 <Integration />
-
-<Checkpoint />

--- a/i18n/de/docusaurus-plugin-content-docs/current/quick-starts/framework/next/_for-tutorial.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/quick-starts/framework/next/_for-tutorial.mdx
@@ -1,5 +1,3 @@
-import Checkpoint from '../../fragments/_checkpoint-test-your-application.md';
-
 import GuideTip from './_guide-tip.mdx';
 import Installation from './_installation.mdx';
 import Integration from './_integration.mdx';
@@ -13,5 +11,3 @@ import Integration from './_integration.mdx';
 ### Integration \{#integration}
 
 <Integration />
-
-<Checkpoint />

--- a/i18n/es/docusaurus-plugin-content-docs/current/quick-starts/framework/dotnet-blazor-wasm/_for-tutorial.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/current/quick-starts/framework/dotnet-blazor-wasm/_for-tutorial.mdx
@@ -1,5 +1,3 @@
-import Checkpoint from '../../fragments/_checkpoint-test-your-application.md';
-
 import GuideTip from './_guide-tip.md';
 import Installation from './_installation.md';
 import Integration from './_integration.mdx';
@@ -11,5 +9,3 @@ import Integration from './_integration.mdx';
 <Installation />
 
 <Integration />
-
-<Checkpoint />

--- a/i18n/es/docusaurus-plugin-content-docs/current/quick-starts/framework/expo/_for-tutorial.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/current/quick-starts/framework/expo/_for-tutorial.mdx
@@ -1,5 +1,3 @@
-import Checkpoint from '../../fragments/_checkpoint-test-your-application.md';
-
 import GuideTip from './_guide-tip.md';
 import Installation from './_installation.mdx';
 import Integration from './_integration.mdx';
@@ -11,5 +9,3 @@ import Integration from './_integration.mdx';
 <Installation />
 
 <Integration />
-
-<Checkpoint />

--- a/i18n/es/docusaurus-plugin-content-docs/current/quick-starts/framework/next/_for-tutorial.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/current/quick-starts/framework/next/_for-tutorial.mdx
@@ -1,5 +1,3 @@
-import Checkpoint from '../../fragments/_checkpoint-test-your-application.md';
-
 import GuideTip from './_guide-tip.mdx';
 import Installation from './_installation.mdx';
 import Integration from './_integration.mdx';
@@ -13,5 +11,3 @@ import Integration from './_integration.mdx';
 ### Integración \{#integration}
 
 <Integration />
-
-<Checkpoint />

--- a/i18n/fr/docusaurus-plugin-content-docs/current/quick-starts/framework/dotnet-blazor-wasm/_for-tutorial.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/quick-starts/framework/dotnet-blazor-wasm/_for-tutorial.mdx
@@ -1,5 +1,3 @@
-import Checkpoint from '../../fragments/_checkpoint-test-your-application.md';
-
 import GuideTip from './_guide-tip.md';
 import Installation from './_installation.md';
 import Integration from './_integration.mdx';
@@ -11,5 +9,3 @@ import Integration from './_integration.mdx';
 <Installation />
 
 <Integration />
-
-<Checkpoint />

--- a/i18n/fr/docusaurus-plugin-content-docs/current/quick-starts/framework/expo/_for-tutorial.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/quick-starts/framework/expo/_for-tutorial.mdx
@@ -1,5 +1,3 @@
-import Checkpoint from '../../fragments/_checkpoint-test-your-application.md';
-
 import GuideTip from './_guide-tip.md';
 import Installation from './_installation.mdx';
 import Integration from './_integration.mdx';
@@ -11,5 +9,3 @@ import Integration from './_integration.mdx';
 <Installation />
 
 <Integration />
-
-<Checkpoint />

--- a/i18n/fr/docusaurus-plugin-content-docs/current/quick-starts/framework/next/_for-tutorial.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/quick-starts/framework/next/_for-tutorial.mdx
@@ -1,5 +1,3 @@
-import Checkpoint from '../../fragments/_checkpoint-test-your-application.md';
-
 import GuideTip from './_guide-tip.mdx';
 import Installation from './_installation.mdx';
 import Integration from './_integration.mdx';
@@ -13,5 +11,3 @@ import Integration from './_integration.mdx';
 ### Intégration \{#integration}
 
 <Integration />
-
-<Checkpoint />

--- a/i18n/ja/docusaurus-plugin-content-docs/current/quick-starts/framework/dotnet-blazor-wasm/_for-tutorial.mdx
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/quick-starts/framework/dotnet-blazor-wasm/_for-tutorial.mdx
@@ -1,5 +1,3 @@
-import Checkpoint from '../../fragments/_checkpoint-test-your-application.md';
-
 import GuideTip from './_guide-tip.md';
 import Installation from './_installation.md';
 import Integration from './_integration.mdx';
@@ -11,5 +9,3 @@ import Integration from './_integration.mdx';
 <Installation />
 
 <Integration />
-
-<Checkpoint />

--- a/i18n/ja/docusaurus-plugin-content-docs/current/quick-starts/framework/expo/_for-tutorial.mdx
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/quick-starts/framework/expo/_for-tutorial.mdx
@@ -1,5 +1,3 @@
-import Checkpoint from '../../fragments/_checkpoint-test-your-application.md';
-
 import GuideTip from './_guide-tip.md';
 import Installation from './_installation.mdx';
 import Integration from './_integration.mdx';
@@ -11,5 +9,3 @@ import Integration from './_integration.mdx';
 <Installation />
 
 <Integration />
-
-<Checkpoint />

--- a/i18n/ja/docusaurus-plugin-content-docs/current/quick-starts/framework/next/_for-tutorial.mdx
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/quick-starts/framework/next/_for-tutorial.mdx
@@ -1,5 +1,3 @@
-import Checkpoint from '../../fragments/_checkpoint-test-your-application.md';
-
 import GuideTip from './_guide-tip.mdx';
 import Installation from './_installation.mdx';
 import Integration from './_integration.mdx';
@@ -13,5 +11,3 @@ import Integration from './_integration.mdx';
 ### 統合 \{#integration}
 
 <Integration />
-
-<Checkpoint />

--- a/i18n/pt-BR/docusaurus-plugin-content-docs/current/quick-starts/framework/dotnet-blazor-wasm/_for-tutorial.mdx
+++ b/i18n/pt-BR/docusaurus-plugin-content-docs/current/quick-starts/framework/dotnet-blazor-wasm/_for-tutorial.mdx
@@ -1,5 +1,3 @@
-import Checkpoint from '../../fragments/_checkpoint-test-your-application.md';
-
 import GuideTip from './_guide-tip.md';
 import Installation from './_installation.md';
 import Integration from './_integration.mdx';
@@ -11,5 +9,3 @@ import Integration from './_integration.mdx';
 <Installation />
 
 <Integration />
-
-<Checkpoint />

--- a/i18n/pt-BR/docusaurus-plugin-content-docs/current/quick-starts/framework/expo/_for-tutorial.mdx
+++ b/i18n/pt-BR/docusaurus-plugin-content-docs/current/quick-starts/framework/expo/_for-tutorial.mdx
@@ -1,5 +1,3 @@
-import Checkpoint from '../../fragments/_checkpoint-test-your-application.md';
-
 import GuideTip from './_guide-tip.md';
 import Installation from './_installation.mdx';
 import Integration from './_integration.mdx';
@@ -11,5 +9,3 @@ import Integration from './_integration.mdx';
 <Installation />
 
 <Integration />
-
-<Checkpoint />

--- a/i18n/pt-BR/docusaurus-plugin-content-docs/current/quick-starts/framework/next/_for-tutorial.mdx
+++ b/i18n/pt-BR/docusaurus-plugin-content-docs/current/quick-starts/framework/next/_for-tutorial.mdx
@@ -1,5 +1,3 @@
-import Checkpoint from '../../fragments/_checkpoint-test-your-application.md';
-
 import GuideTip from './_guide-tip.mdx';
 import Installation from './_installation.mdx';
 import Integration from './_integration.mdx';
@@ -13,5 +11,3 @@ import Integration from './_integration.mdx';
 ### Integração \{#integration}
 
 <Integration />
-
-<Checkpoint />

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/quick-starts/framework/dotnet-blazor-wasm/_for-tutorial.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/quick-starts/framework/dotnet-blazor-wasm/_for-tutorial.mdx
@@ -1,5 +1,3 @@
-import Checkpoint from '../../fragments/_checkpoint-test-your-application.md';
-
 import GuideTip from './_guide-tip.md';
 import Installation from './_installation.md';
 import Integration from './_integration.mdx';
@@ -11,5 +9,3 @@ import Integration from './_integration.mdx';
 <Installation />
 
 <Integration />
-
-<Checkpoint />

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/quick-starts/framework/expo/_for-tutorial.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/quick-starts/framework/expo/_for-tutorial.mdx
@@ -1,5 +1,3 @@
-import Checkpoint from '../../fragments/_checkpoint-test-your-application.md';
-
 import GuideTip from './_guide-tip.md';
 import Installation from './_installation.mdx';
 import Integration from './_integration.mdx';
@@ -11,5 +9,3 @@ import Integration from './_integration.mdx';
 <Installation />
 
 <Integration />
-
-<Checkpoint />

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/quick-starts/framework/next/_for-tutorial.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/quick-starts/framework/next/_for-tutorial.mdx
@@ -1,5 +1,3 @@
-import Checkpoint from '../../fragments/_checkpoint-test-your-application.md';
-
 import GuideTip from './_guide-tip.mdx';
 import Installation from './_installation.mdx';
 import Integration from './_integration.mdx';
@@ -13,5 +11,3 @@ import Integration from './_integration.mdx';
 ### 集成 \{#integration}
 
 <Integration />
-
-<Checkpoint />


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Remove redundant SDK checkpoint sections from tutorials, as the previous `<Integration />` section already included the checkpoint section.
