### PR TITLE
fix: keep svg viewbox and fix tutorial layout styles

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -180,7 +180,15 @@ const config: Config = {
         svgr: {
           svgrConfig: {
             svgoConfig: {
-              plugins: ['preset-default', 'prefixIds'],
+              plugins: [
+                {
+                  name: 'preset-default',
+                  params: {
+                    overrides: { removeViewBox: false },
+                  },
+                },
+                'prefixIds',
+              ],
             },
           },
         },

--- a/src/theme/BlogLayout/index.module.scss
+++ b/src/theme/BlogLayout/index.module.scss
@@ -13,7 +13,6 @@
       display: flex;
       flex-direction: column;
       gap: 24px;
-      overflow: hidden;
       margin-bottom: 50px;
     }
 
@@ -24,6 +23,10 @@
 
   &.hasToc {
     max-width: 1200px;
+
+    .main {
+      max-width: min(900px, calc(100vw - 324px));
+    }
   }
 }
 
@@ -33,6 +36,10 @@
 
     &.hasToc {
       max-width: 100vw;
+
+      .main {
+        max-width: 100%;
+      }
     }
 
     .row .toc {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- Keep SVG viewbox property in order to maintain the original width and height of the SVGs
- Fix the layout styles in the tutorial details page (Docusaurus blog layout)
