### PR TITLE
fix: typo in next app router integration guide

### DIFF
--- a/docs/quick-starts/framework/next-app-router/_integration.mdx
+++ b/docs/quick-starts/framework/next-app-router/_integration.mdx
@@ -106,7 +106,7 @@ Remember to add `'use client'` to the top of the file to indicate that these com
 
 <ServerActionsTip />
 
-Now let's add the sign-in and sign-out buttons in your hoem page. We need to call the server actions in SDK when needed. To help with this, use `getLogtoContext` to fetch authentication status.
+Now let's add the sign-in and sign-out buttons in your home page. We need to call the server actions in SDK when needed. To help with this, use `getLogtoContext` to fetch authentication status.
 
 ```tsx title="app/page.tsx"
 import { getLogtoContext, signIn, signOut } from '@logto/next/server-actions';


### PR DESCRIPTION
Typo fix

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Typo fix. Fixed spelling of the word "home".
