### PR TITLE
refactor: disable tutorial generation for unsupported locales

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -9,8 +9,12 @@ import remarkMath from 'remark-math';
 
 import ogImageGenerator from './plugins/og-image-generator';
 import tutorialGenerator from './plugins/tutorial-generator';
+import { cond } from '@silverhand/essentials';
 
 const defaultLocale = 'en';
+
+// Supported locales for the "Build X with Y" tutorials
+const tutorialLocales = ['en', 'es', 'fr', 'ja'];
 
 // A workaround for locale-specific values in the config
 // https://github.com/facebook/docusaurus/issues/4542#issuecomment-1434839071
@@ -343,7 +347,7 @@ const config: Config = {
     'docusaurus-plugin-sass',
     tutorialGenerator,
     ogImageGenerator,
-    [
+    cond(tutorialLocales.includes(currentLocale) && [
       '@docusaurus/plugin-content-blog',
       {
         /**
@@ -363,7 +367,7 @@ const config: Config = {
         showReadingTime: false,
         postsPerPage: 'ALL',
       },
-    ],
+    ]),
     [
       '@docusaurus/plugin-content-blog',
       {
@@ -386,7 +390,7 @@ const config: Config = {
         feedOptions: {},
       },
     ],
-  ],
+  ].filter(Boolean),
   themes: ['@docusaurus/theme-mermaid'],
 };
 

--- a/static/_redirects
+++ b/static/_redirects
@@ -274,3 +274,21 @@
 # See https://developers.cloudflare.com/pages/configuration/redirects/#per-file
 /docs/* / 301
 /blog/* https://blog.logto.io/:splat 301
+
+# Supported locales for "Build X with Y" tutorials: en, es, fr, and ja.
+# Redirect other locales (de, ko, pt-BR, zh-CN, zh-TW) to the default en tutorial.
+/de/tutorial /tutorial 301
+/de/tutorial/ /tutorial 301
+/de/tutorial/* /tutorial/:splat 301
+/ko/tutorial /tutorial 301
+/ko/tutorial/ /tutorial 301
+/ko/tutorial/* /tutorial/:splat 301
+/pt-BR/tutorial /tutorial 301
+/pt-BR/tutorial/ /tutorial 301
+/pt-BR/tutorial/* /tutorial/:splat 301
+/zh-CN/tutorial /tutorial 301
+/zh-CN/tutorial/ /tutorial 301
+/zh-CN/tutorial/* /tutorial/:splat 301
+/zh-TW/tutorial /tutorial 301
+/zh-TW/tutorial/ /tutorial 301
+/zh-TW/tutorial/* /tutorial/:splat 301


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Disable "Build X with Y" tutorial generation for unsupported locales: `de, ko, pt-BR, zh-CN, zh-TW`.

This config change will completely disable the "blog" plugin for tutorial generations for the locales above, freeing up about **"7k"** files in the production build folder.