### PR TITLE
chore: remove outdated translation detection from main workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,22 +41,3 @@ jobs:
 
       - name: Lint
         run: pnpm lint
-
-  main-check:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node and pnpm
-        uses: silverhand-io/actions-node-pnpm-run-steps@v5
-
-      - name: Check if there are outdated translations
-        run: |
-          node translate.mjs --locale de --all --check
-          node translate.mjs --locale es --all --check
-          node translate.mjs --locale fr --all --check
-          node translate.mjs --locale pt-BR --all --check
-          node translate.mjs --locale zh-CN --all --check
-          
-          


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Remove "outdated translation" detection from the main GitHub action workflow, since we now have a new workflow to automate the process.
