### PR TITLE
fix: content generation workflow concurrency group

### DIFF
--- a/.github/workflows/content-generation.yml
+++ b/.github/workflows/content-generation.yml
@@ -6,7 +6,7 @@ on:
       - master
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Change the "content generation" CI workflow concunrrency group to repository level, in order to make it cancellable when a new commit comes into master branch.
