### PR TITLE
fix: check if previous CI steps has made file changes before submitting PR

### DIFF
--- a/.github/workflows/content-generation.yml
+++ b/.github/workflows/content-generation.yml
@@ -6,7 +6,7 @@ on:
       - master
 
 concurrency:
-  group: ${{ github.workflow }}
+  group: content-generation-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -52,8 +52,19 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Check Git status to determine if the PR is needed
+        id: check-changes
+        run: |
+          git add .
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "HAS_CHANGES=true" >> $GITHUB_OUTPUT
+          else
+            echo "HAS_CHANGES=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Create pull request
         uses: peter-evans/create-pull-request@v6
+        if: steps.check-changes.outputs.HAS_CHANGES == 'true'
         with:
           token: ${{ secrets.BOT_PAT }}
           branch: master


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
- In the "Content generation" action workflow, check if the previous steps have made file changes before submitting a PR.
- Also unified the concurrency group name pattern with the other workflows.
