### PR TITLE
fix: wrong branch name used in content generation workflow

### DIFF
--- a/.github/workflows/content-generation.yml
+++ b/.github/workflows/content-generation.yml
@@ -1,5 +1,8 @@
 name: Content generation
 
+env:
+  CONTENT_GENERATION_BRANCH_NAME: bot-generate-doc-contents
+
 on:
   push:
     branches:
@@ -67,7 +70,7 @@ jobs:
         if: steps.check-changes.outputs.HAS_CHANGES == 'true'
         with:
           token: ${{ secrets.BOT_PAT }}
-          branch: master
+          branch: ${{ env.CONTENT_GENERATION_BRANCH_NAME }}
           committer: silverhand-bot <bot@silverhand.io>
           title: "chore: update translations and generated content"
           commit-message: "chore: update translations and generated content"

--- a/.github/workflows/content-generation.yml
+++ b/.github/workflows/content-generation.yml
@@ -59,6 +59,7 @@ jobs:
         id: check-changes
         run: |
           git add .
+          git status --porcelain
           if [[ -n "$(git status --porcelain)" ]]; then
             echo "HAS_CHANGES=true" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix the wrongly configured branch name in the "submit PR" step in "content generation" workflow
