### PR TITLE
chore: update twitter tutorial name to remove parenthesis from generated tutorial slugs

### DIFF
--- a/docs/integrations/social/x/README.mdx
+++ b/docs/integrations/social/x/README.mdx
@@ -3,7 +3,7 @@ slug: /integrations/x
 sidebar_label: X (Twitter)
 sidebar_custom_props:
   description: X is a social media platform that allows you to connect with friends and family.
-tutorial_name: X (Twitter)
+tutorial_name: x-twitter
 tutorial_config_name: X OAuth app
 ---
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Update Twitter guide `tutorial_name` to remove the parenthesis from generated tutorial slugs
