### PR TITLE
fix: move translate before write heading ID in workflow

### DIFF
--- a/.github/workflows/content-generation.yml
+++ b/.github/workflows/content-generation.yml
@@ -40,10 +40,6 @@ jobs:
           git config --global user.email bot@silverhand.io
           git config --global user.name silverhand-bot
 
-      - name: Write heading IDs
-        run: |
-          node write-heading-ids.mjs
-
       - name: Translate documentations
         env:
           OPENAI_ORG_ID: ${{ secrets.OPENAI_ORG_ID }}
@@ -51,6 +47,10 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           node translate.mjs --sync --all --silent
+
+      - name: Write heading IDs
+        run: |
+          node write-heading-ids.mjs
       
       - name: Build
         run: pnpm build


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Move `translate` before `write-heading-ids`, in order to make sure that newly created i18n translation files can also have heading IDs synced with EN version.
