### PR TITLE
refactor: force sync heading IDs of i18n translation with EN docs

### DIFF
--- a/write-heading-ids.mjs
+++ b/write-heading-ids.mjs
@@ -114,10 +114,10 @@ async function updateTranslations(translationDocPath, sourceDocHeadingIds) {
         continue;
       }
 
-      const [_full, hashes, text, existingIdMark] = match;
+      const [_full, hashes, text, existingIdMark, existingId] = match;
+      const headingId = sourceDocHeadingIds[idIndex];
 
-      if (!existingIdMark) {
-        const headingId = sourceDocHeadingIds[idIndex];
+      if (!existingIdMark || existingId !== headingId) {
         const idStr = ext === '.mdx' ? `\\{#${headingId}}` : `{#${headingId}}`;
         lines[i] = `${hashes} ${text} ${idStr}`;
         modified = true;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Force sync heading IDs in the i18n translations with the original English version docs
