### PR TITLE
refactor: reduce running time of mandatory CI checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,9 @@ concurrency:
 
 jobs:
   main-build:
+    strategy:
+      matrix:
+        locale: [en, de, es, fr, ja, ko, pt-BR, zh-CN, zh-TW]
     runs-on: ubuntu-latest
 
     steps:
@@ -21,14 +24,15 @@ jobs:
         uses: silverhand-io/actions-node-pnpm-run-steps@v5
 
       - name: Build
-        run: pnpm build
+        run: |
+          pnpm build --locale ${{ matrix.locale }}
 
       - name: Test redirects
+        if: ${{ matrix.locale == 'en' }}
         run: |
           pnpm serve &
           sleep 3
           node test-redirects.mjs
-
 
   main-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Use matrix strategy split up the building of i18n builds, in order to speedup the overall running time of the mandatory CI checks in docs.

Currently the average building time is around 30 minutes for 9 locales. After the optimization, it is expected to be around 3-4 minutes.