### PR TITLE
fix: update regex matching rules in write-heading-ids script

### DIFF
--- a/write-heading-ids.mjs
+++ b/write-heading-ids.mjs
@@ -83,7 +83,7 @@ async function processFile(filePath) {
 
     const newId = generateHeadingId(text);
     const idStr = ext === '.mdx' ? `\\{#${newId}}` : `{#${newId}}`;
-    lines[i] = `${hashes} ${text} ${idStr}`;
+    lines[i] = `${hashes} ${text.replace(' \\', '')} ${idStr}`;
     generatedIds.push(newId);
     modified = true;
   }
@@ -119,7 +119,7 @@ async function updateTranslations(translationDocPath, sourceDocHeadingIds) {
 
       if (!existingIdMark || existingId !== headingId) {
         const idStr = ext === '.mdx' ? `\\{#${headingId}}` : `{#${headingId}}`;
-        lines[i] = `${hashes} ${text} ${idStr}`;
+        lines[i] = `${hashes} ${text.replace(' \\', '')} ${idStr}`;
         modified = true;
       }
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Update `write-heading-ids.mjs` script to handle a potential unexpected backslash in the regex matching group
