### PR TITLE
fix: incorrect heading ids generated by an older version of script

### DIFF
--- a/i18n/de/docusaurus-plugin-content-docs/current/integrations/social/linkedin/README.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/integrations/social/linkedin/README.mdx
@@ -23,7 +23,7 @@ Der LinkedIn Connector ermöglicht Endbenutzern, sich mit ihren eigenen LinkedIn
 
 <Integration />
 
-## X (Twitter) Connector testen \ \{#test-linkedin-connector}
+## X (Twitter) Connector testen \{#test-linkedin-connector}
 
 Das war's. Der X (Twitter) Connector sollte jetzt verfügbar sein. Vergiss nicht, [Sozialen Connector in der Anmeldeerfahrung aktivieren](/connectors/social-connectors/#enable-social-sign-in).
 

--- a/i18n/es/docusaurus-plugin-content-docs/current/integrations/social/linkedin/README.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/current/integrations/social/linkedin/README.mdx
@@ -23,7 +23,7 @@ El conector de LinkedIn permite a los usuarios finales iniciar sesión en tu apl
 
 <Integration />
 
-## Probar el conector X (Twitter) \ \{#test-linkedin-connector}
+## Probar el conector X (Twitter) \{#test-linkedin-connector}
 
 Eso es todo. El conector X (Twitter) debería estar disponible ahora. No olvides [habilitar el conector social en la experiencia de inicio de sesión](/connectors/social-connectors/#enable-social-sign-in).
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/social/linkedin/README.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/social/linkedin/README.mdx
@@ -23,7 +23,7 @@ Le connecteur LinkedIn permet aux utilisateurs finaux de se connecter à votre a
 
 <Integration />
 
-## Tester le connecteur X (Twitter) \ \{#test-linkedin-connector}
+## Tester le connecteur X (Twitter) \{#test-linkedin-connector}
 
 C'est tout. Le connecteur X (Twitter) devrait être disponible maintenant. N'oubliez pas de [Activer le connecteur social dans l'expérience de connexion](/connectors/social-connectors/#enable-social-sign-in).
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/integrations/social/linkedin/README.mdx
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/integrations/social/linkedin/README.mdx
@@ -23,7 +23,7 @@ LinkedIn コネクターを使用すると、エンドユーザーは LinkedIn O
 
 <Integration />
 
-## X (Twitter) コネクターのテスト \ \{#test-linkedin-connector}
+## X (Twitter) コネクターのテスト \{#test-linkedin-connector}
 
 これで完了です。X (Twitter) コネクターが利用可能になりました。[サインイン体験でソーシャルコネクターを有効にする](/connectors/social-connectors/#enable-social-sign-in) のを忘れないでください。
 

--- a/i18n/ko/docusaurus-plugin-content-docs/current/integrations/social/linkedin/README.mdx
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/integrations/social/linkedin/README.mdx
@@ -23,7 +23,7 @@ LinkedIn 커넥터는 최종 사용자가 LinkedIn OAuth 2.0 인증 프로토콜
 
 <Integration />
 
-## X (Twitter) 커넥터 테스트 \ \{#test-linkedin-connector}
+## X (Twitter) 커넥터 테스트 \{#test-linkedin-connector}
 
 이제 완료되었습니다. X (Twitter) 커넥터가 이제 사용 가능해야 합니다. [로그인 경험에서 소셜 커넥터 활성화](/connectors/social-connectors/#enable-social-sign-in)를 잊지 마세요.
 

--- a/i18n/pt-BR/docusaurus-plugin-content-docs/current/integrations/social/linkedin/README.mdx
+++ b/i18n/pt-BR/docusaurus-plugin-content-docs/current/integrations/social/linkedin/README.mdx
@@ -23,7 +23,7 @@ O conector LinkedIn permite que os usuários finais façam login no seu aplicati
 
 <Integration />
 
-## Testar conector X (Twitter) \ \{#test-linkedin-connector}
+## Testar conector X (Twitter) \{#test-linkedin-connector}
 
 É isso. O conector X (Twitter) deve estar disponível agora. Não se esqueça de [Habilitar conector social na experiência de login](/connectors/social-connectors/#enable-social-sign-in).
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/integrations/social/feishu-web/README.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/integrations/social/feishu-web/README.mdx
@@ -14,7 +14,7 @@ import GuideTip from '../../fragments/_guide-tip.mdx';
 
 <GuideTip />
 
-## 开始上手配置飞书登录 \ \{#getting-started-with-feishu-social-sign-in}
+## 开始上手配置飞书登录 \{#getting-started-with-feishu-social-sign-in}
 
 飞书连接器是为桌面网页应用设计的。它采用了 OAuth 2.0 认证流程。
 

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/integrations/social/linkedin/README.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/integrations/social/linkedin/README.mdx
@@ -23,7 +23,7 @@ LinkedIn 连接器使终端用户能够通过 LinkedIn OAuth 2.0 认证 (Authent
 
 <Integration />
 
-## 测试 X (Twitter) 连接器 \ \{#test-linkedin-connector}
+## 测试 X (Twitter) 连接器 \{#test-linkedin-connector}
 
 就是这样。X (Twitter) 连接器现在应该可用了。别忘了[在登录体验中启用社交连接器](/connectors/social-connectors/#enable-social-sign-in)。
 

--- a/i18n/zh-TW/docusaurus-plugin-content-docs/current/integrations/social/linkedin/README.mdx
+++ b/i18n/zh-TW/docusaurus-plugin-content-docs/current/integrations/social/linkedin/README.mdx
@@ -23,7 +23,7 @@ LinkedIn 連接器讓終端使用者可以透過 LinkedIn OAuth 2.0 驗證協議
 
 <Integration />
 
-## 測試 X (Twitter) 連接器 \ \{#test-linkedin-connector}
+## 測試 X (Twitter) 連接器 \{#test-linkedin-connector}
 
 就是這樣。X (Twitter) 連接器現在應該可用了。別忘了 [在登入體驗中啟用社交連接器](/connectors/social-connectors/#enable-social-sign-in)。
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Find and replace some incorrect heading IDs generated by the older version of `write-heading-ids.mjs` script. The new version script has addressed this issue (#1038).
