### PR TITLE
fix: align the naming convention of experience app

### DIFF
--- a/docs/end-user-flows/sign-up-and-sign-in/README.mdx
+++ b/docs/end-user-flows/sign-up-and-sign-in/README.mdx
@@ -18,7 +18,7 @@ sequenceDiagram
   participant client as Client app
 
   box Logto
-    participant experience as Sign-in experience app
+    participant experience as experience app
     participant oidc as OIDC provider
   end
 


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
align the naming convention of the experience app

