### PR TITLE
fix: git file timestamp comparison

### DIFF
--- a/translate.shared.mjs
+++ b/translate.shared.mjs
@@ -59,11 +59,11 @@ export const filterFiles = async (files, locale, sync, check) => {
     files.map(async (file) => {
       const targetFile = file.replace(docsBaseDir, path.join(i18nBaseDir, locale, translateDir));
       const [sourceTimestamp, targetTimestamp] = await Promise.all([
-        execa`git log -1 --format=%cd --date=iso-local -- ${file}`,
-        execa`git log -1 --format=%cd --date=iso-local -- ${targetFile}`,
+        execa`git log -1 --format=%cd --date=unix -- ${file}`,
+        execa`git log -1 --format=%cd --date=unix -- ${targetFile}`,
       ]);
 
-      return sourceTimestamp.stdout > targetTimestamp.stdout ? file : null;
+      return Number(sourceTimestamp.stdout) > Number(targetTimestamp.stdout) ? file : null;
     })
   );
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Change the Git file datetime format to unix timestamp, in order to fix unstable comparison results in the CI workflow.

Previously the output format is like: `2024-12-17 08:26:38 +0000`, and the string comparison might not be stable.
