### PR TITLE
fix: git history comparison in translate script

### DIFF
--- a/.github/workflows/content-generation.yml
+++ b/.github/workflows/content-generation.yml
@@ -20,6 +20,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.BOT_PAT }}
+          ref: master
+          fetch-depth: 0
 
       - name: Setup Node and pnpm
         uses: silverhand-io/actions-node-pnpm-run-steps@v5

--- a/translate.shared.mjs
+++ b/translate.shared.mjs
@@ -63,11 +63,7 @@ export const filterFiles = async (files, locale, sync, check) => {
         execa`git log -1 --format=%cd --date=unix -- ${targetFile}`,
       ]);
 
-      const sourceDate = Number(sourceTimestamp.stdout);
-      const targetDate = Number(targetTimestamp.stdout);
-      log(`${file}: ${sourceDate} - ${targetDate}`);
-
-      return Number(sourceDate) > Number(targetDate) ? file : null;
+      return sourceTimestamp.stdout > targetTimestamp.stdout ? file : null;
     })
   );
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix the issue that when translating files in CI environment, the script fails to detect the correct target files by comparing the git commit history.

The issue is caused by the default shallow fetch behavior of the `actions/checkout` plugin. Therefore, the commit history are all set to the current system timestamp, instead of the real file commit timestamps.

This PR fixes the issue by setting `fetch-depth=0` so that the full commit history can be fetched.
