### PR TITLE
refactor: continue the content generation workflow on error

### DIFF
--- a/.github/workflows/content-generation.yml
+++ b/.github/workflows/content-generation.yml
@@ -49,16 +49,20 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           node translate.mjs --sync --all --silent
+        continue-on-error: true
 
       - name: Write heading IDs
         run: |
           node write-heading-ids.mjs
+        continue-on-error: true
       
       - name: Build
         run: pnpm build
+        continue-on-error: true
 
       - name: Lint with autofix
         run: pnpm lint --fix
+        continue-on-error: true
 
       - name: Check Git status to determine if the PR is needed
         id: check-changes


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
We should continue the "content generation" workflow on error, so that even if the AI generated translation is problematic on "build" or "lint" process later on, we can still collect the intermediate file changes and create the PR regardless.

Then we can manually fix the trivial issues ourselves without needing to re-run the whole process, since most of the translation results would be good. By doing this, we can actualy saving unnecessary extra AI token costs.
