### PR TITLE
fix: top navbar should be rendered in docs pages

### DIFF
--- a/terms/custom.scss
+++ b/terms/custom.scss
@@ -1,8 +1,12 @@
-nav.navbar,
-footer {
-  display: none;
-}
+// The '@docusaurus/plugin-content-blog' plugin id terms is set in docusaurus.config.js
 
-header time::before {
-  content: 'Effective date: ';
+.plugin-id-terms {
+  nav.navbar,
+  footer {
+    display: none;
+  }
+
+  header time::before {
+    content: 'Effective date: ';
+  }
 }

--- a/terms/custom.scss
+++ b/terms/custom.scss
@@ -1,5 +1,10 @@
-// The '@docusaurus/plugin-content-blog' plugin id terms is set in docusaurus.config.js
-
+/**
+ * The '@docusaurus/plugin-content-blog' plugin id `terms` is set in docusaurus.config.ts
+ * 
+ * This classname is added to the root element of the html when rendering the terms blog page.
+ * We use this to distinguish the terms page from other docs pages. And we only hide the
+ * docusaurus navbar and footer on the terms page, and show a custom topbar instead.
+ */
 .plugin-id-terms {
   nav.navbar,
   footer {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
The top navbar is missing in all docs pages, which was caused by a CSS pollution in the blog custom css file.
