### PR TITLE
docs: replace patch requests with post for verification-code routes

### DIFF
--- a/docs/end-user-flows/account-settings/by-account-api.mdx
+++ b/docs/end-user-flows/account-settings/by-account-api.mdx
@@ -175,7 +175,7 @@ The response body would be like:
 Upon receiving the verification code, you can use it to update the verification status of the verification record.
 
 ```bash
-curl -X PATCH https://[tenant-id].logto.app/api/verifications/verification-code/verify \
+curl -X POST https://[tenant-id].logto.app/api/verifications/verification-code/verify \
   -H 'authorization: Bearer <access_token>' \
   -H 'content-type: application/json' \
   --data-raw '{"identifier":{"type":"email","value":"..."},"verificationId":"...","code":"123456"}'
@@ -207,7 +207,7 @@ curl -X POST https://[tenant-id].logto.app/api/verifications/verification-code \
 You will find a `verificationId` in the response, and receive a verification code in the email, use it to verify the email.
 
 ```bash
-curl -X PATCH https://[tenant-id].logto.app/api/verifications/verification-code/verify \
+curl -X POST https://[tenant-id].logto.app/api/verifications/verification-code/verify \
   -H 'authorization: Bearer <access_token>' \
   -H 'content-type: application/json' \
   --data-raw '{"identifier":{"type":"email","value":"..."},"verificationId":"...","code":"..."}'


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

This PR changes the `PATCH` requests for `/api/verifications/verification-code/verify` to `POST` requests as the `PATCH` method for this endpoint is actually not allowed.

[Open API docs](https://github.com/logto-io/logto/blob/69e1fe273408feacc01cd7eb1709a9ccf9bcd04e/packages/core/src/routes/verification/index.openapi.json#L93) for proof.
