### PR TITLE
docs: add required CAA records to cert troubleshooting answer

### DIFF
--- a/docs/logto-cloud/custom-domain.mdx
+++ b/docs/logto-cloud/custom-domain.mdx
@@ -47,7 +47,7 @@ To add a new custom domain in the Logto Console, follow these steps:
 
 If you encounter SSL certificate issues when setting up your custom domain, it may be related to CAA records in your DNS configuration. CAA records specify which Certificate Authorities (CAs) are authorized to issue certificates for your domain. If you're using CAA records, you will need to authorize both "letsencrypt.org" and "pki.goog" for Logto to issue SSL certificates.
 
-To troubleshoot and resolve SSL certificate issues related to CAA records, refer to [Cloudflare's documentation](https://developers.cloudflare.com/ssl/edge-certificates/caa-records/) on CAA Records. 
+To troubleshoot and resolve SSL certificate issues related to CAA records, refer to [Cloudflare's documentation](https://developers.cloudflare.com/ssl/edge-certificates/caa-records/) on CAA Records.
 
 </details>
 

--- a/docs/logto-cloud/custom-domain.mdx
+++ b/docs/logto-cloud/custom-domain.mdx
@@ -45,9 +45,9 @@ To add a new custom domain in the Logto Console, follow these steps:
 
 </summary>
 
-If you encounter SSL certificate issues when setting up your custom domain, it may be related to CAA records in your DNS configuration. CAA records specify which Certificate Authorities (CAs) are authorized to issue certificates for your domain.
+If you encounter SSL certificate issues when setting up your custom domain, it may be related to CAA records in your DNS configuration. CAA records specify which Certificate Authorities (CAs) are authorized to issue certificates for your domain. If you're using CAA records, you will need to authorize both "letsencrypt.org" and "pki.goog" for Logto to issue SSL certificates.
 
-To troubleshoot and resolve SSL certificate issues related to CAA records, refer to [Cloudflare's documentation](https://developers.cloudflare.com/ssl/edge-certificates/caa-records/) on CAA Records.
+To troubleshoot and resolve SSL certificate issues related to CAA records, refer to [Cloudflare's documentation](https://developers.cloudflare.com/ssl/edge-certificates/caa-records/) on CAA Records. 
 
 </details>
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
We recently had issues with our certificate not being renewed and had to add pki.goog to our CAA records (we already had letsencrypt.org). The information for this was found from [Google's docs](https://cloud.google.com/load-balancing/docs/ssl-certificates/google-managed-certs#caa) and based on the fact that the existing certificate was issue by Google. Adding these records fixed the certificate issues for us, so I think these are the correct CAA records.

