### PR TITLE
docs: fix the wrong openid configuration url

### DIFF
--- a/docs/authorization/validate-access-tokens/dotnet/_add-validation-logic.mdx
+++ b/docs/authorization/validate-access-tokens/dotnet/_add-validation-logic.mdx
@@ -70,7 +70,7 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>
     {
         options.Authority = AuthConstants.Issuer;
-        options.MetadataAddress = $"{AuthConstants.Issuer}/.well-known/openid_configuration";
+        options.MetadataAddress = $"{AuthConstants.Issuer}/.well-known/openid-configuration";
         options.RequireHttpsMetadata = true;
         options.TokenValidationParameters = new TokenValidationParameters
         {

--- a/i18n/de/docusaurus-plugin-content-docs/current/authorization/validate-access-tokens/dotnet/_add-validation-logic.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/authorization/validate-access-tokens/dotnet/_add-validation-logic.mdx
@@ -70,7 +70,7 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>
     {
         options.Authority = AuthConstants.Issuer;
-        options.MetadataAddress = $"{AuthConstants.Issuer}/.well-known/openid_configuration";
+        options.MetadataAddress = $"{AuthConstants.Issuer}/.well-known/openid-configuration";
         options.RequireHttpsMetadata = true;
         options.TokenValidationParameters = new TokenValidationParameters
         {

--- a/i18n/es/docusaurus-plugin-content-docs/current/authorization/validate-access-tokens/dotnet/_add-validation-logic.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/current/authorization/validate-access-tokens/dotnet/_add-validation-logic.mdx
@@ -70,7 +70,7 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>
     {
         options.Authority = AuthConstants.Issuer;
-        options.MetadataAddress = $"{AuthConstants.Issuer}/.well-known/openid_configuration";
+        options.MetadataAddress = $"{AuthConstants.Issuer}/.well-known/openid-configuration";
         options.RequireHttpsMetadata = true;
         options.TokenValidationParameters = new TokenValidationParameters
         {

--- a/i18n/fr/docusaurus-plugin-content-docs/current/authorization/validate-access-tokens/dotnet/_add-validation-logic.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/authorization/validate-access-tokens/dotnet/_add-validation-logic.mdx
@@ -70,7 +70,7 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>
     {
         options.Authority = AuthConstants.Issuer;
-        options.MetadataAddress = $"{AuthConstants.Issuer}/.well-known/openid_configuration";
+        options.MetadataAddress = $"{AuthConstants.Issuer}/.well-known/openid-configuration";
         options.RequireHttpsMetadata = true;
         options.TokenValidationParameters = new TokenValidationParameters
         {

--- a/i18n/ja/docusaurus-plugin-content-docs/current/authorization/validate-access-tokens/dotnet/_add-validation-logic.mdx
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/authorization/validate-access-tokens/dotnet/_add-validation-logic.mdx
@@ -70,7 +70,7 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>
     {
         options.Authority = AuthConstants.Issuer;
-        options.MetadataAddress = $"{AuthConstants.Issuer}/.well-known/openid_configuration";
+        options.MetadataAddress = $"{AuthConstants.Issuer}/.well-known/openid-configuration";
         options.RequireHttpsMetadata = true;
         options.TokenValidationParameters = new TokenValidationParameters
         {

--- a/i18n/ko/docusaurus-plugin-content-docs/current/authorization/validate-access-tokens/dotnet/_add-validation-logic.mdx
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/authorization/validate-access-tokens/dotnet/_add-validation-logic.mdx
@@ -70,7 +70,7 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>
     {
         options.Authority = AuthConstants.Issuer;
-        options.MetadataAddress = $"{AuthConstants.Issuer}/.well-known/openid_configuration";
+        options.MetadataAddress = $"{AuthConstants.Issuer}/.well-known/openid-configuration";
         options.RequireHttpsMetadata = true;
         options.TokenValidationParameters = new TokenValidationParameters
         {

--- a/i18n/pt-BR/docusaurus-plugin-content-docs/current/authorization/validate-access-tokens/dotnet/_add-validation-logic.mdx
+++ b/i18n/pt-BR/docusaurus-plugin-content-docs/current/authorization/validate-access-tokens/dotnet/_add-validation-logic.mdx
@@ -70,7 +70,7 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>
     {
         options.Authority = AuthConstants.Issuer;
-        options.MetadataAddress = $"{AuthConstants.Issuer}/.well-known/openid_configuration";
+        options.MetadataAddress = $"{AuthConstants.Issuer}/.well-known/openid-configuration";
         options.RequireHttpsMetadata = true;
         options.TokenValidationParameters = new TokenValidationParameters
         {

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/authorization/validate-access-tokens/dotnet/_add-validation-logic.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/authorization/validate-access-tokens/dotnet/_add-validation-logic.mdx
@@ -70,7 +70,7 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>
     {
         options.Authority = AuthConstants.Issuer;
-        options.MetadataAddress = $"{AuthConstants.Issuer}/.well-known/openid_configuration";
+        options.MetadataAddress = $"{AuthConstants.Issuer}/.well-known/openid-configuration";
         options.RequireHttpsMetadata = true;
         options.TokenValidationParameters = new TokenValidationParameters
         {

--- a/i18n/zh-TW/docusaurus-plugin-content-docs/current/authorization/validate-access-tokens/dotnet/_add-validation-logic.mdx
+++ b/i18n/zh-TW/docusaurus-plugin-content-docs/current/authorization/validate-access-tokens/dotnet/_add-validation-logic.mdx
@@ -70,7 +70,7 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>
     {
         options.Authority = AuthConstants.Issuer;
-        options.MetadataAddress = $"{AuthConstants.Issuer}/.well-known/openid_configuration";
+        options.MetadataAddress = $"{AuthConstants.Issuer}/.well-known/openid-configuration";
         options.RequireHttpsMetadata = true;
         options.TokenValidationParameters = new TokenValidationParameters
         {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix the wrong openid configuration URL in .NET docs. (fixes #1175)
