### PR TITLE
chore: suppress google one tap error in local dev env

### DIFF
--- a/src/theme/Layout/hooks.ts
+++ b/src/theme/Layout/hooks.ts
@@ -80,7 +80,8 @@ export function useGoogleOneTapConfig(): {
     const loadConfig = async () => {
       const rawConfig = customFields?.googleOneTapConfig;
       if (typeof rawConfig !== 'string') {
-        throw new TypeError('Google One Tap config is not a string');
+        debugLogger.error('Google One Tap config is not a string');
+        return;
       }
       const parsedConfig = googleOneTapConfigSchema.safeParse(
         // eslint-disable-next-line no-restricted-syntax


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Suppress annoying Google One Tap error popup in local dev environment, if no "GOT" configuration is provided in env. Only log the error in debug console.
