### PR TITLE
fix: react minified error 482 on doc pages that have table component

### DIFF
--- a/src/theme/MDXComponents/Table/index.tsx
+++ b/src/theme/MDXComponents/Table/index.tsx
@@ -73,11 +73,11 @@ export default function Table(props: HTMLAttributes<HTMLTableElement>) {
   const parsedHeadCells = Children.toArray(headRow.props.children).map((cell) =>
     parseHeaderCell(cell)
   );
-  const headCellElements = parsedHeadCells.map(async ({ element }) => element);
+  const headCellElements = parsedHeadCells.map(({ element }): ReactNode => element);
   const rebuiltHeadRow = cloneElement(headRow, {}, headCellElements);
   const rebuiltThead = cloneElement(theadNode, {}, rebuiltHeadRow);
-  const finalChildren = tableNodes.map(async (node, index) =>
-    index === theadPosition ? rebuiltThead : node
+  const finalChildren = tableNodes.map(
+    (node, index): ReactNode => (index === theadPosition ? rebuiltThead : node)
   );
 
   const hasWidths = parsedHeadCells.some((cell) => Boolean(cell.width));


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fixed the page crash when opening doc pages that contain table components.

```
The full text of the error you just encountered is:

An unknown Component is an async Client Component. Only Server Components can be async at the moment. This error is often caused by accidentally adding `'use client'` to a module that was originally written for the server.
```
