### PR TITLE
docs: add dev tenant data retention policy

### DIFF
--- a/docs/logto-cloud/README.mdx
+++ b/docs/logto-cloud/README.mdx
@@ -1,7 +1,8 @@
-import TenantSettings from '@site/docs/logto-cloud/assets/icons/data-storage.svg';
-import PricingAndBilling from '@site/docs/logto-cloud/assets/icons/key.svg';
-import CustomDomains from '@site/docs/logto-cloud/assets/icons/research.svg';
-import TenantMemberManagement from '@site/docs/logto-cloud/assets/icons/settings.svg';
+import TenantSettings from '@site/src/assets/database.svg';
+import Developer from '@site/src/assets/developer.svg';
+import TenantMemberManagement from '@site/src/assets/gear.svg';
+import PricingAndBilling from '@site/src/assets/key.svg';
+import CustomDomains from '@site/src/assets/search.svg';
 
 # Logto cloud service
 
@@ -21,6 +22,16 @@ If you have any questions about cloud services and need additional support, plea
         'Update or change the tenant name, check the regions, and delete or leave the tenant.',
       customProps: {
         icon: <TenantSettings />,
+      },
+    },
+    {
+      type: 'link',
+      label: 'Dev tenant data retention policy',
+      href: '/logto-cloud/dev-tenant-data-retention',
+      description:
+        'Understand the dev tenant 90-day user retention policy and how to use Logto dev tenant effectively.',
+      customProps: {
+        icon: <Developer />,
       },
     },
     {

--- a/docs/logto-cloud/dev-tenant-data-retention.mdx
+++ b/docs/logto-cloud/dev-tenant-data-retention.mdx
@@ -1,0 +1,93 @@
+---
+id: dev-tenant-data-retention
+title: Dev tenant data retention policy
+sidebar_label: Dev tenant data retention policy
+sidebar_position: 2
+---
+
+# Dev tenant data retention policy
+
+Logto Cloud follows a clear principle: **production is for persistence, development is for testing**.
+
+- In **production tenants** (Free, Pro, and Enterprise), objects and entities are kept for the full lifespan of the account, unless you remove them or request otherwise.
+- In **dev tenants**, the goal is different. They are **safe sandboxes for testing,** focused on security, performance, and clean environments rather than storing data long term.
+
+To uphold this principle, Logto applies a 90-day retention policy in dev tenants: **users** in dev tenants are automatically deleted after 90 days.
+
+In dev environments, developers often create many test accounts during integration. These accounts generate large amounts of data but rarely provide long-term value. The 90-day policy ensures Logto's platform resources are used efficiently, keeps test environments clean and performant, prevents unused accounts from piling up, and clearly separates temporary test data from long-term production data.
+
+## Understanding the 90-day policy
+
+### Only user accounts older than 90 days are deleted
+
+Deleting users means removing all profiles information, authentication data, and related information.
+
+### What stays intact
+
+Your development work and configurations remain untouched. This makes it easy to carry over your dev and integration setup into production environments in the future. We offer options to directly [convert your dev tenant](./tenant-settings#tenant-types-dev-vs-prod) to production tenant.
+
+## What automatic user deletion means for you
+
+- Privacy protection: Test accounts are often shared across teams during development or left unused for long periods. We recommend refreshing them every 90 days.
+- Resource efficiency: Automatic deletion frees up storage and processing capacity, keeping environments clean and efficient.
+- Clear separation of environments: Dev tenants are temporary sandboxes. Long-term, persistent data belongs in production tenants.
+
+## Best practices for dev tenants
+
+### During development
+
+- Use Logto dev tenants as your sandbox for testing.
+- Keep notes on important test scenarios so you can easily recreate them.
+- Plan your development lifecycle carefully and move to production when the time is right.
+
+### For long-term projects
+
+- Create new test users or accounts as needed instead of keeping old ones.
+- Use production tenants if you need staging environments with persistent data.
+
+## FAQs
+
+<details>
+<summary>
+
+### Can I extend the 90-day retention period?
+
+</summary>
+
+No. The 90-day policy is fixed for all dev tenants to keep things consistent and secure. If you have special requirements, please contact us for guidance.
+
+</details>
+
+<details>
+<summary>
+
+### Does this affect production tenants?
+
+</summary>
+
+No. All data in production tenants, including users and configurations for both Free, Pro, and Enterprise plans is not affected.
+
+</details>
+
+<details>
+<summary>
+
+### For enterprise customers, will dev tenants under private instances be deleted?
+
+</summary>
+
+No. Dev tenants in private instances are excluded from the 90-day deletion policy.
+
+</details>
+
+## Summary
+
+1. Users in dev tenants are automatically cleaned up after 90 days
+2. All your configurations, apps, and settings remain permanent
+3. This policy ensures security, performance, and clean testing conditions
+4. Production tenants have different retention policies for persistent data
+5. Plan your development workflow around this automated cleanup cycle
+
+This retention policy ensures that your development environment remains a secure, efficient, and reliable testing ground while protecting user privacy and maintaining system performance.
+
+For persistent user data storage, consider upgrading to a production tenant where data retention follows your organization's specific requirements.

--- a/docs/logto-cloud/tenant-settings.mdx
+++ b/docs/logto-cloud/tenant-settings.mdx
@@ -1,7 +1,7 @@
 ---
 id: tenant-settings
 title: Tenant settings
-sidebar_position: 2
+sidebar_position: 1
 ---
 
 # Tenant settings
@@ -69,7 +69,7 @@ The development tenant (dev tenant) is primarily intended for testing purposes a
 
 However, there are certain limitations that apply to development tenants:
 
-- Dev tenant will automatically delete users and organizations over 90 days.
+- Dev tenant will automatically delete users over 90 days. Check the [Dev tenant data retention policy](./dev-tenant-data-retention) for details.
 - A banner appears during the sign-in experience, indicating that the tenant is in development mode.
 - Development tenants may have quota limits on specific features. These limits are explained on the feature details page, if applicable.
 - Logto may update the development tenant's quota limits, and we will try our best to notify you in advance.


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
- Introduced a new documentation page for the 90-day user data retention policy in dev tenants.
- Updated tenant settings documentation to reference the new policy and clarify that only users, not organizations, are deleted after 90 days
<!-- Provide detailed PR description below -->

