### PR TITLE
fix: unexpected content wraps of URL links

### DIFF
--- a/src/components/Url/index.module.scss
+++ b/src/components/Url/index.module.scss
@@ -25,7 +25,7 @@
   }
 
   p {
-    display: inline-block;
+    display: inline;
     margin: 0;
   }
 
@@ -38,7 +38,8 @@
   p>&,
   li>&,
   span>&,
-  strong>& {
+  strong>&,
+  em>& {
     display: inline-flex;
 
     +.linkWrapper {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Fix unexpected URL content wraps.

Before:
<img width="1092" height="184" alt="image" src="https://github.com/user-attachments/assets/5e498904-d111-472e-abc7-25ade7551491" />

After:
<img width="1428" height="88" alt="image" src="https://github.com/user-attachments/assets/67a87352-89bb-4510-a11f-0fcced27b922" />

Before:
<img width="998" height="758" alt="image" src="https://github.com/user-attachments/assets/49992570-7476-4d09-a2eb-94960230acdb" />

After:
<img width="996" height="494" alt="image" src="https://github.com/user-attachments/assets/6b18540c-1d21-41a0-9b49-22607f35cc82" />


