### PR TITLE
fix: remove unexpected translations from code identifiers in i18n docs

### DIFF
--- a/i18n/es/docusaurus-plugin-content-docs/current/authorization/validate-access-tokens/go/_init.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/current/authorization/validate-access-tokens/go/_init.mdx
@@ -37,11 +37,11 @@ func extractBearerTokenFromHeaders(r *http.Request) (string, error) {
 
     authorization := r.Header.Get("Authorization")
     if authorization == "" {
-        return "", NewAuthorizationError("El encabezado Authorization (Authorization header) falta", http.StatusUnauthorized)
+        return "", NewAuthorizationError("El encabezado Authorization falta", http.StatusUnauthorized)
     }
 
     if !strings.HasPrefix(authorization, bearerPrefix) {
-        return "", NewAuthorizationError(fmt.Sprintf("El encabezado Authorization (Authorization header) debe comenzar con \"%s\"", bearerPrefix), http.StatusUnauthorized)
+        return "", NewAuthorizationError(fmt.Sprintf("El encabezado Authorization debe comenzar con \"%s\"", bearerPrefix), http.StatusUnauthorized)
     }
 
     return strings.TrimPrefix(authorization, bearerPrefix), nil

--- a/i18n/es/docusaurus-plugin-content-docs/current/authorization/validate-access-tokens/rust/_init.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/current/authorization/validate-access-tokens/rust/_init.mdx
@@ -64,16 +64,16 @@ impl std::error::Error for AuthorizationError {}
 
 pub fn extract_bearer_token(authorization: Option<&str>) -> Result<&str, AuthorizationError> {
     let auth_header = authorization.ok_or_else(|| {
-        AuthorizationError::with_status("Falta el encabezado de autorización (Authorization header is missing)", 401)
+        AuthorizationError::with_status("Falta el encabezado de autorización", 401)
     })?;
 
     if !auth_header.starts_with("Bearer ") {
         return Err(AuthorizationError::with_status(
-            "El encabezado de autorización debe comenzar con \"Bearer \" (Authorization header must start with \"Bearer \")",
+            "El encabezado de autorización debe comenzar con \"Bearer \"",
             401,
         ));
     }
 
-    Ok(&auth_header[7..]) // Elimina el prefijo 'Bearer ' (Remove 'Bearer ' prefix)
+    Ok(&auth_header[7..]) // Elimina el prefijo 'Bearer '
 }
 ```

--- a/i18n/fr/docusaurus-plugin-content-docs/current/authorization/validate-access-tokens/rust/_init.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/authorization/validate-access-tokens/rust/_init.mdx
@@ -64,16 +64,16 @@ impl std::error::Error for AuthorizationError {}
 
 pub fn extract_bearer_token(authorization: Option<&str>) -> Result<&str, AuthorizationError> {
     let auth_header = authorization.ok_or_else(|| {
-        AuthorizationError::with_status("Le header Authorization est manquant (Authorization header is missing)", 401)
+        AuthorizationError::with_status("Le header Authorization est manquant", 401)
     })?;
 
     if !auth_header.starts_with("Bearer ") {
         return Err(AuthorizationError::with_status(
-            "Le header Authorization doit commencer par \"Bearer \" (Authorization header must start with \"Bearer \")",
+            "Le header Authorization doit commencer par \"Bearer \"",
             401,
         ));
     }
 
-    Ok(&auth_header[7..]) // Supprime le préfixe 'Bearer ' (Remove 'Bearer ' prefix)
+    Ok(&auth_header[7..]) // Supprime le préfixe 'Bearer '
 }
 ```

--- a/i18n/ja/docusaurus-plugin-content-docs/current/authorization/validate-access-tokens/rust/_init.mdx
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/authorization/validate-access-tokens/rust/_init.mdx
@@ -64,16 +64,16 @@ impl std::error::Error for AuthorizationError {}
 
 pub fn extract_bearer_token(authorization: Option<&str>) -> Result<&str, AuthorizationError> {
     let auth_header = authorization.ok_or_else(|| {
-        AuthorizationError::with_status("Authorization ヘッダーがありません (Authorization header is missing)", 401)
+        AuthorizationError::with_status("Authorization ヘッダーがありません", 401)
     })?;
 
     if !auth_header.starts_with("Bearer ") {
         return Err(AuthorizationError::with_status(
-            "Authorization ヘッダーは \"Bearer \" で始まる必要があります (Authorization header must start with \"Bearer \")",
+            "Authorization ヘッダーは \"Bearer \" で始まる必要があります",
             401,
         ));
     }
 
-    Ok(&auth_header[7..]) // 'Bearer ' プレフィックスを削除 (Remove 'Bearer ' prefix)
+    Ok(&auth_header[7..]) // 'Bearer ' プレフィックスを削除
 }
 ```

--- a/i18n/ko/docusaurus-plugin-content-docs/current/authorization/validate-access-tokens/python/fragments/django-rest/_validation.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/authorization/validate-access-tokens/python/fragments/django-rest/_validation.md
@@ -3,7 +3,7 @@ from rest_framework.authentication import TokenAuthentication
 from rest_framework import exceptions
 from jwt_validator import validate_jwt, create_auth_info
 
-class 액세스 토큰 (Access token) 인증 (Authentication)(TokenAuthentication):
+class AccessTokenAuthentication(TokenAuthentication):
     keyword = 'Bearer'  # 'Token' 대신 'Bearer'를 사용하세요
 
     def authenticate_credentials(self, key):

--- a/i18n/pt-BR/docusaurus-plugin-content-docs/current/authorization/validate-access-tokens/rust/_init.mdx
+++ b/i18n/pt-BR/docusaurus-plugin-content-docs/current/authorization/validate-access-tokens/rust/_init.mdx
@@ -64,16 +64,16 @@ impl std::error::Error for AuthorizationError {}
 
 pub fn extract_bearer_token(authorization: Option<&str>) -> Result<&str, AuthorizationError> {
     let auth_header = authorization.ok_or_else(|| {
-        AuthorizationError::with_status("Cabeçalho de autorização está ausente (Authorization header is missing)", 401)
+        AuthorizationError::with_status("Cabeçalho Authorization ausente", 401)
     })?;
 
     if !auth_header.starts_with("Bearer ") {
         return Err(AuthorizationError::with_status(
-            "O cabeçalho de autorização deve começar com \"Bearer \" (Authorization header must start with \"Bearer \")",
+            "O cabeçalho de autorização deve começar com \"Bearer \"",
             401,
         ));
     }
 
-    Ok(&auth_header[7..]) // Remove o prefixo 'Bearer ' (Remove 'Bearer ' prefix)
+    Ok(&auth_header[7..]) // Remove o prefixo 'Bearer '
 }
 ```

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/authorization/validate-access-tokens/go/_init.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/authorization/validate-access-tokens/go/_init.mdx
@@ -37,11 +37,11 @@ func extractBearerTokenFromHeaders(r *http.Request) (string, error) {
 
     authorization := r.Header.Get("Authorization")
     if authorization == "" {
-        return "", NewAuthorizationError("Authorization header is missing", http.StatusUnauthorized)
+        return "", NewAuthorizationError("Authorization 头缺失", http.StatusUnauthorized)
     }
 
     if !strings.HasPrefix(authorization, bearerPrefix) {
-        return "", NewAuthorizationError(fmt.Sprintf("Authorization header must start with \"%s\"", bearerPrefix), http.StatusUnauthorized)
+        return "", NewAuthorizationError(fmt.Sprintf("Authorization 头必须以 \"%s\" 开头", bearerPrefix), http.StatusUnauthorized)
     }
 
     return strings.TrimPrefix(authorization, bearerPrefix), nil

--- a/i18n/zh-TW/docusaurus-plugin-content-docs/current/authorization/validate-access-tokens/dotnet/_init.mdx
+++ b/i18n/zh-TW/docusaurus-plugin-content-docs/current/authorization/validate-access-tokens/dotnet/_init.mdx
@@ -11,11 +11,11 @@ namespace YourApiNamespace
 ```csharp title="AuthenticationExceptions.cs"
 namespace YourApiNamespace.Exceptions
 {
-    public class 授權 (Authorization)Exception : Exception
+    public class AuthorizationException : Exception
     {
         public int StatusCode { get; }
 
-        public 授權 (Authorization)Exception(string message, int statusCode = 403) : base(message)
+        public AuthorizationException(string message, int statusCode = 403) : base(message)
         {
             StatusCode = statusCode;
         }

--- a/i18n/zh-TW/docusaurus-plugin-content-docs/current/authorization/validate-access-tokens/rust/_init.mdx
+++ b/i18n/zh-TW/docusaurus-plugin-content-docs/current/authorization/validate-access-tokens/rust/_init.mdx
@@ -33,12 +33,12 @@ impl AuthInfo {
 }
 
 #[derive(Debug)]
-pub struct 授權錯誤 (AuthorizationError) {
+pub struct AuthorizationError {
     pub message: String,
     pub status_code: u16,
 }
 
-impl 授權錯誤 (AuthorizationError) {
+impl AuthorizationError {
     pub fn new(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
@@ -54,21 +54,21 @@ impl 授權錯誤 (AuthorizationError) {
     }
 }
 
-impl fmt::Display for 授權錯誤 (AuthorizationError) {
+impl fmt::Display for AuthorizationError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.message)
     }
 }
 
-impl std::error::Error for 授權錯誤 (AuthorizationError) {}
+impl std::error::Error for AuthorizationError {}
 
-pub fn extract_bearer_token(authorization: Option<&str>) -> Result<&str, 授權錯誤 (AuthorizationError)> {
+pub fn extract_bearer_token(authorization: Option<&str>) -> Result<&str, AuthorizationError> {
     let auth_header = authorization.ok_or_else(|| {
-        授權錯誤 (AuthorizationError)::with_status("Authorization header is missing", 401)
+        AuthorizationError::with_status("Authorization header is missing", 401)
     })?;
 
     if !auth_header.starts_with("Bearer ") {
-        return Err(授權錯誤 (AuthorizationError)::with_status(
+        return Err(AuthorizationError::with_status(
             "Authorization header must start with \"Bearer \"",
             401,
         ));

--- a/translate.openai.mjs
+++ b/translate.openai.mjs
@@ -52,6 +52,7 @@ const buildInstructions = (locale, asIsTerms, terms, patterns) => {
     'Irregular whitespaces are not allowed in the translated content.',
     locale.startsWith('ja') &&
       'Do not violating the "end-tag-mismatch" lint rule in translated MDX. When a line starts with custom component tags like `<CloudLink>`, remember to wrap any content after the ending tag `</CloudLink>` into the next line. E.g. `<CloudLink to="path">\n  some text\n</CloudLink> some other text.` should be `<CloudLink to="path">\n  some text\n</CloudLink>\nsome other text.`.',
+    'Do not translate programming language code identifiers in fenced code blocks. E.g. ```go title="_init.go"\nfunc (e *AuthorizationError) Error() string { return e.Message }```. Only translate comments and output messages.',
   ].filter(Boolean);
 };
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Updated multiple internationalized documentation files to remove inline translations from programming language code identifiers, class names, and error types. Now only comments and output messages remain translated.
Also updated openai prompt, telling it not to translate code examples in fenced code blocks.
