### PR TITLE
docs: document Account Center identifier query parameter

### DIFF
--- a/docs/end-user-flows/account-settings/by-account-center-ui.mdx
+++ b/docs/end-user-flows/account-settings/by-account-center-ui.mdx
@@ -58,7 +58,7 @@ Configure the field permissions according to your needs:
 
 To use the prebuilt Account Center UI, you need to redirect users from your application to the appropriate Logto pages. There are two approaches:
 
-#### Approach A: Direct linking with redirect parameter \{#approach-a-direct-linking}
+#### Approach A: Direct linking with query parameters \{#approach-a-direct-linking}
 
 Add links in your application that redirect users to the prebuilt pages. Include a `redirect` query parameter to bring users back to your app after they complete the action:
 
@@ -67,6 +67,14 @@ https://[tenant-id].logto.app/account/email?redirect=https://your-app.com/settin
 ```
 
 When users complete updating their email, they will be redirected back to `https://your-app.com/settings`.
+
+For identifier-based pages (`/account/email`, `/account/phone`, and `/account/username`), you can also include an optional `identifier` query parameter to pre-fill the input field:
+
+```
+https://[tenant-id].logto.app/account/email?redirect=https://your-app.com/settings&identifier=user%40example.com
+```
+
+This is useful when your application already knows the new email address, phone number, or username that the user is about to verify or update.
 
 #### Approach B: Embedding in your account settings flow \{#approach-b-embedding}
 


### PR DESCRIPTION
## Summary
Document the `identifier` query parameter for the prebuilt Account Center UI.

Related: logto-io/logto#8483

- clarify that direct links to `/account/email`, `/account/phone`, and `/account/username` can pre-fill the identifier input
- add an example that combines `redirect` and `identifier`

## Testing
N/A

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
