### PR TITLE
Add docusaurus-plugin-copy-page-button for AI-friendly docs

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -63,6 +63,7 @@ const config: Config = {
     addAliasPlugin,
     injectHeadTagsPlugin,
     'docusaurus-plugin-sass',
+    'docusaurus-plugin-copy-page-button',
     ogImageGenerator,
     disableExpensiveBundlerOptimizationPlugin,
     [

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "arg": "^5.0.2",
     "clsx": "^2.1.1",
     "core-js": "^3.38.1",
-    "docusaurus-plugin-copy-page-button": "^0.4.2",
+    "docusaurus-plugin-copy-page-button": "^0.5.2",
     "docusaurus-plugin-remote-content": "^4.0.0",
     "docusaurus-plugin-sass": "^0.2.6",
     "dotenv": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "arg": "^5.0.2",
     "clsx": "^2.1.1",
     "core-js": "^3.38.1",
+    "docusaurus-plugin-copy-page-button": "^0.4.2",
     "docusaurus-plugin-remote-content": "^4.0.0",
     "docusaurus-plugin-sass": "^0.2.6",
     "dotenv": "^17.0.0",


### PR DESCRIPTION
## What this adds

A "Copy page" button in the docs sidebar that exports the current Logto docs page as clean markdown, with one-click "Open in ChatGPT", "Open in Claude", and "Open in Gemini" actions.

## Why for Logto

Logto users are mid-integration most of the time and frequently bouncing between the docs and an AI assistant for help wiring up SDKs, configuring connectors, or debugging custom JWT claims. A one-click handoff from a docs page to a clean markdown context drops a real friction point.

## Production users

The plugin is already shipping on Ethereum execution-apis, Sui (Mysten Labs), Walrus, Seal, SuiNS, Monad, Flare, Kaia, Nillion, and Chronicle docs. ~10k npm installs/month.

## Changes

- Adds `docusaurus-plugin-copy-page-button` to `devDependencies`
- Adds the plugin string to the `plugins` array in `docusaurus.config.ts`

The button auto-injects into the table-of-contents sidebar. No further config required, theme-aware, mobile-friendly.

## Links

- Live demo: https://portdeveloper.github.io/copy-page-button-showcase/
- Plugin repo: https://github.com/portdeveloper/docusaurus-plugin-copy-page-button
- npm: https://www.npmjs.com/package/docusaurus-plugin-copy-page-button

Happy to revert or adjust if this doesn't fit the project's direction.