### PR TITLE
docs: add tenant creation automation guide

### DIFF
--- a/docs/logto-cloud/README.mdx
+++ b/docs/logto-cloud/README.mdx
@@ -77,10 +77,10 @@ If you have any questions about cloud services and need additional support, plea
     },
     {
       type: 'link',
-      label: 'Automate tenant creation',
+      label: 'Automate tenant management',
       href: '/logto-cloud/automate-tenant-creation',
       description:
-        'Create tenants programmatically and continue provisioning each new tenant with Management API.',
+        'Create and manage tenants programmatically with Logto Cloud API and Management API.',
       customProps: {
         icon: <TenantAutomation />,
       },

--- a/docs/logto-cloud/README.mdx
+++ b/docs/logto-cloud/README.mdx
@@ -3,6 +3,7 @@ import Developer from '@site/src/assets/developer.svg';
 import TenantMemberManagement from '@site/src/assets/gear.svg';
 import PricingAndBilling from '@site/src/assets/key.svg';
 import McpIcon from '@site/src/assets/mcp.svg';
+import TenantAutomation from '@site/src/assets/robot.svg';
 import CustomDomains from '@site/src/assets/search.svg';
 import SystemLimit from '@site/src/assets/security.svg';
 
@@ -72,6 +73,16 @@ If you have any questions about cloud services and need additional support, plea
         'Understand the system limits and rate protection for Dev, Pro, and Enterprise tenants.',
       customProps: {
         icon: <SystemLimit />,
+      },
+    },
+    {
+      type: 'link',
+      label: 'Automate tenant creation',
+      href: '/logto-cloud/automate-tenant-creation',
+      description:
+        'Create tenants programmatically and continue provisioning each new tenant with Management API.',
+      customProps: {
+        icon: <TenantAutomation />,
       },
     },
     {

--- a/docs/logto-cloud/automate-tenant-creation.mdx
+++ b/docs/logto-cloud/automate-tenant-creation.mdx
@@ -1,12 +1,12 @@
 ---
 id: automate-tenant-creation
-title: Automate tenant creation
+title: Automate tenant management
 sidebar_position: 8
 ---
 
-# Automate tenant creation
+# Automate tenant management
 
-You can create Logto Cloud tenants programmatically and continue configuring the newly created tenant without switching to Console.
+You can manage Logto Cloud tenants programmatically, including creating tenants and continuing configuration without switching to Console.
 
 This is useful when you need to provision tenants from your own onboarding flow, internal platform, AI agent, or integration automation.
 
@@ -27,7 +27,7 @@ Prepare the following values:
 | `CLOUD_API_ENDPOINT` | The Logto Cloud API endpoint. For Logto Cloud, use `https://cloud.logto.io`. |
 | `LOGTO_CLOUD_PAT`    | A PAT for your Logto Cloud account.                                          |
 | `TENANT_NAME`        | The display name of the tenant to create.                                    |
-| `TENANT_TAG`         | The tenant type. Use `Development` or `Production`.                          |
+| `TENANT_TAG`         | The tenant type. Use `development` or `production`.                          |
 | `REGION_NAME`        | The region identifier for the tenant.                                        |
 
 Set them as environment variables:
@@ -36,7 +36,7 @@ Set them as environment variables:
 export CLOUD_API_ENDPOINT="https://cloud.logto.io"
 export LOGTO_CLOUD_PAT="<logto-cloud-pat>"
 export TENANT_NAME="My automated tenant"
-export TENANT_TAG="Development"
+export TENANT_TAG="development"
 export REGION_NAME="<region-name>"
 ```
 
@@ -92,7 +92,7 @@ Example response:
 {
   "id": "new-tenant-id",
   "name": "My automated tenant",
-  "tag": "Development",
+  "tag": "development",
   "indicator": "https://new-tenant-id.logto.app",
   "regionName": "EU",
   "defaultApplication": {
@@ -188,7 +188,7 @@ const createTenantResponse = await fetch(`${cloudApiEndpoint}/api/tenants`, {
   },
   body: JSON.stringify({
     name: 'My automated tenant',
-    tag: 'Development',
+    tag: 'development',
     regionName: 'EU',
   }),
 });

--- a/docs/logto-cloud/automate-tenant-creation.mdx
+++ b/docs/logto-cloud/automate-tenant-creation.mdx
@@ -12,7 +12,7 @@ This is useful when you need to provision tenants from your own onboarding flow,
 
 The automation flow is:
 
-1. Use an **admin tenant Personal Access Token (PAT)** to call the Logto Cloud API.
+1. Use a **Logto Cloud Personal Access Token (PAT)** to call the Logto Cloud API.
 2. Create a tenant with `POST /api/tenants`.
 3. Read the default Machine-to-machine (M2M) application credentials from the creation response.
 4. Use the default M2M application to get a Management API access token for the new tenant.
@@ -25,7 +25,7 @@ Prepare the following values:
 | Variable             | Description                                                                  |
 | -------------------- | ---------------------------------------------------------------------------- |
 | `CLOUD_API_ENDPOINT` | The Logto Cloud API endpoint. For Logto Cloud, use `https://cloud.logto.io`. |
-| `ADMIN_TENANT_PAT`   | A PAT that belongs to a user in the admin tenant.                            |
+| `LOGTO_CLOUD_PAT`    | A PAT for your Logto Cloud account.                                          |
 | `TENANT_NAME`        | The display name of the tenant to create.                                    |
 | `TENANT_TAG`         | The tenant type. Use `Development` or `Production`.                          |
 | `REGION_NAME`        | The region identifier for the tenant.                                        |
@@ -34,7 +34,7 @@ Set them as environment variables:
 
 ```bash
 export CLOUD_API_ENDPOINT="https://cloud.logto.io"
-export ADMIN_TENANT_PAT="<admin-tenant-pat>"
+export LOGTO_CLOUD_PAT="<logto-cloud-pat>"
 export TENANT_NAME="My automated tenant"
 export TENANT_TAG="Development"
 export REGION_NAME="<region-name>"
@@ -42,11 +42,11 @@ export REGION_NAME="<region-name>"
 
 ## Get available regions \{#get-available-regions}
 
-Before creating a tenant, fetch the regions available to the admin tenant user:
+Before creating a tenant, fetch the regions available to your Logto Cloud account:
 
 ```bash
 curl "$CLOUD_API_ENDPOINT/api/me/regions" \
-  -H "Authorization: Bearer $ADMIN_TENANT_PAT"
+  -H "Authorization: Bearer $LOGTO_CLOUD_PAT"
 ```
 
 The response contains the available regions. Use the `name` value as `REGION_NAME` when creating the tenant.
@@ -70,12 +70,12 @@ Example response:
 
 ## Create a tenant \{#create-a-tenant}
 
-Call `POST /api/tenants` with the admin tenant PAT:
+Call `POST /api/tenants` with the Logto Cloud PAT:
 
 ```bash
 curl "$CLOUD_API_ENDPOINT/api/tenants" \
   -X POST \
-  -H "Authorization: Bearer $ADMIN_TENANT_PAT" \
+  -H "Authorization: Bearer $LOGTO_CLOUD_PAT" \
   -H "Content-Type: application/json" \
   -d '{
     "name": "'"$TENANT_NAME"'",
@@ -178,12 +178,12 @@ The following Node.js example creates a tenant, exchanges the returned default M
 
 ```js
 const cloudApiEndpoint = 'https://cloud.logto.io';
-const adminTenantPat = process.env.ADMIN_TENANT_PAT;
+const logtoCloudPat = process.env.LOGTO_CLOUD_PAT;
 
 const createTenantResponse = await fetch(`${cloudApiEndpoint}/api/tenants`, {
   method: 'POST',
   headers: {
-    authorization: `Bearer ${adminTenantPat}`,
+    authorization: `Bearer ${logtoCloudPat}`,
     'content-type': 'application/json',
   },
   body: JSON.stringify({

--- a/docs/logto-cloud/automate-tenant-creation.mdx
+++ b/docs/logto-cloud/automate-tenant-creation.mdx
@@ -1,0 +1,242 @@
+---
+id: automate-tenant-creation
+title: Automate tenant creation
+sidebar_position: 8
+---
+
+# Automate tenant creation
+
+You can create Logto Cloud tenants programmatically and continue configuring the newly created tenant without switching to Console.
+
+This is useful when you need to provision tenants from your own onboarding flow, internal platform, AI agent, or integration automation.
+
+The automation flow is:
+
+1. Use an **admin tenant Personal Access Token (PAT)** to call the Logto Cloud API.
+2. Create a tenant with `POST /api/tenants`.
+3. Read the default Machine-to-machine (M2M) application credentials from the creation response.
+4. Use the default M2M application to get a Management API access token for the new tenant.
+5. Call the new tenant's Management API to continue provisioning applications, users, roles, resources, organizations, and other settings.
+
+## Before you start \{#before-you-start}
+
+Prepare the following values:
+
+| Variable             | Description                                                                  |
+| -------------------- | ---------------------------------------------------------------------------- |
+| `CLOUD_API_ENDPOINT` | The Logto Cloud API endpoint. For Logto Cloud, use `https://cloud.logto.io`. |
+| `ADMIN_TENANT_PAT`   | A PAT that belongs to a user in the admin tenant.                            |
+| `TENANT_NAME`        | The display name of the tenant to create.                                    |
+| `TENANT_TAG`         | The tenant type. Use `Development` or `Production`.                          |
+| `REGION_NAME`        | The region identifier for the tenant.                                        |
+
+Set them as environment variables:
+
+```bash
+export CLOUD_API_ENDPOINT="https://cloud.logto.io"
+export ADMIN_TENANT_PAT="<admin-tenant-pat>"
+export TENANT_NAME="My automated tenant"
+export TENANT_TAG="Development"
+export REGION_NAME="<region-name>"
+```
+
+## Get available regions \{#get-available-regions}
+
+Before creating a tenant, fetch the regions available to the admin tenant user:
+
+```bash
+curl "$CLOUD_API_ENDPOINT/api/me/regions" \
+  -H "Authorization: Bearer $ADMIN_TENANT_PAT"
+```
+
+The response contains the available regions. Use the `name` value as `REGION_NAME` when creating the tenant.
+
+Example response:
+
+```json
+{
+  "regions": [
+    {
+      "name": "EU",
+      "displayName": "Europe"
+    },
+    {
+      "name": "US",
+      "displayName": "United States"
+    }
+  ]
+}
+```
+
+## Create a tenant \{#create-a-tenant}
+
+Call `POST /api/tenants` with the admin tenant PAT:
+
+```bash
+curl "$CLOUD_API_ENDPOINT/api/tenants" \
+  -X POST \
+  -H "Authorization: Bearer $ADMIN_TENANT_PAT" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "'"$TENANT_NAME"'",
+    "tag": "'"$TENANT_TAG"'",
+    "regionName": "'"$REGION_NAME"'"
+  }'
+```
+
+The response includes the created tenant and a default M2M application. The M2M application is created in the new tenant and has access to the tenant's Management API.
+
+Example response:
+
+```json
+{
+  "id": "new-tenant-id",
+  "name": "My automated tenant",
+  "tag": "Development",
+  "indicator": "https://new-tenant-id.logto.app",
+  "regionName": "EU",
+  "defaultApplication": {
+    "id": "default-m2m-app-id",
+    "secret": "default-m2m-app-secret"
+  }
+}
+```
+
+Save the values you need for the next step:
+
+```bash
+export TENANT_ID="<response.id>"
+export TENANT_ENDPOINT="<response.indicator>"
+export DEFAULT_M2M_APP_ID="<response.defaultApplication.id>"
+export DEFAULT_M2M_APP_SECRET="<response.defaultApplication.secret>"
+```
+
+## Get a Management API access token for the new tenant \{#get-a-management-api-access-token-for-the-new-tenant}
+
+Use the default M2M application credentials to request an access token from the new tenant:
+
+```bash
+curl "$TENANT_ENDPOINT/oidc/token" \
+  -X POST \
+  -u "$DEFAULT_M2M_APP_ID:$DEFAULT_M2M_APP_SECRET" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials" \
+  -d "resource=$TENANT_ENDPOINT/api" \
+  -d "scope=all"
+```
+
+Example response:
+
+```json
+{
+  "access_token": "eyJ...",
+  "expires_in": 3600,
+  "token_type": "Bearer",
+  "scope": "all"
+}
+```
+
+Save the access token:
+
+```bash
+export MANAGEMENT_API_ACCESS_TOKEN="<response.access_token>"
+```
+
+## Continue provisioning the new tenant \{#continue-provisioning-the-new-tenant}
+
+Use the Management API access token to call the new tenant's Management API.
+
+For example, list applications:
+
+```bash
+curl "$TENANT_ENDPOINT/api/applications" \
+  -H "Authorization: Bearer $MANAGEMENT_API_ACCESS_TOKEN"
+```
+
+Or create an application:
+
+```bash
+curl "$TENANT_ENDPOINT/api/applications" \
+  -X POST \
+  -H "Authorization: Bearer $MANAGEMENT_API_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "My web app",
+    "type": "SPA",
+    "oidcClientMetadata": {
+      "redirectUris": ["https://example.com/callback"],
+      "postLogoutRedirectUris": ["https://example.com"]
+    }
+  }'
+```
+
+At this point, your automation can continue with any Management API operation, such as creating users, applications, API resources, roles, organizations, connectors, or sign-in experience settings.
+
+## Full automation example \{#full-automation-example}
+
+The following Node.js example creates a tenant, exchanges the returned default M2M credentials for a Management API access token, and lists applications in the new tenant:
+
+```js
+const cloudApiEndpoint = 'https://cloud.logto.io';
+const adminTenantPat = process.env.ADMIN_TENANT_PAT;
+
+const createTenantResponse = await fetch(`${cloudApiEndpoint}/api/tenants`, {
+  method: 'POST',
+  headers: {
+    authorization: `Bearer ${adminTenantPat}`,
+    'content-type': 'application/json',
+  },
+  body: JSON.stringify({
+    name: 'My automated tenant',
+    tag: 'Development',
+    regionName: 'EU',
+  }),
+});
+
+if (!createTenantResponse.ok) {
+  throw new Error(`Failed to create tenant: ${await createTenantResponse.text()}`);
+}
+
+const tenant = await createTenantResponse.json();
+const tenantEndpoint = tenant.indicator;
+const { id: appId, secret: appSecret } = tenant.defaultApplication;
+
+const tokenResponse = await fetch(`${tenantEndpoint}/oidc/token`, {
+  method: 'POST',
+  headers: {
+    authorization: `Basic ${Buffer.from(`${appId}:${appSecret}`).toString('base64')}`,
+    'content-type': 'application/x-www-form-urlencoded',
+  },
+  body: new URLSearchParams({
+    grant_type: 'client_credentials',
+    resource: `${tenantEndpoint}/api`,
+    scope: 'all',
+  }),
+});
+
+if (!tokenResponse.ok) {
+  throw new Error(`Failed to get Management API token: ${await tokenResponse.text()}`);
+}
+
+const { access_token: managementApiAccessToken } = await tokenResponse.json();
+
+const applicationsResponse = await fetch(`${tenantEndpoint}/api/applications`, {
+  headers: {
+    authorization: `Bearer ${managementApiAccessToken}`,
+  },
+});
+
+if (!applicationsResponse.ok) {
+  throw new Error(`Failed to list applications: ${await applicationsResponse.text()}`);
+}
+
+const applications = await applicationsResponse.json();
+
+console.log({ tenantId: tenant.id, applications });
+```
+
+## Related resources \{#related-resources}
+
+- [Personal access token](/user-management/personal-access-token)
+- [Interact with Management API](/integrate-logto/interact-with-management-api)
+- [Machine-to-machine quick start](/quick-starts/m2m)


### PR DESCRIPTION
## Summary
- Add a Logto Cloud guide for automating tenant creation with an admin tenant PAT.
- Document how to use returned default M2M credentials to access the new tenant Management API.
- Add the new guide to the Logto Cloud docs landing page.

## Validation
- pnpm lint
- pnpm typecheck
- pnpm build

Note: pnpm emitted the existing unsupported Node engine warning because the local runtime is Node v25.9.0.