### PR TITLE
fix(docs): improve the refresh token ttl section wording

### DIFF
--- a/docs/integrate-logto/application-data-structure.mdx
+++ b/docs/integrate-logto/application-data-structure.mdx
@@ -167,7 +167,7 @@ The duration for which a refresh token can be used to request new access tokens 
 
 Typically, a lower value is preferred.
 
-Note: TTL refreshment is unavailable in SPA (single page app) for security reasons. This means Logto will not extend the TTL through token requests. To enhance the user experience, you can enable the "Rotate refresh token" feature, allowing Logto to issue a new refresh token when necessary.
+Note: TTL refreshment is unavailable in SPA (single page app) for security reasons. This means Logto will not extend the TTL through token requests, and refresh token rotation does not make SPA refresh tokens expire indefinitely. For non-SPA apps, you can enable the "Rotate refresh token" feature to let Logto issue a new refresh token when necessary.
 
 :::caution Refresh token and session binding
 When a refresh token is issued **without** the `offline_access` scope in the authorization request, it will be bound to the user session. The session has a fixed TTL of **14 days**. After the session expires, the refresh token becomes invalid regardless of its own TTL setting.

--- a/docs/integrate-logto/application-data-structure.mdx
+++ b/docs/integrate-logto/application-data-structure.mdx
@@ -167,7 +167,7 @@ The duration for which a refresh token can be used to request new access tokens 
 
 Typically, a lower value is preferred.
 
-Note: TTL refreshment is unavailable in SPA (single page app) for security reasons. This means Logto will not extend the TTL through token requests, and refresh token rotation does not make SPA refresh tokens expire indefinitely. For non-SPA apps, you can enable the "Rotate refresh token" feature to let Logto issue a new refresh token when necessary.
+Note: TTL refreshment is unavailable in SPA (single page app) for security reasons. This means Logto will not extend the TTL through token requests, and refresh token rotation does not make SPA refresh tokens expire indefinitely.
 
 :::caution Refresh token and session binding
 When a refresh token is issued **without** the `offline_access` scope in the authorization request, it will be bound to the user session. The session has a fixed TTL of **14 days**. After the session expires, the refresh token becomes invalid regardless of its own TTL setting.

--- a/docs/integrate-logto/application-data-structure.mdx
+++ b/docs/integrate-logto/application-data-structure.mdx
@@ -167,7 +167,9 @@ The duration for which a refresh token can be used to request new access tokens 
 
 Typically, a lower value is preferred.
 
-Note: TTL refreshment is unavailable in SPA (single page app) for security reasons. This means Logto will not extend the TTL through token requests, and refresh token rotation does not make SPA refresh tokens expire indefinitely.
+:::note
+TTL refreshment is unavailable in single-page applications (SPAs) for security reasons. This means Logto will not extend the TTL through token requests, and refresh token rotation does not prevent SPA refresh tokens from expiring.
+:::
 
 :::caution Refresh token and session binding
 When a refresh token is issued **without** the `offline_access` scope in the authorization request, it will be bound to the user session. The session has a fixed TTL of **14 days**. After the session expires, the refresh token becomes invalid regardless of its own TTL setting.


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Refine the refresh token TTL setting wording.  Since SPA does not support refresh token TTL renew, the original sentence is missleading. 