### PR TITLE
docs: clarify refresh token and grant TTL rules

### DIFF
--- a/docs/end-user-flows/sign-out.mdx
+++ b/docs/end-user-flows/sign-out.mdx
@@ -49,7 +49,7 @@ flowchart TD
   C --> D["Revoke centralized Logto session"]
   D --> E{"Check per-app grant"}
   E -->|"offline_access not granted"| F["Revoke grant"]
-  E -->|"offline_access granted"| G["Keep grant until grant TTL expires"]
+  E -->|"offline_access granted"| G["Keep grant until expiration or revocation"]
 ```
 
 During global sign-out:

--- a/docs/end-user-flows/sign-out.mdx
+++ b/docs/end-user-flows/sign-out.mdx
@@ -58,13 +58,14 @@ During global sign-out:
 - Related app grants are handled per app authorization state:
   - If `offline_access` is **not** granted, related grants are revoked.
   - If `offline_access` **is** granted, grants are not revoked by end-session.
-- For `offline_access` cases, refresh tokens and grants remain valid until grant expiration.
+- For `offline_access` cases, refresh tokens and grants remain valid until the earliest of grant expiration, refresh token expiration, or explicit revocation.
 
 ## Grant lifetime and `offline_access` impact \{#grant-lifetime-and-offline-access-impact}
 
 - Default Logto grant TTL is **180 days**.
 - If `offline_access` is granted, end-session does not revoke that app grant by default.
-- Refresh token chain associated with that grant can continue until the grant expires (or is explicitly revoked).
+- Refresh token chains associated with that grant can continue until the grant expires, the refresh token expires, or the grant is explicitly revoked.
+- For single page applications (SPAs), refresh token rotation does not extend the refresh token TTL, so the refresh token may expire before the grant does.
 
 ## Federated sign-out: back-channel logout \{#federated-sign-out-back-channel-logout}
 

--- a/docs/integrate-logto/application-data-structure.mdx
+++ b/docs/integrate-logto/application-data-structure.mdx
@@ -144,20 +144,20 @@ However, this practice is discouraged unless necessary (usually it's useful for 
 
 _Default: `true`_
 
-When enabled, Logto may issue a new refresh token when a client uses a refresh token to request new tokens. The default rotation policy is:
+When enabled, Logto may issue a new refresh token when a client uses a refresh token to request new tokens. If the refresh token and its app grant are still valid, the default rotation policy is:
 
-- Refresh tokens can be rotated only before the refresh token chain has existed for one year. After that, Logto no longer rotates the refresh token, and the current refresh token's expiration is final.
-- For non-sender-constrained public clients, such as Native applications and single page applications (SPAs), Logto rotates the refresh token on every refresh token request while rotation is allowed.
+- Refresh tokens can be rotated only before the refresh token chain has existed for one year. This is an internal rotation safety cap; the refresh token's own TTL or the app grant TTL may expire earlier. After the cap is reached, Logto no longer rotates the refresh token, and the current refresh token's expiration is final.
+- For public clients that do not use sender-constrained refresh tokens (for example, regular Native applications and single page applications), Logto rotates the refresh token on every refresh token request while rotation is allowed.
 - For other clients, Logto rotates the refresh token only when it is close to expiration (>=70% of its original Time to Live (TTL) has passed).
 
 :::note
 For public clients, it is highly recommended to keep refresh token rotation enabled for security reasons.
 
-For non-sender-constrained SPAs, rotation issues a new refresh token but does not extend the refresh token's lifetime. The new refresh token inherits the remaining TTL of the previous refresh token.
+Sender-constrained refresh tokens are bound to a client-held proof key or certificate. For regular SPAs, rotation issues a new refresh token but does not extend the refresh token's lifetime. The new refresh token inherits the remaining TTL of the previous refresh token.
 :::
 
 :::caution Refresh token chain lifetime
-Refresh tokens are associated with an app grant. The default Logto grant TTL is **180 days**. When the grant expires, the refresh token grant can no longer be used, even if refresh token rotation is enabled.
+Refresh tokens are associated with an app grant. The default Logto grant TTL is **180 days**. When the grant expires, refresh token requests fail and the refresh token can no longer be used to obtain new tokens, even if refresh token rotation is enabled.
 
 This means the practical maximum lifetime of a refresh-token-backed authorization is currently capped by the grant TTL, explicit revocation, or the refresh token's own expiration, whichever happens first.
 :::

--- a/docs/integrate-logto/application-data-structure.mdx
+++ b/docs/integrate-logto/application-data-structure.mdx
@@ -144,15 +144,22 @@ However, this practice is discouraged unless necessary (usually it's useful for 
 
 _Default: `true`_
 
-When enabled, Logto will issue a new refresh token for token requests under the following conditions:
+When enabled, Logto may issue a new refresh token when a client uses a refresh token to request new tokens. The default rotation policy is:
 
-- If the refresh token has been rotated (have its TTL prolonged by issuing a new one) for one year; **OR**
-- If the refresh token is close to its expiration time (>=70% of its original Time to Live (TTL) passed); **OR**
-- If the client is a public client, e.g. Native application or single page application (SPA).
+- Refresh tokens can be rotated only before the refresh token chain has existed for one year. After that, Logto no longer rotates the refresh token, and the current refresh token's expiration is final.
+- For non-sender-constrained public clients, such as Native applications and single page applications (SPAs), Logto rotates the refresh token on every refresh token request while rotation is allowed.
+- For other clients, Logto rotates the refresh token only when it is close to expiration (>=70% of its original Time to Live (TTL) has passed).
 
 :::note
-For public clients, when this feature is enabled, a new refresh token will always be issued when the client is exchanging for a new access token using the refresh token.
-Although you can still turn off the feature for those public clients, it is highly recommended to keep it enabled for security reasons.
+For public clients, it is highly recommended to keep refresh token rotation enabled for security reasons.
+
+For non-sender-constrained SPAs, rotation issues a new refresh token but does not extend the refresh token's lifetime. The new refresh token inherits the remaining TTL of the previous refresh token.
+:::
+
+:::caution Refresh token chain lifetime
+Refresh tokens are associated with an app grant. The default Logto grant TTL is **180 days**. When the grant expires, the refresh token grant can no longer be used, even if refresh token rotation is enabled.
+
+This means the practical maximum lifetime of a refresh-token-backed authorization is currently capped by the grant TTL, explicit revocation, or the refresh token's own expiration, whichever happens first.
 :::
 
 <Url href="https://blog.logto.io/understanding-refresh-token-rotation">
@@ -161,14 +168,20 @@ Although you can still turn off the feature for those public clients, it is high
 
 ### Refresh token time-to-live (TTL) in days \{#refresh-token-time-to-live-ttl-in-days}
 
-_Availability: Not SPA; Default: 14 days_
+_Availability: Native app, Traditional web, SPA; Default: 14 days; Maximum: 180 days_
 
 The duration for which a refresh token can be used to request new access tokens before it expires and becomes invalid. Token requests will extend the TTL of the refresh token to this value.
 
 Typically, a lower value is preferred.
 
 :::note
-TTL refreshment is unavailable in single-page applications (SPAs) for security reasons. This means Logto will not extend the TTL through token requests, and refresh token rotation does not prevent SPA refresh tokens from expiring.
+TTL refreshment is unavailable in single-page applications (SPAs) for security reasons. For SPAs, this setting controls the fixed refresh token lifetime from the original issuance time. Logto will not extend the TTL through token requests, and refresh token rotation does not prevent SPA refresh tokens from expiring.
+:::
+
+:::caution Refresh token TTL and grant TTL
+Refresh token TTL is not the only expiration limit. Refresh tokens are tied to an app grant, and the default Logto grant TTL is **180 days**. When the grant expires, refresh token requests fail even if the refresh token would otherwise still be valid.
+
+For clients where token requests refresh the refresh token TTL, the grant TTL acts as the absolute maximum lifetime for the refresh token chain. For SPAs, the refresh token's fixed TTL may expire before the grant does.
 :::
 
 :::caution Refresh token and session binding

--- a/docs/user-management/manage-users.mdx
+++ b/docs/user-management/manage-users.mdx
@@ -95,7 +95,7 @@ You cannot set a specific password for users in the Logto Console, but you can u
 On the "User details" page, navigate to the "Session details" page by clicking on the "Manage" button of a specific session. Here you can view detailed information about the session, such as the device, location, and login time. If you want to log out the user from this session, simply click the "Revoke session" button at the right top corner, and the session will be immediately revoked.
 
 - By default revoking a session on the Console will also revoke all the first-party app grants associated with that session, and the user will need to sign in again to restore access. Any pre-issued opaque access tokens and refresh tokens to first-party apps will also be revoked immediately.
-- For third-party apps with `offline_access` scope, revoking a session does not revoke the app grant by default, any pre-issued refresh tokens can still be used until the grant expires.
+- For third-party apps with the `offline_access` scope, revoking a session does not revoke the app grant by default. Any pre-issued refresh tokens can still be used until the earliest of grant expiration, refresh token expiration, or explicit revocation.
 
 ### Manage user authorized third-party apps \{#manage-user-authorized-third-party-apps}
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Clarify refresh-token, grant TTL, and rotation behavior across docs.

Updates sign-out flow to state that offline_access grants and refresh tokens remain valid only until the earliest of grant expiration, refresh token expiration, or explicit revocation, and notes SPAs may see refresh tokens expire before grants. 

Revise refresh-token-rotation policy to describe a one-year rotation cap, per-client rotation behavior (non-sender-constrained SPAs rotate on every refresh but do not extend TTL; other clients rotate near 70% TTL), and add cautions that grant TTL (default 180 days) is an absolute upper bound on refresh-token-backed authorization.

Also update TTL availability text and warnings about SPA limitations.
