### PR TITLE
docs: update Bring your UI CSP configuration

### DIFF
--- a/docs/customization/bring-your-ui/README.mdx
+++ b/docs/customization/bring-your-ui/README.mdx
@@ -55,6 +55,26 @@ Proceed with caution when using this feature in production, since it will immedi
 3. Once the upload is complete, save the changes, and your custom UI will be served immediately.
 4. The "Sign-in preview" window will be disabled when you use your custom sign-in UI. However, you can still click the "[Live preview](/customization/live-preview)" button to test your custom sign-in page in a new opened browser tab.
 
+### Configure custom CSP sources \{#configure-custom-csp-sources}
+
+Logto applies a Content Security Policy (CSP) header to custom UI pages. If your custom UI loads third-party scripts or connects to external services, add the extra source origins in <CloudLink to="/sign-in-experience/branding">Console > Sign-in & account > Branding > Bring your UI</CloudLink>.
+
+You can configure:
+
+- `script-src`: Allows JavaScript module or script sources, such as CAPTCHA, analytics, or tag manager providers.
+- `connect-src`: Allows network endpoints used by `fetch`, XMLHttpRequest, EventSource, and WebSocket connections.
+
+Example:
+
+```json
+{
+  "scriptSrc": ["https://scripts.example.com"],
+  "connectSrc": ["https://api.example.com", "wss://events.example.com"]
+}
+```
+
+Use HTTPS origins for both directives. `connect-src` also accepts `wss://` origins for WebSocket connections. Logto appends these sources to the existing security policy only when your custom UI assets are active.
+
 ## Develop your custom UI \{#develop-your-custom-ui}
 
 ### Interact with Experience API \{#interact-with-experience-api}

--- a/i18n/de/docusaurus-plugin-content-docs/current/customization/bring-your-ui/README.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/customization/bring-your-ui/README.mdx
@@ -55,6 +55,26 @@ Sei vorsichtig bei der Verwendung dieser Funktion in der Produktion, da sie sofo
 3. Nach Abschluss des Uploads speichere die Änderungen – deine eigene UI wird sofort bereitgestellt.
 4. Das Fenster „Anmeldevorschau“ ist deaktiviert, wenn du deine eigene Anmelde-UI verwendest. Du kannst jedoch weiterhin auf die Schaltfläche „[Live-Vorschau](/customization/live-preview)“ klicken, um deine eigene Anmeldeseite in einem neuen Browser-Tab zu testen.
 
+### Eigene CSP-Quellen konfigurieren \{#configure-custom-csp-sources}
+
+Logto wendet einen Content Security Policy (CSP)-Header auf eigene UI-Seiten an. Wenn deine eigene UI Drittanbieter-Skripte lädt oder Verbindungen zu externen Diensten herstellt, füge die zusätzlichen erlaubten Origins unter <CloudLink to="/sign-in-experience/branding">Konsole > Anmeldung & Konto > Branding > Eigene UI verwenden</CloudLink> hinzu.
+
+Du kannst Folgendes konfigurieren:
+
+- `script-src`: Erlaubt JavaScript module- oder script-Quellen, zum Beispiel CAPTCHA-, Analytics- oder Tag-Manager-Anbieter.
+- `connect-src`: Erlaubt Netzwerk-Endpunkte, die von `fetch`, XMLHttpRequest, EventSource und WebSocket-Verbindungen verwendet werden.
+
+Beispiel:
+
+```json
+{
+  "scriptSrc": ["https://scripts.example.com"],
+  "connectSrc": ["https://api.example.com", "wss://events.example.com"]
+}
+```
+
+Verwende HTTPS-Origins für beide directives. `connect-src` akzeptiert außerdem `wss://`-Origins für WebSocket-Verbindungen. Logto hängt diese Quellen nur dann an die bestehende Sicherheitsrichtlinie an, wenn deine eigenen UI-Assets aktiv sind.
+
 ## Entwickle deine eigene UI \{#develop-your-custom-ui}
 
 ### Interaktion mit Experience API \{#interact-with-experience-api}

--- a/i18n/es/docusaurus-plugin-content-docs/current/customization/bring-your-ui/README.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/current/customization/bring-your-ui/README.mdx
@@ -55,6 +55,26 @@ Procede con precaución al usar esta función en producción, ya que afectará i
 3. Una vez completada la carga, guarda los cambios y tu interfaz personalizada estará disponible de inmediato.
 4. La ventana de "Vista previa de inicio de sesión" se desactivará cuando uses tu propia interfaz de inicio de sesión. Sin embargo, aún puedes hacer clic en el botón "[Vista previa en vivo](/customization/live-preview)" para probar tu página de inicio de sesión personalizada en una nueva pestaña del navegador.
 
+### Configura fuentes CSP personalizadas \{#configure-custom-csp-sources}
+
+Logto aplica un encabezado Content Security Policy (CSP) a las páginas de interfaz personalizada. Si tu interfaz personalizada carga scripts de terceros o se conecta a servicios externos, agrega los origins adicionales permitidos en <CloudLink to="/sign-in-experience/branding">Console > Sign-in & account > Branding > Bring your UI</CloudLink>.
+
+Puedes configurar:
+
+- `script-src`: Permite orígenes de JavaScript module o script, como proveedores de CAPTCHA, analytics o tag manager.
+- `connect-src`: Permite endpoints de red usados por `fetch`, XMLHttpRequest, EventSource y conexiones WebSocket.
+
+Ejemplo:
+
+```json
+{
+  "scriptSrc": ["https://scripts.example.com"],
+  "connectSrc": ["https://api.example.com", "wss://events.example.com"]
+}
+```
+
+Usa origins HTTPS para ambas directives. `connect-src` también acepta origins `wss://` para conexiones WebSocket. Logto agrega estas fuentes a la política de seguridad existente solo cuando tus recursos de interfaz personalizada están activos.
+
 ## Desarrolla tu interfaz personalizada \{#develop-your-custom-ui}
 
 ### Interactúa con Experience API \{#interact-with-experience-api}

--- a/i18n/fr/docusaurus-plugin-content-docs/current/customization/bring-your-ui/README.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/customization/bring-your-ui/README.mdx
@@ -55,6 +55,26 @@ Procédez avec prudence lors de l'utilisation de cette fonctionnalité en produc
 3. Une fois le téléchargement terminé, enregistrez les modifications et votre interface personnalisée sera immédiatement servie.
 4. La fenêtre "Aperçu de la connexion" sera désactivée lorsque vous utilisez votre interface de connexion personnalisée. Cependant, vous pouvez toujours cliquer sur le bouton "[Aperçu en direct](/customization/live-preview)" pour tester votre page de connexion personnalisée dans un nouvel onglet du navigateur.
 
+### Configurer des sources CSP personnalisées \{#configure-custom-csp-sources}
+
+Logto applique un en-tête Content Security Policy (CSP) aux pages d'interface personnalisée. Si votre interface personnalisée charge des scripts tiers ou se connecte à des services externes, ajoutez les origins supplémentaires autorisées dans <CloudLink to="/sign-in-experience/branding">Console > Connexion & compte > Marque > Apportez votre interface</CloudLink>.
+
+Vous pouvez configurer:
+
+- `script-src`: Autorise les sources JavaScript module ou script, comme les fournisseurs CAPTCHA, analytics ou tag manager.
+- `connect-src`: Autorise les endpoints réseau utilisés par `fetch`, XMLHttpRequest, EventSource et les connexions WebSocket.
+
+Exemple:
+
+```json
+{
+  "scriptSrc": ["https://scripts.example.com"],
+  "connectSrc": ["https://api.example.com", "wss://events.example.com"]
+}
+```
+
+Utilisez des origins HTTPS pour les deux directives. `connect-src` accepte aussi les origins `wss://` pour les connexions WebSocket. Logto ajoute ces sources à la politique de sécurité existante uniquement lorsque vos ressources d'interface personnalisée sont actives.
+
 ## Développez votre interface personnalisée \{#develop-your-custom-ui}
 
 ### Interagir avec Experience API \{#interact-with-experience-api}

--- a/i18n/ja/docusaurus-plugin-content-docs/current/customization/bring-your-ui/README.mdx
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/customization/bring-your-ui/README.mdx
@@ -58,6 +58,26 @@ Logto プロジェクト全体は [pnpm モノレポ](https://pnpm.io/workspaces
 3. アップロードが完了したら変更を保存してください。カスタム UI が即座に提供されます。
 4. 独自のサインイン UI を使用している場合、「サインインプレビュー」ウィンドウは無効になります。ただし、 [ライブプレビュー](/customization/live-preview) ボタンをクリックして、新しいブラウザタブでカスタムサインインページをテストできます。
 
+### カスタム CSP ソースを設定する \{#configure-custom-csp-sources}
+
+Logto はカスタム UI ページに Content Security Policy (CSP) ヘッダーを適用します。カスタム UI がサードパーティスクリプトを読み込む場合や外部サービスへ接続する場合は、<CloudLink to="/sign-in-experience/branding">コンソール > サインイン & アカウント > ブランディング > 独自 UI の持ち込み</CloudLink> で追加の許可ソースを設定できます。
+
+設定できる項目:
+
+- `script-src`: CAPTCHA、分析ツール、タグマネージャーなどの JavaScript module または script のソースを許可します。
+- `connect-src`: `fetch`、XMLHttpRequest、EventSource、WebSocket 接続で使用するネットワークエンドポイントを許可します。
+
+例:
+
+```json
+{
+  "scriptSrc": ["https://scripts.example.com"],
+  "connectSrc": ["https://api.example.com", "wss://events.example.com"]
+}
+```
+
+どちらの directive も HTTPS origin を使用してください。WebSocket 接続の場合、`connect-src` は `wss://` origin も受け付けます。Logto はカスタム UI アセットが有効な場合にのみ、これらのソースを既存のセキュリティポリシーへ追加します。
+
 ## カスタム UI の開発 \{#develop-your-custom-ui}
 
 ### Experience API との連携 \{#interact-with-experience-api}

--- a/i18n/ko/docusaurus-plugin-content-docs/current/customization/bring-your-ui/README.mdx
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/customization/bring-your-ui/README.mdx
@@ -58,6 +58,26 @@ pnpm install && pnpm build
 3. 업로드가 완료되면 변경 사항을 저장하세요. 사용자 정의 UI가 즉시 적용됩니다.
 4. 사용자 정의 로그인 UI를 사용할 경우 "로그인 미리보기" 창은 비활성화됩니다. 하지만 "[라이브 미리보기](/customization/live-preview)" 버튼을 클릭하여 새 브라우저 탭에서 사용자 정의 로그인 페이지를 테스트할 수 있습니다.
 
+### 사용자 정의 CSP 소스 설정하기 \{#configure-custom-csp-sources}
+
+Logto는 사용자 정의 UI 페이지에 Content Security Policy (CSP) 헤더를 적용합니다. 사용자 정의 UI가 타사 스크립트를 로드하거나 외부 서비스에 연결해야 한다면 <CloudLink to="/sign-in-experience/branding">Console > 로그인 & 계정 > 브랜딩 > 나만의 UI 가져오기</CloudLink>에서 추가로 허용할 origin을 설정하세요.
+
+다음을 설정할 수 있습니다:
+
+- `script-src`: CAPTCHA, analytics, tag manager 제공자와 같은 JavaScript module 또는 script 소스를 허용합니다.
+- `connect-src`: `fetch`, XMLHttpRequest, EventSource, WebSocket 연결에서 사용하는 네트워크 엔드포인트를 허용합니다.
+
+예시:
+
+```json
+{
+  "scriptSrc": ["https://scripts.example.com"],
+  "connectSrc": ["https://api.example.com", "wss://events.example.com"]
+}
+```
+
+두 directive 모두 HTTPS origin을 사용하세요. WebSocket 연결의 경우 `connect-src`는 `wss://` origin도 허용합니다. Logto는 사용자 정의 UI 에셋이 활성화된 경우에만 이러한 소스를 기존 보안 정책에 추가합니다.
+
 ## 사용자 정의 UI 개발하기 \{#develop-your-custom-ui}
 
 ### Experience API와 상호작용하기 \{#interact-with-experience-api}

--- a/i18n/pt-BR/docusaurus-plugin-content-docs/current/customization/bring-your-ui/README.mdx
+++ b/i18n/pt-BR/docusaurus-plugin-content-docs/current/customization/bring-your-ui/README.mdx
@@ -55,6 +55,26 @@ Prossiga com cautela ao usar esse recurso em produção, pois ele afetará imedi
 3. Assim que o upload for concluído, salve as alterações e sua UI personalizada será disponibilizada imediatamente.
 4. A janela "Pré-visualização de login" será desativada quando você usar sua UI de login personalizada. No entanto, você ainda pode clicar no botão "[Pré-visualização ao vivo](/customization/live-preview)" para testar sua página de login personalizada em uma nova aba do navegador.
 
+### Configure fontes CSP personalizadas \{#configure-custom-csp-sources}
+
+O Logto aplica um cabeçalho Content Security Policy (CSP) às páginas de UI personalizada. Se sua UI personalizada carrega scripts de terceiros ou se conecta a serviços externos, adicione as origens extras permitidas em <CloudLink to="/sign-in-experience/branding">Console > Login & conta > Branding > Traga sua UI</CloudLink>.
+
+Você pode configurar:
+
+- `script-src`: Permite origens de JavaScript module ou script, como provedores de CAPTCHA, analytics ou tag manager.
+- `connect-src`: Permite endpoints de rede usados por `fetch`, XMLHttpRequest, EventSource e conexões WebSocket.
+
+Exemplo:
+
+```json
+{
+  "scriptSrc": ["https://scripts.example.com"],
+  "connectSrc": ["https://api.example.com", "wss://events.example.com"]
+}
+```
+
+Use origins HTTPS para ambas as directives. `connect-src` também aceita origins `wss://` para conexões WebSocket. O Logto adiciona essas fontes à política de segurança existente somente quando os ativos da UI personalizada estão ativos.
+
 ## Desenvolva sua UI personalizada \{#develop-your-custom-ui}
 
 ### Interaja com a Experience API \{#interact-with-experience-api}

--- a/i18n/th/docusaurus-plugin-content-docs/current/customization/bring-your-ui/README.mdx
+++ b/i18n/th/docusaurus-plugin-content-docs/current/customization/bring-your-ui/README.mdx
@@ -55,6 +55,26 @@ pnpm install && pnpm build
 3. เมื่ออัปโหลดเสร็จสิ้น ให้บันทึกการเปลี่ยนแปลง และ UI แบบกำหนดเองของคุณจะถูกใช้งานทันที
 4. หน้าต่าง "Sign-in preview" จะถูกปิดใช้งานเมื่อคุณใช้ UI ลงชื่อเข้าใช้แบบกำหนดเอง อย่างไรก็ตาม คุณยังสามารถคลิกปุ่ม "[Live preview](/customization/live-preview)" เพื่อทดสอบหน้าลงชื่อเข้าใช้แบบกำหนดเองในแท็บเบราว์เซอร์ใหม่ได้
 
+### กำหนดค่า CSP source แบบกำหนดเอง \{#configure-custom-csp-sources}
+
+Logto จะใช้ Content Security Policy (CSP) header กับหน้า UI แบบกำหนดเอง หาก UI แบบกำหนดเองของคุณโหลด script จาก third-party หรือเชื่อมต่อกับบริการภายนอก ให้เพิ่ม origin ที่อนุญาตเพิ่มเติมใน <CloudLink to="/sign-in-experience/branding">Console > Sign-in & account > Branding > Bring your UI</CloudLink>
+
+คุณสามารถกำหนดค่า:
+
+- `script-src`: อนุญาต source ของ JavaScript module หรือ script เช่น CAPTCHA, analytics หรือ tag manager provider
+- `connect-src`: อนุญาต network endpoint ที่ใช้โดย `fetch`, XMLHttpRequest, EventSource และการเชื่อมต่อ WebSocket
+
+ตัวอย่าง:
+
+```json
+{
+  "scriptSrc": ["https://scripts.example.com"],
+  "connectSrc": ["https://api.example.com", "wss://events.example.com"]
+}
+```
+
+ใช้ HTTPS origin สำหรับทั้งสอง directive สำหรับการเชื่อมต่อ WebSocket นั้น `connect-src` ยังรองรับ origin แบบ `wss://` ด้วย Logto จะเพิ่ม source เหล่านี้เข้าไปใน security policy เดิมเฉพาะเมื่อ custom UI assets ของคุณเปิดใช้งานอยู่เท่านั้น
+
 ## พัฒนา UI แบบกำหนดเองของคุณ \{#develop-your-custom-ui}
 
 ### โต้ตอบกับ Experience API \{#interact-with-experience-api}

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/customization/bring-your-ui/README.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/customization/bring-your-ui/README.mdx
@@ -55,6 +55,26 @@ pnpm install && pnpm build
 3. 上传完成后，保存更改，你的自定义 UI 将立即生效。
 4. 使用自定义登录 UI 时，“登录预览”窗口将被禁用。但你仍可点击“[实时预览](/customization/live-preview)”按钮，在新打开的浏览器标签页中测试你的自定义登录页面。
 
+### 配置自定义 CSP 来源 \{#configure-custom-csp-sources}
+
+Logto 会为自定义 UI 页面应用 Content Security Policy (CSP) header。如果你的自定义 UI 需要加载第三方脚本，或连接到外部服务，可以在 <CloudLink to="/sign-in-experience/branding">控制台 > 登录与账户 > 品牌定制 > 自定义你的 UI</CloudLink> 中添加额外允许的来源。
+
+你可以配置：
+
+- `script-src`：允许 JavaScript module 或 script 的来源，例如 CAPTCHA、分析工具或 tag manager 服务。
+- `connect-src`：允许 `fetch`、XMLHttpRequest、EventSource 和 WebSocket 连接使用的网络端点。
+
+示例：
+
+```json
+{
+  "scriptSrc": ["https://scripts.example.com"],
+  "connectSrc": ["https://api.example.com", "wss://events.example.com"]
+}
+```
+
+两个 directive 都应使用 HTTPS origin。对于 WebSocket 连接，`connect-src` 也支持 `wss://` origin。只有当自定义 UI 资源处于启用状态时，Logto 才会将这些来源追加到现有安全策略中。
+
 ## 开发你的自定义 UI \{#develop-your-custom-ui}
 
 ### 与 Experience API 交互 \{#interact-with-experience-api}

--- a/i18n/zh-TW/docusaurus-plugin-content-docs/current/customization/bring-your-ui/README.mdx
+++ b/i18n/zh-TW/docusaurus-plugin-content-docs/current/customization/bring-your-ui/README.mdx
@@ -55,6 +55,26 @@ pnpm install && pnpm build
 3. 上傳完成後，儲存變更，你的自訂 UI 將立即生效。
 4. 當你使用自訂登入 UI 時，「登入預覽」視窗將會停用。不過，你仍可點擊「[即時預覽](/customization/live-preview)」按鈕，在新開的瀏覽器分頁測試你的自訂登入頁面。
 
+### 設定自訂 CSP 來源 \{#configure-custom-csp-sources}
+
+Logto 會為自訂 UI 頁面套用 Content Security Policy (CSP) header。如果你的自訂 UI 需要載入第三方腳本，或連線到外部服務，可以在 <CloudLink to="/sign-in-experience/branding">Console > 登入與帳號 > 品牌設定 > 自訂你的 UI</CloudLink> 中新增額外允許的來源。
+
+你可以設定：
+
+- `script-src`：允許 JavaScript module 或 script 的來源，例如 CAPTCHA、分析工具或 tag manager 服務。
+- `connect-src`：允許 `fetch`、XMLHttpRequest、EventSource 和 WebSocket 連線使用的網路端點。
+
+範例：
+
+```json
+{
+  "scriptSrc": ["https://scripts.example.com"],
+  "connectSrc": ["https://api.example.com", "wss://events.example.com"]
+}
+```
+
+兩個 directive 都應使用 HTTPS origin。對於 WebSocket 連線，`connect-src` 也支援 `wss://` origin。只有當自訂 UI 資產處於啟用狀態時，Logto 才會將這些來源追加到現有安全策略中。
+
 ## 開發你的自訂 UI \{#develop-your-custom-ui}
 
 ### 與 Experience API 互動 \{#interact-with-experience-api}


### PR DESCRIPTION
## Summary
Update the Bring your UI documentation to describe custom CSP source configuration for custom UI pages.

The new section explains how to configure `script-src` and `connect-src`, includes a JSON example, and notes HTTPS and WebSocket source requirements. Existing localized Bring your UI pages are updated with the same guidance.

## Testing
N/A

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
