### PR TITLE
docs: document --dapc seed flag for air-gapped OSS installs

### DIFF
--- a/docs/logto-oss/deployment-and-configuration.mdx
+++ b/docs/logto-oss/deployment-and-configuration.mdx
@@ -110,7 +110,7 @@ Refer to the [Logto CLI](/logto-oss/using-cli) for more details.
 
 :::tip Air-gapped or offline installs
 
-If your deployment environment cannot reach `api.pwnedpasswords.com`, append `--dapc` to the seed command so the first admin sign-up does not hang on the HaveIBeenPwned breach check. See [Seed for air-gapped or offline deployments](/logto-oss/using-cli#seed-for-air-gapped-or-offline-deployments) for details.
+If your deployment environment cannot reach `api.pwnedpasswords.com`, append `--disable-admin-pwned-password-check` to the seed command so the first admin sign-up does not hang on the Have I Been Pwned breach check. See [Seed for air-gapped or offline deployments](/logto-oss/using-cli#seed-for-air-gapped-or-offline-deployments) for details.
 
 :::
 

--- a/docs/logto-oss/deployment-and-configuration.mdx
+++ b/docs/logto-oss/deployment-and-configuration.mdx
@@ -108,6 +108,12 @@ npm run cli db seed -- --swe
 
 Refer to the [Logto CLI](/logto-oss/using-cli) for more details.
 
+:::tip Air-gapped or offline installs
+
+If your deployment environment cannot reach `api.pwnedpasswords.com`, append `--dapc` to the seed command so the first admin sign-up does not hang on the HaveIBeenPwned breach check. See [Seed for air-gapped or offline deployments](/logto-oss/using-cli#seed-for-air-gapped-or-offline-deployments) for details.
+
+:::
+
 ### Shared connectors folder \{#shared-connectors-folder}
 
 By default, Logto will create a `connectors` folder in the root directory of the `core` folder. We recommend sharing the folder between multiple instances of Logto, you need to mount the `packages/core/connectors` folder to the container and run `npm run cli connector add -- --official` to deploy the connectors.

--- a/docs/logto-oss/deployment-and-configuration.mdx
+++ b/docs/logto-oss/deployment-and-configuration.mdx
@@ -110,7 +110,7 @@ Refer to the [Logto CLI](/logto-oss/using-cli) for more details.
 
 :::tip Air-gapped or offline installs
 
-If your deployment environment cannot reach `api.pwnedpasswords.com`, append `--disable-admin-pwned-password-check` to the seed command so the first admin sign-up does not hang on the Have I Been Pwned breach check. See [Seed for air-gapped or offline deployments](/logto-oss/using-cli#seed-for-air-gapped-or-offline-deployments) for details.
+If your deployment environment cannot reach `api.pwnedpasswords.com`, append `--disable-admin-pwned-password-check` to either `logto init` or `npm run cli db seed` so the first admin sign-up does not hang on the Have I Been Pwned breach check. See [Seed for air-gapped or offline deployments](/logto-oss/using-cli#seed-for-air-gapped-or-offline-deployments) for details.
 
 :::
 

--- a/docs/logto-oss/using-cli/README.mdx
+++ b/docs/logto-oss/using-cli/README.mdx
@@ -90,7 +90,7 @@ Since Logto v1.40.0, both the `init` (install) and `db seed` commands accept an 
 
 When set, the seeded password policy on the **admin tenant** disables the [Have I Been Pwned (HIBP)](https://haveibeenpwned.com/) breach check by default. This means creating the initial admin from the Welcome page no longer hangs when `api.pwnedpasswords.com` is unreachable (for example in air-gapped data centers or behind strict egress firewalls).
 
-The flag is scoped to the admin tenant only — the default tenant's password policy is left untouched, and stays under your control through Admin Console > **Sign-in experience** > **Password policy** after the first admin signs in.
+The flag is scoped to the admin tenant only. The default tenant's password policy is left untouched, and stays under your control through Admin Console > **Sign-in experience** > **Password policy** after the first admin signs in.
 
 **One-step install** (recommended for fresh OSS deployments):
 
@@ -141,4 +141,4 @@ npx @logto/cli db seed --disable-admin-pwned-password-check
 
 </Tabs>
 
-Both `--dapc` and `--disable-admin-pwned-password-check` are accepted — they are aliases of each other.
+`--dapc` and `--disable-admin-pwned-password-check` are aliases; either one works.

--- a/docs/logto-oss/using-cli/README.mdx
+++ b/docs/logto-oss/using-cli/README.mdx
@@ -79,3 +79,45 @@ This will be helpful for one-off invocations, e.g.:
 ```bash
 npx @logto/cli db seed --db-url postgresql://your-database-url
 ```
+
+### Seed for air-gapped or offline deployments \{#seed-for-air-gapped-or-offline-deployments}
+
+Since Logto v1.40.0, the `db seed` command accepts an extra flag for environments that cannot reach the public internet during installation:
+
+```bash
+--dapc, --disable-admin-pwned-password-check
+```
+
+When set, the seeded `sign_in_experiences.password_policy` row for the **admin tenant** is `{"rejects": {"pwned": false}}` instead of the default `{}`. This skips the [HaveIBeenPwned (HIBP)](https://haveibeenpwned.com/) password breach check during the first admin sign-up, so creating the initial admin from the Welcome page no longer hangs when `api.pwnedpasswords.com` is unreachable (for example in air-gapped data centers or behind strict egress firewalls).
+
+The flag is scoped to the admin tenant only — the default tenant's password policy is left untouched, and stays under your control through Admin Console > **Sign-in experience** > **Password policy** after the first admin signs in. From the Admin Console you can also re-enable the HIBP check on the admin tenant at any time.
+
+Example:
+
+<Tabs groupId="cmd">
+
+  <TabItem value="cli" label="CLI">
+
+```bash
+logto db seed --dapc
+```
+
+  </TabItem>
+  <TabItem value="npm" label="npm">
+
+```bash
+npm run cli db seed -- --dapc
+```
+
+  </TabItem>
+  <TabItem value="npx" label="npx">
+
+```bash
+npx @logto/cli db seed --dapc
+```
+
+  </TabItem>
+
+</Tabs>
+
+The long alias `--disable-admin-pwned-password-check` is accepted as a more explicit equivalent in scripts.

--- a/docs/logto-oss/using-cli/README.mdx
+++ b/docs/logto-oss/using-cli/README.mdx
@@ -90,7 +90,7 @@ Since Logto v1.40.0, both the `init` (install) and `db seed` commands accept an 
 
 When set, the seeded password policy on the **admin tenant** disables the [Have I Been Pwned (HIBP)](https://haveibeenpwned.com/) breach check by default. This means creating the initial admin from the Welcome page no longer hangs when `api.pwnedpasswords.com` is unreachable (for example in air-gapped data centers or behind strict egress firewalls).
 
-The flag is scoped to the admin tenant only — the default tenant's password policy is left untouched, and stays under your control through Admin Console > **Sign-in experience** > **Password policy** after the first admin signs in. From the Admin Console you can also re-enable the HIBP check on the admin tenant at any time.
+The flag is scoped to the admin tenant only — the default tenant's password policy is left untouched, and stays under your control through Admin Console > **Sign-in experience** > **Password policy** after the first admin signs in.
 
 **One-step install** (recommended for fresh OSS deployments):
 
@@ -141,4 +141,4 @@ npx @logto/cli db seed --disable-admin-pwned-password-check
 
 </Tabs>
 
-The short alias `--dapc` is accepted as an equivalent for terser scripts.
+Both `--dapc` and `--disable-admin-pwned-password-check` are accepted — they are aliases of each other.

--- a/docs/logto-oss/using-cli/README.mdx
+++ b/docs/logto-oss/using-cli/README.mdx
@@ -110,6 +110,13 @@ npm init @logto@latest -- --disable-admin-pwned-password-check
 ```
 
   </TabItem>
+  <TabItem value="npx" label="npx">
+
+```bash
+npx @logto/cli init --disable-admin-pwned-password-check
+```
+
+  </TabItem>
 
 </Tabs>
 

--- a/docs/logto-oss/using-cli/README.mdx
+++ b/docs/logto-oss/using-cli/README.mdx
@@ -85,10 +85,10 @@ npx @logto/cli db seed --db-url postgresql://your-database-url
 Since Logto v1.40.0, the `db seed` command accepts an extra flag for environments that cannot reach the public internet during installation:
 
 ```bash
---dapc, --disable-admin-pwned-password-check
+--disable-admin-pwned-password-check, --dapc
 ```
 
-When set, the seeded `sign_in_experiences.password_policy` row for the **admin tenant** is `{"rejects": {"pwned": false}}` instead of the default `{}`. This skips the [HaveIBeenPwned (HIBP)](https://haveibeenpwned.com/) password breach check during the first admin sign-up, so creating the initial admin from the Welcome page no longer hangs when `api.pwnedpasswords.com` is unreachable (for example in air-gapped data centers or behind strict egress firewalls).
+When set, the seeded password policy on the **admin tenant** disables the [Have I Been Pwned (HIBP)](https://haveibeenpwned.com/) breach check by default. This means creating the initial admin from the Welcome page no longer hangs when `api.pwnedpasswords.com` is unreachable (for example in air-gapped data centers or behind strict egress firewalls).
 
 The flag is scoped to the admin tenant only — the default tenant's password policy is left untouched, and stays under your control through Admin Console > **Sign-in experience** > **Password policy** after the first admin signs in. From the Admin Console you can also re-enable the HIBP check on the admin tenant at any time.
 
@@ -99,25 +99,25 @@ Example:
   <TabItem value="cli" label="CLI">
 
 ```bash
-logto db seed --dapc
+logto db seed --disable-admin-pwned-password-check
 ```
 
   </TabItem>
   <TabItem value="npm" label="npm">
 
 ```bash
-npm run cli db seed -- --dapc
+npm run cli db seed -- --disable-admin-pwned-password-check
 ```
 
   </TabItem>
   <TabItem value="npx" label="npx">
 
 ```bash
-npx @logto/cli db seed --dapc
+npx @logto/cli db seed --disable-admin-pwned-password-check
 ```
 
   </TabItem>
 
 </Tabs>
 
-The long alias `--disable-admin-pwned-password-check` is accepted as a more explicit equivalent in scripts.
+The short alias `--dapc` is accepted as an equivalent for terser scripts.

--- a/docs/logto-oss/using-cli/README.mdx
+++ b/docs/logto-oss/using-cli/README.mdx
@@ -82,7 +82,7 @@ npx @logto/cli db seed --db-url postgresql://your-database-url
 
 ### Seed for air-gapped or offline deployments \{#seed-for-air-gapped-or-offline-deployments}
 
-Since Logto v1.40.0, the `db seed` command accepts an extra flag for environments that cannot reach the public internet during installation:
+Since Logto v1.40.0, both the `init` (install) and `db seed` commands accept an extra flag for environments that cannot reach the public internet during installation:
 
 ```bash
 --disable-admin-pwned-password-check, --dapc
@@ -92,7 +92,28 @@ When set, the seeded password policy on the **admin tenant** disables the [Have 
 
 The flag is scoped to the admin tenant only — the default tenant's password policy is left untouched, and stays under your control through Admin Console > **Sign-in experience** > **Password policy** after the first admin signs in. From the Admin Console you can also re-enable the HIBP check on the admin tenant at any time.
 
-Example:
+**One-step install** (recommended for fresh OSS deployments):
+
+<Tabs groupId="cmd">
+
+  <TabItem value="cli" label="CLI">
+
+```bash
+logto init --disable-admin-pwned-password-check
+```
+
+  </TabItem>
+  <TabItem value="npm" label="npm">
+
+```bash
+npm init @logto@latest -- --disable-admin-pwned-password-check
+```
+
+  </TabItem>
+
+</Tabs>
+
+**Seed an existing database** (when Logto is already extracted, or when re-seeding):
 
 <Tabs groupId="cmd">
 

--- a/docs/logto-oss/using-cli/install-logto.mdx
+++ b/docs/logto-oss/using-cli/install-logto.mdx
@@ -33,17 +33,16 @@ npm init @logto@latest
 
 ## Options and silent installation \{#options-and-silent-installation}
 
-Alternatively, you can add the options below to skip some questions:
+Alternatively, you can add any of the options below (all optional) to skip some questions:
 
-```bash
-# All these options are optional
---db-url                                    The Postgres URL to Logto database
--p, --path                                  Path to your Logto instance, must be a non-existing path
---ss                                        Skip Logto database seeding
---disable-admin-pwned-password-check, --dapc  Seed the admin tenant with the Have I Been Pwned (HIBP) password breach check disabled (for air-gapped or offline deployments)
-```
+| Option                                         | Description                                                                                                                                                                                                                                       |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--db-url`                                     | The Postgres URL to Logto database.                                                                                                                                                                                                               |
+| `-p, --path`                                   | Path to your Logto instance, must be a non-existing path.                                                                                                                                                                                         |
+| `--ss`                                         | Skip Logto database seeding.                                                                                                                                                                                                                      |
+| `--disable-admin-pwned-password-check, --dapc` | Seed the admin tenant with the Have I Been Pwned (HIBP) password breach check disabled, for air-gapped or offline deployments. See [Seed for air-gapped or offline deployments](/logto-oss/using-cli#seed-for-air-gapped-or-offline-deployments). |
 
-Run `logto init --help` for full help info. For the `--disable-admin-pwned-password-check` flag, see [Seed for air-gapped or offline deployments](/logto-oss/using-cli#seed-for-air-gapped-or-offline-deployments).
+Run `logto init --help` for full help info.
 
 Here's an example for performing a silent installation (e.g., in CI):
 

--- a/docs/logto-oss/using-cli/install-logto.mdx
+++ b/docs/logto-oss/using-cli/install-logto.mdx
@@ -37,10 +37,11 @@ Alternatively, you can add the options below to skip some questions:
 
 ```bash
 # All these options are optional
---db-url      The Postgres URL to Logto database
--p, --path    Path to your Logto instance, must be a non-existing path
---ss          Skip Logto database seeding
---oc          Add official connectors after installation
+--db-url                                    The Postgres URL to Logto database
+-p, --path                                  Path to your Logto instance, must be a non-existing path
+--ss                                        Skip Logto database seeding
+--oc                                        Add official connectors after installation
+--disable-admin-pwned-password-check, --dapc  Seed the admin tenant with the Have I Been Pwned (HIBP) password breach check disabled (for air-gapped or offline deployments). See [Seed for air-gapped or offline deployments](/logto-oss/using-cli#seed-for-air-gapped-or-offline-deployments).
 ```
 
 Run `logto init --help` for full help info.

--- a/docs/logto-oss/using-cli/install-logto.mdx
+++ b/docs/logto-oss/using-cli/install-logto.mdx
@@ -40,10 +40,10 @@ Alternatively, you can add the options below to skip some questions:
 --db-url                                    The Postgres URL to Logto database
 -p, --path                                  Path to your Logto instance, must be a non-existing path
 --ss                                        Skip Logto database seeding
---disable-admin-pwned-password-check, --dapc  Seed the admin tenant with the Have I Been Pwned (HIBP) password breach check disabled (for air-gapped or offline deployments). See [Seed for air-gapped or offline deployments](/logto-oss/using-cli#seed-for-air-gapped-or-offline-deployments).
+--disable-admin-pwned-password-check, --dapc  Seed the admin tenant with the Have I Been Pwned (HIBP) password breach check disabled (for air-gapped or offline deployments)
 ```
 
-Run `logto init --help` for full help info.
+Run `logto init --help` for full help info. For the `--disable-admin-pwned-password-check` flag, see [Seed for air-gapped or offline deployments](/logto-oss/using-cli#seed-for-air-gapped-or-offline-deployments).
 
 Here's an example for performing a silent installation (e.g., in CI):
 

--- a/docs/logto-oss/using-cli/install-logto.mdx
+++ b/docs/logto-oss/using-cli/install-logto.mdx
@@ -40,7 +40,6 @@ Alternatively, you can add the options below to skip some questions:
 --db-url                                    The Postgres URL to Logto database
 -p, --path                                  Path to your Logto instance, must be a non-existing path
 --ss                                        Skip Logto database seeding
---oc                                        Add official connectors after installation
 --disable-admin-pwned-password-check, --dapc  Seed the admin tenant with the Have I Been Pwned (HIBP) password breach check disabled (for air-gapped or offline deployments). See [Seed for air-gapped or offline deployments](/logto-oss/using-cli#seed-for-air-gapped-or-offline-deployments).
 ```
 


### PR DESCRIPTION
## Summary

Documents the new `db seed --disable-admin-pwned-password-check` (alias `--dapc`) flag added to `@logto/cli` in [logto-io/logto#8859](https://github.com/logto-io/logto/pull/8859). The flag pre-disables the Have I Been Pwned (HIBP) breach check on the admin tenant, unblocking first-admin sign-up for OSS deployments that cannot reach `api.pwnedpasswords.com` (air-gapped data centers, strict egress firewalls).

Files updated:

- `docs/logto-oss/using-cli/README.mdx` — new section "Seed for air-gapped or offline deployments" describing the flag, its scope (admin tenant only), and how to re-enable HIBP later from the Admin Console > Sign-in experience > Password policy.
- `docs/logto-oss/deployment-and-configuration.mdx` — short admonition under "Database setup" cross-referencing the new CLI section so air-gapped operators see the flag while planning their Postgres setup.

Only English docs are updated. Translated copies under `i18n/` are left to the regular translation pipeline.

## Testing

Tested locally

## Checklist

- [ ] `.changeset` (only when explicitly required)
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments

