### PR TITLE
docs: document Protected App ID token claims configuration

### DIFF
--- a/docs/integrate-logto/protected-app.mdx
+++ b/docs/integrate-logto/protected-app.mdx
@@ -175,13 +175,13 @@ By default, the `Logto-ID-Token` header includes standard OIDC claims (for examp
 
 Extended claims are included in the forwarded ID token only when the claim is enabled in Custom JWT and the corresponding scope is selected for the Protected App. See [Custom ID token](/developers/custom-id-token) for the full list of extended scopes and claims.
 
-| Scope                                | Claims                         |
-| ------------------------------------ | ------------------------------ |
-| `custom_data`                        | `custom_data`                  |
-| `identities`                         | `identities`, `sso_identities` |
-| `roles`                              | `roles`                        |
+| Scope                                | Claims                               |
+| ------------------------------------ | ------------------------------------ |
+| `custom_data`                        | `custom_data`                        |
+| `identities`                         | `identities`, `sso_identities`       |
+| `roles`                              | `roles`                              |
 | `urn:logto:scope:organizations`      | `organizations`, `organization_data` |
-| `urn:logto:scope:organization_roles` | `organization_roles`           |
+| `urn:logto:scope:organization_roles` | `organization_roles`                 |
 
 ## Get the original host \{#get-the-original-host}
 

--- a/docs/integrate-logto/protected-app.mdx
+++ b/docs/integrate-logto/protected-app.mdx
@@ -166,6 +166,23 @@ app.get('/', (req, res) => {
 app.listen(3000);
 ```
 
+## Customize ID token claims \{#customize-id-token-claims}
+
+By default, the `Logto-ID-Token` header includes standard OIDC claims (for example `sub`, `name`, and `email`). To include [extended claims](/developers/custom-id-token#extended-claims) such as roles or organization data, both of the following must be configured:
+
+1. **Tenant toggle**: Enable the claim in <CloudLink to="/customize-jwt">Console > Custom JWT > ID token</CloudLink>.
+2. **Protected App scopes**: In your Protected App settings, select the matching scope under **ID token claims** > **Additional scopes**.
+
+Extended claims are included in the forwarded ID token only when the claim is enabled in Custom JWT and the corresponding scope is selected for the Protected App. See [Custom ID token](/developers/custom-id-token) for the full list of extended scopes and claims.
+
+| Scope                                | Claims                         |
+| ------------------------------------ | ------------------------------ |
+| `custom_data`                        | `custom_data`                  |
+| `identities`                         | `identities`, `sso_identities` |
+| `roles`                              | `roles`                        |
+| `urn:logto:scope:organizations`      | `organizations`, `organization_data` |
+| `urn:logto:scope:organization_roles` | `organization_roles`           |
+
 ## Get the original host \{#get-the-original-host}
 
 If you need to get the original host requested by the client, you can use the `Logto-Host` or `x-forwarded-host` header.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Document the Protected App **ID token claims** / **Additional scopes** feature from [logto-io/logto#8798](https://github.com/logto-io/logto/pull/8798).

Adds a new section to the Protected App guide explaining the dual-condition model (Custom JWT toggle + Protected App scope selection) and lists the available extended scopes.

No doc changes for [#8808](https://github.com/logto-io/logto/pull/8808) (app secret fix) or [#8828](https://github.com/logto-io/logto/pull/8828) (custom domain fix) — both are internal bug fixes with no user-facing behavior change beyond existing docs.

## Testing

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f50f0eea-aa16-477e-962d-771701cdaf1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f50f0eea-aa16-477e-962d-771701cdaf1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

