### PR TITLE
docs: add organization context to custom token claims

### DIFF
--- a/docs/developers/custom-token-claims/create-script.mdx
+++ b/docs/developers/custom-token-claims/create-script.mdx
@@ -86,6 +86,18 @@ The context object contains the user data and grant data that relevant to the cu
 
 - **User data object**
   For user access token, Logto provides additional user data context for you to access. The user data object contains all the user profile data and organization membership data you may need to set up the custom claims. Please check [Users](/user-management/user-data) and [Organizations](/organizations/organization-management#organization-data-structure) for more details.
+- **Organization data object**
+  For [organization access tokens](/authorization/organization-template) (an access token requested for a specific organization), Logto provides the target organization through `context.organization`, so you can attach per-organization claims—for example, mapping the Logto organization ID to an internal ID stored in the organization's custom data. This data object is only present when the token is issued for a specific organization, and contains:
+
+  | Property      | Description                         | Type                      |
+  | ------------- | ----------------------------------- | ------------------------- |
+  | `id`          | The unique organization id          | `string`                  |
+  | `name`        | The organization name               | `string`                  |
+  | `description` | The organization description        | `string \| null`          |
+  | `customData`  | The custom data of the organization | `Record<string, unknown>` |
+
+  Please check [Organizations](/organizations/organization-management#organization-data-structure) for more details.
+
 - **Grant data object**
   For user access token granted by impersonation token exchange, Logto provides additional grant data context for you to access. The grant data object contains the custom context from the subject token. Please check [Impersonation](/developers/user-impersonation) for more details.
 - **User interaction data object**


### PR DESCRIPTION
## Summary

Documents the new **organization context** exposed to the custom JWT / custom token claims script.

In [Create a custom access token script](https://docs.logto.io/developers/custom-token-claims/create-script#context-only-available-for-user-access-token), the `context` section now lists an **Organization data object** alongside the existing user / grant / user-interaction objects. For organization access tokens, the script receives the target organization via `context.organization` (`id`, `name`, `description`, `customData`), so authors can attach per-organization claims — e.g. mapping the Logto organization ID to an internal ID stored in the organization's custom data.

## Notes

- This documents the feature added in logto-io/logto#9069, which is currently behind the `isDevFeaturesEnabled` flag. Hold/merge this to line up with that feature's release.
- Both internal links resolve to existing pages (`/authorization/organization-template`, `/organizations/organization-management#organization-data-structure`).
- Translations are left to the docs translation flow.
