### PR TITLE
docs: update Swift SDK integration guide

### DIFF
--- a/docs/quick-starts/framework/swift/_add-sdk.mdx
+++ b/docs/quick-starts/framework/swift/_add-sdk.mdx
@@ -1,3 +1,17 @@
+import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs';
+
+:::note
+The minimum supported iOS version of Logto Swift SDK is iOS 13.
+:::
+
+Logto Swift SDK comes in two major versions:
+
+- **v1**: Opens the sign-in experience in an embedded WebView, which is required by the native social plugin targets, but does not support <MainSiteUrl href="/end-user-flows/sign-up-and-sign-in/passkey-sign-in">passkey sign-in</MainSiteUrl> (WebView does not support WebAuthn, the underlying standard of passkeys).
+- **v2 (beta)**: Opens the sign-in experience in [`ASWebAuthenticationSession`](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession) (the system browser), which unlocks passkey sign-in and shares the browser session. Note that v2 removes the native social plugin targets; social connectors still work through the browser. If you depend on the native WeChat or Alipay SDK handoff, stay on v1.
+
+This guide covers both versions. Choose your version in the tabs below, and the choice will be kept in sync throughout this guide.
+
 Use the following URL to add Logto SDK as a dependency in Swift Package Manager.
 
 ```bash
@@ -5,6 +19,36 @@ https://github.com/logto-io/swift.git
 ```
 
 Since Xcode 11, you can [directly import a Swift package](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) w/o any additional tool.
+
+When Xcode asks for the package version, choose the version you want to integrate:
+
+<Tabs groupId="swift-sdk-version" defaultValue="v2">
+
+<TabItem value="v2" label="v2 (beta)">
+
+v2 is released as `2.0.0-beta.x` prereleases until GA. Use `2.0.0-beta.1` or the latest `2.0.0-beta.x` prerelease as the version. During beta, we recommend selecting the prerelease explicitly instead of relying on a normal version range to pick it automatically.
+
+If you use `Package.swift` directly:
+
+```swift title="Package.swift"
+.package(url: "https://github.com/logto-io/swift.git", exact: "2.0.0-beta.1")
+```
+
+</TabItem>
+
+<TabItem value="v1" label="v1">
+
+Use the latest v1 release as the stable line. The latest v1 version is `1.2.0`.
+
+If you use `Package.swift` directly:
+
+```swift title="Package.swift"
+.package(url: "https://github.com/logto-io/swift.git", from: "1.2.0")
+```
+
+</TabItem>
+
+</Tabs>
 
 We do not support **Carthage** and **CocoaPods** at the time due to some technical issues.
 
@@ -16,8 +60,7 @@ We do not support **Carthage** and **CocoaPods** at the time due to some technic
 
 </summary>
 
-Carthage [needs a `xcodeproj` file to build](https://github.com/Carthage/Carthage/issues/1226#issuecomment-290931385), but `swift package generate-xcodeproj` will report a failure since we are using binary targets
-for native social plugins. We will try to find a workaround later.
+Carthage [needs a `xcodeproj` file to build](https://github.com/Carthage/Carthage/issues/1226#issuecomment-290931385). We will try to find a workaround later.
 
 </details>
 

--- a/docs/quick-starts/framework/swift/_implement-sign-in-and-sign-out.mdx
+++ b/docs/quick-starts/framework/swift/_implement-sign-in-and-sign-out.mdx
@@ -1,3 +1,6 @@
+import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs';
+
 import ConfigureRedirectUri from '../../fragments/_configure-redirect-uri.mdx';
 import SignInNote from '../../fragments/_sign-in-note.mdx';
 import SignInFlowSummary from '../../fragments/_web-sign-in-flow-summary.mdx';
@@ -5,6 +8,61 @@ import SignInFlowSummary from '../../fragments/_web-sign-in-flow-summary.mdx';
 <SignInFlowSummary />
 
 #### Configure redirect URI \{#configure-redirect-uri}
+
+<Tabs groupId="swift-sdk-version" defaultValue="v2">
+
+<TabItem value="v2" label="v2 (beta)">
+
+<ConfigureRedirectUri
+  figureSrc="/img/assets/ios-redirect-uri.png"
+  redirectUri="io.logto.app://callback"
+/>
+
+In v2, the sign-in experience opens in [`ASWebAuthenticationSession`](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession) (the system browser), and the redirect is routed back to your app through OS-level callback matching. For a custom scheme redirect URI such as `io.logto.app://callback`, register only the scheme part (`io.logto.app`) in your app's `Info.plist`, then add the full redirect URI to your Logto application's Redirect URIs.
+
+In Xcode, open your app target, select **Info**, expand **URL Types**, and add one entry with `io.logto.app` in **URL Schemes**. If you edit `Info.plist` directly, add:
+
+```xml title="Info.plist"
+<key>CFBundleURLTypes</key>
+<array>
+  <dict>
+    <key>CFBundleTypeRole</key>
+    <string>Editor</string>
+    <key>CFBundleURLName</key>
+    <string>io.logto.app</string>
+    <key>CFBundleURLSchemes</key>
+    <array>
+      <string>io.logto.app</string>
+    </array>
+  </dict>
+</array>
+```
+
+For the browser flow in v2, you do not need to call `LogtoClient.handle(url:)`; that plugin handoff API was removed with the embedded WebView flow.
+
+<details>
+
+<summary>
+
+#### Use Universal Links instead of a custom scheme? \{#use-universal-links-instead-of-a-custom-scheme}
+
+</summary>
+
+You can also use an HTTPS redirect URI such as `https://example.com/callback`:
+
+1. Add the Associated Domains capability to your app.
+2. Configure `webcredentials:example.com` so `ASWebAuthenticationSession` can match HTTPS callbacks on iOS 17.4 and newer.
+3. If the same URL should also open your app as a Universal Link outside the authentication session, configure `applinks:example.com` and host a valid `apple-app-site-association` file for the domain and path.
+4. Add the HTTPS URI to your Logto application's Redirect URIs.
+5. Pass the same URI to `signInWithBrowser`.
+
+On iOS 17.4 and newer, the SDK uses `ASWebAuthenticationSession`'s HTTPS callback matching API so HTTPS redirects can automatically complete and dismiss the session. On older iOS versions, the authorization request can still use the HTTPS redirect URI, but the session may not close automatically unless your app handles the Universal Link callback itself. Keep a custom scheme redirect as a compatibility option if you need automatic completion on older iOS versions.
+
+</details>
+
+</TabItem>
+
+<TabItem value="v1" label="v1">
 
 <ConfigureRedirectUri
   figureSrc="/img/assets/ios-redirect-uri.png"
@@ -15,9 +73,75 @@ import SignInFlowSummary from '../../fragments/_web-sign-in-flow-summary.mdx';
 The Redirect URI in iOS SDK is only for internal use. There's _NO NEED_ to add a [Custom URL Scheme](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app) until a connector asks.
 :::
 
+</TabItem>
+
+</Tabs>
+
 #### Sign-in and sign-out \{#sign-in-and-sign-out}
 
 <SignInNote calling=".signInWithBrowser(redirectUri:)" />
+
+<Tabs groupId="swift-sdk-version" defaultValue="v2">
+
+<TabItem value="v2" label="v2 (beta)">
+
+In v2, `client.signOut(postLogoutRedirectUri:)` performs a complete sign-out: it clears the local credentials, revokes the refresh token, and ends the Logto session by opening the end session endpoint in the system browser. The browser then navigates back to your app through the post sign-out redirect URI. Before using it, switch to the application details page of Logto Console, add the post sign-out redirect URI `io.logto.app://signed-out` and click "Save changes". The post sign-out redirect URI can use the same custom scheme you registered for sign-in.
+
+For example, in a SwiftUI app:
+
+```swift title="ContentView.swift"
+struct ContentView: View {
+  @State var isAuthenticated: Bool
+
+  private let redirectUri = "io.logto.app://callback"
+  private let postLogoutRedirectUri = "io.logto.app://signed-out"
+
+  init() {
+    isAuthenticated = client.isAuthenticated
+  }
+
+  var body: some View {
+    VStack {
+      if isAuthenticated {
+        Button("Sign Out") {
+          Task { [self] in
+            let error = await client.signOut(postLogoutRedirectUri: postLogoutRedirectUri)
+            if let error = error {
+              print(error)
+              return
+            }
+            isAuthenticated = false
+          }
+        }
+      } else {
+        Button("Sign In") {
+          Task { [self] in
+            do {
+              try await client.signInWithBrowser(redirectUri: redirectUri)
+              isAuthenticated = true
+            } catch let error as LogtoClientErrors.SignIn {
+              // error occurred during sign in
+            } catch {
+              // other errors
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+:::note
+
+- You can also call `client.signOut()` without a post sign-out redirect URI. No Console configuration is needed in this case: the browser shows the Logto sign-out page, and the user returns to the app by dismissing it manually.
+- If no UI context is available, you can call `client.clearCredentials()` to clear the local credentials and revoke the refresh token. Note that this keeps the Logto session in the browser, so the next `signInWithBrowser` may silently sign the user back in through that session.
+
+:::
+
+</TabItem>
+
+<TabItem value="v1" label="v1">
 
 You can use `client.signInWithBrowser(redirectUri:)` to sign in the user and `client.signOut()` to sign out the user.
 
@@ -44,12 +168,10 @@ struct ContentView: View {
         Button("Sign In") {
           Task { [self] in
             do {
-              try await client.signInWithBrowser(redirectUri: "${
-                props.redirectUris[0] ?? 'io.logto://callback'
-              }")
+              try await client.signInWithBrowser(redirectUri: "io.logto://callback")
               isAuthenticated = true
             } catch let error as LogtoClientErrors.SignIn {
-              // error occured during sign in
+              // error occurred during sign in
             } catch {
               // other errors
             }
@@ -60,3 +182,7 @@ struct ContentView: View {
   }
 }
 ```
+
+</TabItem>
+
+</Tabs>

--- a/i18n/de/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_add-sdk.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_add-sdk.mdx
@@ -1,12 +1,56 @@
-Verwende die folgende URL, um Logto SDK als Abhängigkeit im Swift Package Manager hinzuzufügen.
+import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs';
+
+:::note
+The minimum supported iOS version of Logto Swift SDK is iOS 13.
+:::
+
+Logto Swift SDK comes in two major versions:
+
+- **v1**: Opens the sign-in experience in an embedded WebView, which is required by the native social plugin targets, but does not support <MainSiteUrl href="/end-user-flows/sign-up-and-sign-in/passkey-sign-in">passkey sign-in</MainSiteUrl> (WebView does not support WebAuthn, the underlying standard of passkeys).
+- **v2 (beta)**: Opens the sign-in experience in [`ASWebAuthenticationSession`](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession) (the system browser), which unlocks passkey sign-in and shares the browser session. Note that v2 removes the native social plugin targets; social connectors still work through the browser. If you depend on the native WeChat or Alipay SDK handoff, stay on v1.
+
+This guide covers both versions. Choose your version in the tabs below, and the choice will be kept in sync throughout this guide.
+
+Use the following URL to add Logto SDK as a dependency in Swift Package Manager.
 
 ```bash
 https://github.com/logto-io/swift.git
 ```
 
-Seit Xcode 11 kannst du [ein Swift-Paket direkt importieren](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) ohne zusätzliche Tools.
+Since Xcode 11, you can [directly import a Swift package](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) w/o any additional tool.
 
-Wir unterstützen derzeit **Carthage** und **CocoaPods** aufgrund einiger technischer Probleme nicht.
+When Xcode asks for the package version, choose the version you want to integrate:
+
+<Tabs groupId="swift-sdk-version" defaultValue="v2">
+
+<TabItem value="v2" label="v2 (beta)">
+
+v2 is released as `2.0.0-beta.x` prereleases until GA. Use `2.0.0-beta.1` or the latest `2.0.0-beta.x` prerelease as the version. During beta, we recommend selecting the prerelease explicitly instead of relying on a normal version range to pick it automatically.
+
+If you use `Package.swift` directly:
+
+```swift title="Package.swift"
+.package(url: "https://github.com/logto-io/swift.git", exact: "2.0.0-beta.1")
+```
+
+</TabItem>
+
+<TabItem value="v1" label="v1">
+
+Use the latest v1 release as the stable line. The latest v1 version is `1.2.0`.
+
+If you use `Package.swift` directly:
+
+```swift title="Package.swift"
+.package(url: "https://github.com/logto-io/swift.git", from: "1.2.0")
+```
+
+</TabItem>
+
+</Tabs>
+
+We do not support **Carthage** and **CocoaPods** at the time due to some technical issues.
 
 <details>
 
@@ -16,7 +60,7 @@ Wir unterstützen derzeit **Carthage** und **CocoaPods** aufgrund einiger techni
 
 </summary>
 
-Carthage [benötigt eine `xcodeproj`-Datei zum Bauen](https://github.com/Carthage/Carthage/issues/1226#issuecomment-290931385), aber `swift package generate-xcodeproj` wird einen Fehler melden, da wir binäre Ziele für native soziale Plugins verwenden. Wir werden versuchen, später eine Lösung zu finden.
+Carthage [needs a `xcodeproj` file to build](https://github.com/Carthage/Carthage/issues/1226#issuecomment-290931385). We will try to find a workaround later.
 
 </details>
 
@@ -28,6 +72,6 @@ Carthage [benötigt eine `xcodeproj`-Datei zum Bauen](https://github.com/Carthag
 
 </summary>
 
-CocoaPods [unterstützt keine lokale Abhängigkeit](https://github.com/CocoaPods/CocoaPods/issues/3276) und Monorepo, daher ist es schwierig, ein `.podspec` für dieses Repository zu erstellen.
+CocoaPods [does not support local dependency](https://github.com/CocoaPods/CocoaPods/issues/3276) and monorepo, thus it&apos;s hard to create a `.podspec` for this repo.
 
 </details>

--- a/i18n/de/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_implement-sign-in-and-sign-out.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_implement-sign-in-and-sign-out.mdx
@@ -1,10 +1,68 @@
+import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs';
+
 import ConfigureRedirectUri from '../../fragments/_configure-redirect-uri.mdx';
 import SignInNote from '../../fragments/_sign-in-note.mdx';
 import SignInFlowSummary from '../../fragments/_web-sign-in-flow-summary.mdx';
 
 <SignInFlowSummary />
 
-#### Redirect-URI konfigurieren \{#configure-redirect-uri}
+#### Configure redirect URI \{#configure-redirect-uri}
+
+<Tabs groupId="swift-sdk-version" defaultValue="v2">
+
+<TabItem value="v2" label="v2 (beta)">
+
+<ConfigureRedirectUri
+  figureSrc="/img/assets/ios-redirect-uri.png"
+  redirectUri="io.logto.app://callback"
+/>
+
+In v2, the sign-in experience opens in [`ASWebAuthenticationSession`](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession) (the system browser), and the redirect is routed back to your app through OS-level callback matching. For a custom scheme redirect URI such as `io.logto.app://callback`, register only the scheme part (`io.logto.app`) in your app's `Info.plist`, then add the full redirect URI to your Logto application's Redirect URIs.
+
+In Xcode, open your app target, select **Info**, expand **URL Types**, and add one entry with `io.logto.app` in **URL Schemes**. If you edit `Info.plist` directly, add:
+
+```xml title="Info.plist"
+<key>CFBundleURLTypes</key>
+<array>
+  <dict>
+    <key>CFBundleTypeRole</key>
+    <string>Editor</string>
+    <key>CFBundleURLName</key>
+    <string>io.logto.app</string>
+    <key>CFBundleURLSchemes</key>
+    <array>
+      <string>io.logto.app</string>
+    </array>
+  </dict>
+</array>
+```
+
+For the browser flow in v2, you do not need to call `LogtoClient.handle(url:)`; that plugin handoff API was removed with the embedded WebView flow.
+
+<details>
+
+<summary>
+
+#### Use Universal Links instead of a custom scheme? \{#use-universal-links-instead-of-a-custom-scheme}
+
+</summary>
+
+You can also use an HTTPS redirect URI such as `https://example.com/callback`:
+
+1. Add the Associated Domains capability to your app.
+2. Configure `webcredentials:example.com` so `ASWebAuthenticationSession` can match HTTPS callbacks on iOS 17.4 and newer.
+3. If the same URL should also open your app as a Universal Link outside the authentication session, configure `applinks:example.com` and host a valid `apple-app-site-association` file for the domain and path.
+4. Add the HTTPS URI to your Logto application's Redirect URIs.
+5. Pass the same URI to `signInWithBrowser`.
+
+On iOS 17.4 and newer, the SDK uses `ASWebAuthenticationSession`'s HTTPS callback matching API so HTTPS redirects can automatically complete and dismiss the session. On older iOS versions, the authorization request can still use the HTTPS redirect URI, but the session may not close automatically unless your app handles the Universal Link callback itself. Keep a custom scheme redirect as a compatibility option if you need automatic completion on older iOS versions.
+
+</details>
+
+</TabItem>
+
+<TabItem value="v1" label="v1">
 
 <ConfigureRedirectUri
   figureSrc="/img/assets/ios-redirect-uri.png"
@@ -12,16 +70,82 @@ import SignInFlowSummary from '../../fragments/_web-sign-in-flow-summary.mdx';
 />
 
 :::info
-Die Redirect-URI im iOS SDK ist nur für den internen Gebrauch. Es besteht _KEINE NOTWENDIGKEIT_, ein [Custom URL Scheme](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app) hinzuzufügen, bis ein Connector dies verlangt.
+The Redirect URI in iOS SDK is only for internal use. There's _NO NEED_ to add a [Custom URL Scheme](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app) until a connector asks.
 :::
 
-#### Anmelden und Abmelden \{#sign-in-and-sign-out}
+</TabItem>
+
+</Tabs>
+
+#### Sign-in and sign-out \{#sign-in-and-sign-out}
 
 <SignInNote calling=".signInWithBrowser(redirectUri:)" />
 
-Du kannst `client.signInWithBrowser(redirectUri:)` verwenden, um den Benutzer anzumelden, und `client.signOut()`, um den Benutzer abzumelden.
+<Tabs groupId="swift-sdk-version" defaultValue="v2">
 
-Zum Beispiel in einer SwiftUI-App:
+<TabItem value="v2" label="v2 (beta)">
+
+In v2, `client.signOut(postLogoutRedirectUri:)` performs a complete sign-out: it clears the local credentials, revokes the refresh token, and ends the Logto session by opening the end session endpoint in the system browser. The browser then navigates back to your app through the post sign-out redirect URI. Before using it, switch to the application details page of Logto Console, add the post sign-out redirect URI `io.logto.app://signed-out` and click "Save changes". The post sign-out redirect URI can use the same custom scheme you registered for sign-in.
+
+For example, in a SwiftUI app:
+
+```swift title="ContentView.swift"
+struct ContentView: View {
+  @State var isAuthenticated: Bool
+
+  private let redirectUri = "io.logto.app://callback"
+  private let postLogoutRedirectUri = "io.logto.app://signed-out"
+
+  init() {
+    isAuthenticated = client.isAuthenticated
+  }
+
+  var body: some View {
+    VStack {
+      if isAuthenticated {
+        Button("Sign Out") {
+          Task { [self] in
+            let error = await client.signOut(postLogoutRedirectUri: postLogoutRedirectUri)
+            if let error = error {
+              print(error)
+              return
+            }
+            isAuthenticated = false
+          }
+        }
+      } else {
+        Button("Sign In") {
+          Task { [self] in
+            do {
+              try await client.signInWithBrowser(redirectUri: redirectUri)
+              isAuthenticated = true
+            } catch let error as LogtoClientErrors.SignIn {
+              // error occurred during sign in
+            } catch {
+              // other errors
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+:::note
+
+- You can also call `client.signOut()` without a post sign-out redirect URI. No Console configuration is needed in this case: the browser shows the Logto sign-out page, and the user returns to the app by dismissing it manually.
+- If no UI context is available, you can call `client.clearCredentials()` to clear the local credentials and revoke the refresh token. Note that this keeps the Logto session in the browser, so the next `signInWithBrowser` may silently sign the user back in through that session.
+
+:::
+
+</TabItem>
+
+<TabItem value="v1" label="v1">
+
+You can use `client.signInWithBrowser(redirectUri:)` to sign in the user and `client.signOut()` to sign out the user.
+
+For example, in a SwiftUI app:
 
 ```swift title="ContentView.swift"
 struct ContentView: View {
@@ -34,24 +158,22 @@ struct ContentView: View {
   var body: some View {
     VStack {
       if isAuthenticated {
-        Button("Abmelden") {
+        Button("Sign Out") {
           Task { [self] in
             await client.signOut()
             isAuthenticated = false
           }
         }
       } else {
-        Button("Anmelden") {
+        Button("Sign In") {
           Task { [self] in
             do {
-              try await client.signInWithBrowser(redirectUri: "${
-                props.redirectUris[0] ?? 'io.logto://callback'
-              }")
+              try await client.signInWithBrowser(redirectUri: "io.logto://callback")
               isAuthenticated = true
             } catch let error as LogtoClientErrors.SignIn {
-              // Fehler trat während der Anmeldung auf
+              // error occurred during sign in
             } catch {
-              // andere Fehler
+              // other errors
             }
           }
         }
@@ -60,3 +182,7 @@ struct ContentView: View {
   }
 }
 ```
+
+</TabItem>
+
+</Tabs>

--- a/i18n/es/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_add-sdk.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_add-sdk.mdx
@@ -1,12 +1,56 @@
-Utiliza la siguiente URL para agregar Logto SDK como una dependencia en Swift Package Manager.
+import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs';
+
+:::note
+The minimum supported iOS version of Logto Swift SDK is iOS 13.
+:::
+
+Logto Swift SDK comes in two major versions:
+
+- **v1**: Opens the sign-in experience in an embedded WebView, which is required by the native social plugin targets, but does not support <MainSiteUrl href="/end-user-flows/sign-up-and-sign-in/passkey-sign-in">passkey sign-in</MainSiteUrl> (WebView does not support WebAuthn, the underlying standard of passkeys).
+- **v2 (beta)**: Opens the sign-in experience in [`ASWebAuthenticationSession`](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession) (the system browser), which unlocks passkey sign-in and shares the browser session. Note that v2 removes the native social plugin targets; social connectors still work through the browser. If you depend on the native WeChat or Alipay SDK handoff, stay on v1.
+
+This guide covers both versions. Choose your version in the tabs below, and the choice will be kept in sync throughout this guide.
+
+Use the following URL to add Logto SDK as a dependency in Swift Package Manager.
 
 ```bash
 https://github.com/logto-io/swift.git
 ```
 
-Desde Xcode 11, puedes [importar directamente un paquete Swift](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) sin ninguna herramienta adicional.
+Since Xcode 11, you can [directly import a Swift package](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) w/o any additional tool.
 
-No admitimos **Carthage** y **CocoaPods** en este momento debido a algunos problemas técnicos.
+When Xcode asks for the package version, choose the version you want to integrate:
+
+<Tabs groupId="swift-sdk-version" defaultValue="v2">
+
+<TabItem value="v2" label="v2 (beta)">
+
+v2 is released as `2.0.0-beta.x` prereleases until GA. Use `2.0.0-beta.1` or the latest `2.0.0-beta.x` prerelease as the version. During beta, we recommend selecting the prerelease explicitly instead of relying on a normal version range to pick it automatically.
+
+If you use `Package.swift` directly:
+
+```swift title="Package.swift"
+.package(url: "https://github.com/logto-io/swift.git", exact: "2.0.0-beta.1")
+```
+
+</TabItem>
+
+<TabItem value="v1" label="v1">
+
+Use the latest v1 release as the stable line. The latest v1 version is `1.2.0`.
+
+If you use `Package.swift` directly:
+
+```swift title="Package.swift"
+.package(url: "https://github.com/logto-io/swift.git", from: "1.2.0")
+```
+
+</TabItem>
+
+</Tabs>
+
+We do not support **Carthage** and **CocoaPods** at the time due to some technical issues.
 
 <details>
 
@@ -16,7 +60,7 @@ No admitimos **Carthage** y **CocoaPods** en este momento debido a algunos probl
 
 </summary>
 
-Carthage [necesita un archivo `xcodeproj` para compilar](https://github.com/Carthage/Carthage/issues/1226#issuecomment-290931385), pero `swift package generate-xcodeproj` reportará un error ya que estamos utilizando objetivos binarios para plugins sociales nativos. Intentaremos encontrar una solución más adelante.
+Carthage [needs a `xcodeproj` file to build](https://github.com/Carthage/Carthage/issues/1226#issuecomment-290931385). We will try to find a workaround later.
 
 </details>
 
@@ -28,6 +72,6 @@ Carthage [necesita un archivo `xcodeproj` para compilar](https://github.com/Cart
 
 </summary>
 
-CocoaPods [no admite dependencias locales](https://github.com/CocoaPods/CocoaPods/issues/3276) y monorepo, por lo tanto, es difícil crear un `.podspec` para este repositorio.
+CocoaPods [does not support local dependency](https://github.com/CocoaPods/CocoaPods/issues/3276) and monorepo, thus it&apos;s hard to create a `.podspec` for this repo.
 
 </details>

--- a/i18n/es/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_implement-sign-in-and-sign-out.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_implement-sign-in-and-sign-out.mdx
@@ -1,10 +1,68 @@
+import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs';
+
 import ConfigureRedirectUri from '../../fragments/_configure-redirect-uri.mdx';
 import SignInNote from '../../fragments/_sign-in-note.mdx';
 import SignInFlowSummary from '../../fragments/_web-sign-in-flow-summary.mdx';
 
 <SignInFlowSummary />
 
-#### Configurar URI de redirección \{#configure-redirect-uri}
+#### Configure redirect URI \{#configure-redirect-uri}
+
+<Tabs groupId="swift-sdk-version" defaultValue="v2">
+
+<TabItem value="v2" label="v2 (beta)">
+
+<ConfigureRedirectUri
+  figureSrc="/img/assets/ios-redirect-uri.png"
+  redirectUri="io.logto.app://callback"
+/>
+
+In v2, the sign-in experience opens in [`ASWebAuthenticationSession`](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession) (the system browser), and the redirect is routed back to your app through OS-level callback matching. For a custom scheme redirect URI such as `io.logto.app://callback`, register only the scheme part (`io.logto.app`) in your app's `Info.plist`, then add the full redirect URI to your Logto application's Redirect URIs.
+
+In Xcode, open your app target, select **Info**, expand **URL Types**, and add one entry with `io.logto.app` in **URL Schemes**. If you edit `Info.plist` directly, add:
+
+```xml title="Info.plist"
+<key>CFBundleURLTypes</key>
+<array>
+  <dict>
+    <key>CFBundleTypeRole</key>
+    <string>Editor</string>
+    <key>CFBundleURLName</key>
+    <string>io.logto.app</string>
+    <key>CFBundleURLSchemes</key>
+    <array>
+      <string>io.logto.app</string>
+    </array>
+  </dict>
+</array>
+```
+
+For the browser flow in v2, you do not need to call `LogtoClient.handle(url:)`; that plugin handoff API was removed with the embedded WebView flow.
+
+<details>
+
+<summary>
+
+#### Use Universal Links instead of a custom scheme? \{#use-universal-links-instead-of-a-custom-scheme}
+
+</summary>
+
+You can also use an HTTPS redirect URI such as `https://example.com/callback`:
+
+1. Add the Associated Domains capability to your app.
+2. Configure `webcredentials:example.com` so `ASWebAuthenticationSession` can match HTTPS callbacks on iOS 17.4 and newer.
+3. If the same URL should also open your app as a Universal Link outside the authentication session, configure `applinks:example.com` and host a valid `apple-app-site-association` file for the domain and path.
+4. Add the HTTPS URI to your Logto application's Redirect URIs.
+5. Pass the same URI to `signInWithBrowser`.
+
+On iOS 17.4 and newer, the SDK uses `ASWebAuthenticationSession`'s HTTPS callback matching API so HTTPS redirects can automatically complete and dismiss the session. On older iOS versions, the authorization request can still use the HTTPS redirect URI, but the session may not close automatically unless your app handles the Universal Link callback itself. Keep a custom scheme redirect as a compatibility option if you need automatic completion on older iOS versions.
+
+</details>
+
+</TabItem>
+
+<TabItem value="v1" label="v1">
 
 <ConfigureRedirectUri
   figureSrc="/img/assets/ios-redirect-uri.png"
@@ -12,16 +70,82 @@ import SignInFlowSummary from '../../fragments/_web-sign-in-flow-summary.mdx';
 />
 
 :::info
-El URI de redirección en iOS SDK es solo para uso interno. _NO HAY NECESIDAD_ de agregar un [Esquema de URL personalizado](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app) hasta que un conector lo solicite.
+The Redirect URI in iOS SDK is only for internal use. There's _NO NEED_ to add a [Custom URL Scheme](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app) until a connector asks.
 :::
 
-#### Inicio y cierre de sesión \{#sign-in-and-sign-out}
+</TabItem>
+
+</Tabs>
+
+#### Sign-in and sign-out \{#sign-in-and-sign-out}
 
 <SignInNote calling=".signInWithBrowser(redirectUri:)" />
 
-Puedes usar `client.signInWithBrowser(redirectUri:)` para iniciar sesión del usuario y `client.signOut()` para cerrar sesión del usuario.
+<Tabs groupId="swift-sdk-version" defaultValue="v2">
 
-Por ejemplo, en una aplicación SwiftUI:
+<TabItem value="v2" label="v2 (beta)">
+
+In v2, `client.signOut(postLogoutRedirectUri:)` performs a complete sign-out: it clears the local credentials, revokes the refresh token, and ends the Logto session by opening the end session endpoint in the system browser. The browser then navigates back to your app through the post sign-out redirect URI. Before using it, switch to the application details page of Logto Console, add the post sign-out redirect URI `io.logto.app://signed-out` and click "Save changes". The post sign-out redirect URI can use the same custom scheme you registered for sign-in.
+
+For example, in a SwiftUI app:
+
+```swift title="ContentView.swift"
+struct ContentView: View {
+  @State var isAuthenticated: Bool
+
+  private let redirectUri = "io.logto.app://callback"
+  private let postLogoutRedirectUri = "io.logto.app://signed-out"
+
+  init() {
+    isAuthenticated = client.isAuthenticated
+  }
+
+  var body: some View {
+    VStack {
+      if isAuthenticated {
+        Button("Sign Out") {
+          Task { [self] in
+            let error = await client.signOut(postLogoutRedirectUri: postLogoutRedirectUri)
+            if let error = error {
+              print(error)
+              return
+            }
+            isAuthenticated = false
+          }
+        }
+      } else {
+        Button("Sign In") {
+          Task { [self] in
+            do {
+              try await client.signInWithBrowser(redirectUri: redirectUri)
+              isAuthenticated = true
+            } catch let error as LogtoClientErrors.SignIn {
+              // error occurred during sign in
+            } catch {
+              // other errors
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+:::note
+
+- You can also call `client.signOut()` without a post sign-out redirect URI. No Console configuration is needed in this case: the browser shows the Logto sign-out page, and the user returns to the app by dismissing it manually.
+- If no UI context is available, you can call `client.clearCredentials()` to clear the local credentials and revoke the refresh token. Note that this keeps the Logto session in the browser, so the next `signInWithBrowser` may silently sign the user back in through that session.
+
+:::
+
+</TabItem>
+
+<TabItem value="v1" label="v1">
+
+You can use `client.signInWithBrowser(redirectUri:)` to sign in the user and `client.signOut()` to sign out the user.
+
+For example, in a SwiftUI app:
 
 ```swift title="ContentView.swift"
 struct ContentView: View {
@@ -34,24 +158,22 @@ struct ContentView: View {
   var body: some View {
     VStack {
       if isAuthenticated {
-        Button("Cerrar sesión") {
+        Button("Sign Out") {
           Task { [self] in
             await client.signOut()
             isAuthenticated = false
           }
         }
       } else {
-        Button("Iniciar sesión") {
+        Button("Sign In") {
           Task { [self] in
             do {
-              try await client.signInWithBrowser(redirectUri: "${
-                props.redirectUris[0] ?? 'io.logto://callback'
-              }")
+              try await client.signInWithBrowser(redirectUri: "io.logto://callback")
               isAuthenticated = true
             } catch let error as LogtoClientErrors.SignIn {
-              // error ocurrido durante el inicio de sesión
+              // error occurred during sign in
             } catch {
-              // otros errores
+              // other errors
             }
           }
         }
@@ -60,3 +182,7 @@ struct ContentView: View {
   }
 }
 ```
+
+</TabItem>
+
+</Tabs>

--- a/i18n/fr/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_add-sdk.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_add-sdk.mdx
@@ -1,12 +1,56 @@
-Utilisez l'URL suivante pour ajouter Logto SDK comme dépendance dans Swift Package Manager.
+import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs';
+
+:::note
+The minimum supported iOS version of Logto Swift SDK is iOS 13.
+:::
+
+Logto Swift SDK comes in two major versions:
+
+- **v1**: Opens the sign-in experience in an embedded WebView, which is required by the native social plugin targets, but does not support <MainSiteUrl href="/end-user-flows/sign-up-and-sign-in/passkey-sign-in">passkey sign-in</MainSiteUrl> (WebView does not support WebAuthn, the underlying standard of passkeys).
+- **v2 (beta)**: Opens the sign-in experience in [`ASWebAuthenticationSession`](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession) (the system browser), which unlocks passkey sign-in and shares the browser session. Note that v2 removes the native social plugin targets; social connectors still work through the browser. If you depend on the native WeChat or Alipay SDK handoff, stay on v1.
+
+This guide covers both versions. Choose your version in the tabs below, and the choice will be kept in sync throughout this guide.
+
+Use the following URL to add Logto SDK as a dependency in Swift Package Manager.
 
 ```bash
 https://github.com/logto-io/swift.git
 ```
 
-Depuis Xcode 11, vous pouvez [importer directement un package Swift](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) sans aucun outil supplémentaire.
+Since Xcode 11, you can [directly import a Swift package](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) w/o any additional tool.
 
-Nous ne prenons pas en charge **Carthage** et **CocoaPods** pour le moment en raison de certains problèmes techniques.
+When Xcode asks for the package version, choose the version you want to integrate:
+
+<Tabs groupId="swift-sdk-version" defaultValue="v2">
+
+<TabItem value="v2" label="v2 (beta)">
+
+v2 is released as `2.0.0-beta.x` prereleases until GA. Use `2.0.0-beta.1` or the latest `2.0.0-beta.x` prerelease as the version. During beta, we recommend selecting the prerelease explicitly instead of relying on a normal version range to pick it automatically.
+
+If you use `Package.swift` directly:
+
+```swift title="Package.swift"
+.package(url: "https://github.com/logto-io/swift.git", exact: "2.0.0-beta.1")
+```
+
+</TabItem>
+
+<TabItem value="v1" label="v1">
+
+Use the latest v1 release as the stable line. The latest v1 version is `1.2.0`.
+
+If you use `Package.swift` directly:
+
+```swift title="Package.swift"
+.package(url: "https://github.com/logto-io/swift.git", from: "1.2.0")
+```
+
+</TabItem>
+
+</Tabs>
+
+We do not support **Carthage** and **CocoaPods** at the time due to some technical issues.
 
 <details>
 
@@ -16,7 +60,7 @@ Nous ne prenons pas en charge **Carthage** et **CocoaPods** pour le moment en ra
 
 </summary>
 
-Carthage [nécessite un fichier `xcodeproj` pour construire](https://github.com/Carthage/Carthage/issues/1226#issuecomment-290931385), mais `swift package generate-xcodeproj` signalera un échec car nous utilisons des cibles binaires pour les plugins sociaux natifs. Nous essaierons de trouver une solution plus tard.
+Carthage [needs a `xcodeproj` file to build](https://github.com/Carthage/Carthage/issues/1226#issuecomment-290931385). We will try to find a workaround later.
 
 </details>
 
@@ -28,6 +72,6 @@ Carthage [nécessite un fichier `xcodeproj` pour construire](https://github.com/
 
 </summary>
 
-CocoaPods [ne prend pas en charge la dépendance locale](https://github.com/CocoaPods/CocoaPods/issues/3276) et le monorepo, il est donc difficile de créer un `.podspec` pour ce dépôt.
+CocoaPods [does not support local dependency](https://github.com/CocoaPods/CocoaPods/issues/3276) and monorepo, thus it&apos;s hard to create a `.podspec` for this repo.
 
 </details>

--- a/i18n/fr/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_implement-sign-in-and-sign-out.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_implement-sign-in-and-sign-out.mdx
@@ -1,10 +1,68 @@
+import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs';
+
 import ConfigureRedirectUri from '../../fragments/_configure-redirect-uri.mdx';
 import SignInNote from '../../fragments/_sign-in-note.mdx';
 import SignInFlowSummary from '../../fragments/_web-sign-in-flow-summary.mdx';
 
 <SignInFlowSummary />
 
-#### Configurer l'URI de redirection \{#configure-redirect-uri}
+#### Configure redirect URI \{#configure-redirect-uri}
+
+<Tabs groupId="swift-sdk-version" defaultValue="v2">
+
+<TabItem value="v2" label="v2 (beta)">
+
+<ConfigureRedirectUri
+  figureSrc="/img/assets/ios-redirect-uri.png"
+  redirectUri="io.logto.app://callback"
+/>
+
+In v2, the sign-in experience opens in [`ASWebAuthenticationSession`](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession) (the system browser), and the redirect is routed back to your app through OS-level callback matching. For a custom scheme redirect URI such as `io.logto.app://callback`, register only the scheme part (`io.logto.app`) in your app's `Info.plist`, then add the full redirect URI to your Logto application's Redirect URIs.
+
+In Xcode, open your app target, select **Info**, expand **URL Types**, and add one entry with `io.logto.app` in **URL Schemes**. If you edit `Info.plist` directly, add:
+
+```xml title="Info.plist"
+<key>CFBundleURLTypes</key>
+<array>
+  <dict>
+    <key>CFBundleTypeRole</key>
+    <string>Editor</string>
+    <key>CFBundleURLName</key>
+    <string>io.logto.app</string>
+    <key>CFBundleURLSchemes</key>
+    <array>
+      <string>io.logto.app</string>
+    </array>
+  </dict>
+</array>
+```
+
+For the browser flow in v2, you do not need to call `LogtoClient.handle(url:)`; that plugin handoff API was removed with the embedded WebView flow.
+
+<details>
+
+<summary>
+
+#### Use Universal Links instead of a custom scheme? \{#use-universal-links-instead-of-a-custom-scheme}
+
+</summary>
+
+You can also use an HTTPS redirect URI such as `https://example.com/callback`:
+
+1. Add the Associated Domains capability to your app.
+2. Configure `webcredentials:example.com` so `ASWebAuthenticationSession` can match HTTPS callbacks on iOS 17.4 and newer.
+3. If the same URL should also open your app as a Universal Link outside the authentication session, configure `applinks:example.com` and host a valid `apple-app-site-association` file for the domain and path.
+4. Add the HTTPS URI to your Logto application's Redirect URIs.
+5. Pass the same URI to `signInWithBrowser`.
+
+On iOS 17.4 and newer, the SDK uses `ASWebAuthenticationSession`'s HTTPS callback matching API so HTTPS redirects can automatically complete and dismiss the session. On older iOS versions, the authorization request can still use the HTTPS redirect URI, but the session may not close automatically unless your app handles the Universal Link callback itself. Keep a custom scheme redirect as a compatibility option if you need automatic completion on older iOS versions.
+
+</details>
+
+</TabItem>
+
+<TabItem value="v1" label="v1">
 
 <ConfigureRedirectUri
   figureSrc="/img/assets/ios-redirect-uri.png"
@@ -12,16 +70,82 @@ import SignInFlowSummary from '../../fragments/_web-sign-in-flow-summary.mdx';
 />
 
 :::info
-L'URI de redirection dans le SDK iOS est uniquement pour un usage interne. Il n'y a _PAS BESOIN_ d'ajouter un [schéma d'URL personnalisé](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app) jusqu'à ce qu'un connecteur le demande.
+The Redirect URI in iOS SDK is only for internal use. There's _NO NEED_ to add a [Custom URL Scheme](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app) until a connector asks.
 :::
 
-#### Connexion et déconnexion \{#sign-in-and-sign-out}
+</TabItem>
+
+</Tabs>
+
+#### Sign-in and sign-out \{#sign-in-and-sign-out}
 
 <SignInNote calling=".signInWithBrowser(redirectUri:)" />
 
-Vous pouvez utiliser `client.signInWithBrowser(redirectUri:)` pour connecter l'utilisateur et `client.signOut()` pour déconnecter l'utilisateur.
+<Tabs groupId="swift-sdk-version" defaultValue="v2">
 
-Par exemple, dans une application SwiftUI :
+<TabItem value="v2" label="v2 (beta)">
+
+In v2, `client.signOut(postLogoutRedirectUri:)` performs a complete sign-out: it clears the local credentials, revokes the refresh token, and ends the Logto session by opening the end session endpoint in the system browser. The browser then navigates back to your app through the post sign-out redirect URI. Before using it, switch to the application details page of Logto Console, add the post sign-out redirect URI `io.logto.app://signed-out` and click "Save changes". The post sign-out redirect URI can use the same custom scheme you registered for sign-in.
+
+For example, in a SwiftUI app:
+
+```swift title="ContentView.swift"
+struct ContentView: View {
+  @State var isAuthenticated: Bool
+
+  private let redirectUri = "io.logto.app://callback"
+  private let postLogoutRedirectUri = "io.logto.app://signed-out"
+
+  init() {
+    isAuthenticated = client.isAuthenticated
+  }
+
+  var body: some View {
+    VStack {
+      if isAuthenticated {
+        Button("Sign Out") {
+          Task { [self] in
+            let error = await client.signOut(postLogoutRedirectUri: postLogoutRedirectUri)
+            if let error = error {
+              print(error)
+              return
+            }
+            isAuthenticated = false
+          }
+        }
+      } else {
+        Button("Sign In") {
+          Task { [self] in
+            do {
+              try await client.signInWithBrowser(redirectUri: redirectUri)
+              isAuthenticated = true
+            } catch let error as LogtoClientErrors.SignIn {
+              // error occurred during sign in
+            } catch {
+              // other errors
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+:::note
+
+- You can also call `client.signOut()` without a post sign-out redirect URI. No Console configuration is needed in this case: the browser shows the Logto sign-out page, and the user returns to the app by dismissing it manually.
+- If no UI context is available, you can call `client.clearCredentials()` to clear the local credentials and revoke the refresh token. Note that this keeps the Logto session in the browser, so the next `signInWithBrowser` may silently sign the user back in through that session.
+
+:::
+
+</TabItem>
+
+<TabItem value="v1" label="v1">
+
+You can use `client.signInWithBrowser(redirectUri:)` to sign in the user and `client.signOut()` to sign out the user.
+
+For example, in a SwiftUI app:
 
 ```swift title="ContentView.swift"
 struct ContentView: View {
@@ -34,24 +158,22 @@ struct ContentView: View {
   var body: some View {
     VStack {
       if isAuthenticated {
-        Button("Déconnexion") {
+        Button("Sign Out") {
           Task { [self] in
             await client.signOut()
             isAuthenticated = false
           }
         }
       } else {
-        Button("Connexion") {
+        Button("Sign In") {
           Task { [self] in
             do {
-              try await client.signInWithBrowser(redirectUri: "${
-                props.redirectUris[0] ?? 'io.logto://callback'
-              }")
+              try await client.signInWithBrowser(redirectUri: "io.logto://callback")
               isAuthenticated = true
             } catch let error as LogtoClientErrors.SignIn {
-              // erreur survenue lors de la connexion
+              // error occurred during sign in
             } catch {
-              // autres erreurs
+              // other errors
             }
           }
         }
@@ -60,3 +182,7 @@ struct ContentView: View {
   }
 }
 ```
+
+</TabItem>
+
+</Tabs>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_add-sdk.mdx
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_add-sdk.mdx
@@ -1,12 +1,56 @@
-次の URL を使用して、Swift Package Manager に Logto SDK を依存関係として追加します。
+import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs';
+
+:::note
+The minimum supported iOS version of Logto Swift SDK is iOS 13.
+:::
+
+Logto Swift SDK comes in two major versions:
+
+- **v1**: Opens the sign-in experience in an embedded WebView, which is required by the native social plugin targets, but does not support <MainSiteUrl href="/end-user-flows/sign-up-and-sign-in/passkey-sign-in">passkey sign-in</MainSiteUrl> (WebView does not support WebAuthn, the underlying standard of passkeys).
+- **v2 (beta)**: Opens the sign-in experience in [`ASWebAuthenticationSession`](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession) (the system browser), which unlocks passkey sign-in and shares the browser session. Note that v2 removes the native social plugin targets; social connectors still work through the browser. If you depend on the native WeChat or Alipay SDK handoff, stay on v1.
+
+This guide covers both versions. Choose your version in the tabs below, and the choice will be kept in sync throughout this guide.
+
+Use the following URL to add Logto SDK as a dependency in Swift Package Manager.
 
 ```bash
 https://github.com/logto-io/swift.git
 ```
 
-Xcode 11 以降、[Swift パッケージを直接インポート](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) できます。追加のツールは必要ありません。
+Since Xcode 11, you can [directly import a Swift package](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) w/o any additional tool.
 
-技術的な問題により、現在 **Carthage** と **CocoaPods** はサポートしていません。
+When Xcode asks for the package version, choose the version you want to integrate:
+
+<Tabs groupId="swift-sdk-version" defaultValue="v2">
+
+<TabItem value="v2" label="v2 (beta)">
+
+v2 is released as `2.0.0-beta.x` prereleases until GA. Use `2.0.0-beta.1` or the latest `2.0.0-beta.x` prerelease as the version. During beta, we recommend selecting the prerelease explicitly instead of relying on a normal version range to pick it automatically.
+
+If you use `Package.swift` directly:
+
+```swift title="Package.swift"
+.package(url: "https://github.com/logto-io/swift.git", exact: "2.0.0-beta.1")
+```
+
+</TabItem>
+
+<TabItem value="v1" label="v1">
+
+Use the latest v1 release as the stable line. The latest v1 version is `1.2.0`.
+
+If you use `Package.swift` directly:
+
+```swift title="Package.swift"
+.package(url: "https://github.com/logto-io/swift.git", from: "1.2.0")
+```
+
+</TabItem>
+
+</Tabs>
+
+We do not support **Carthage** and **CocoaPods** at the time due to some technical issues.
 
 <details>
 
@@ -16,7 +60,7 @@ Xcode 11 以降、[Swift パッケージを直接インポート](https://develo
 
 </summary>
 
-Carthage は [ビルドに `xcodeproj` ファイルを必要とします](https://github.com/Carthage/Carthage/issues/1226#issuecomment-290931385) が、ネイティブソーシャルプラグインのバイナリターゲットを使用しているため、`swift package generate-xcodeproj` は失敗を報告します。後で回避策を見つけるようにします。
+Carthage [needs a `xcodeproj` file to build](https://github.com/Carthage/Carthage/issues/1226#issuecomment-290931385). We will try to find a workaround later.
 
 </details>
 
@@ -28,6 +72,6 @@ Carthage は [ビルドに `xcodeproj` ファイルを必要とします](https:
 
 </summary>
 
-CocoaPods は [ローカル依存関係](https://github.com/CocoaPods/CocoaPods/issues/3276) とモノレポをサポートしていないため、このリポジトリの `.podspec` を作成するのは難しいです。
+CocoaPods [does not support local dependency](https://github.com/CocoaPods/CocoaPods/issues/3276) and monorepo, thus it&apos;s hard to create a `.podspec` for this repo.
 
 </details>

--- a/i18n/ja/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_implement-sign-in-and-sign-out.mdx
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_implement-sign-in-and-sign-out.mdx
@@ -1,10 +1,68 @@
+import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs';
+
 import ConfigureRedirectUri from '../../fragments/_configure-redirect-uri.mdx';
 import SignInNote from '../../fragments/_sign-in-note.mdx';
 import SignInFlowSummary from '../../fragments/_web-sign-in-flow-summary.mdx';
 
 <SignInFlowSummary />
 
-#### リダイレクト URI の設定 \{#configure-redirect-uri}
+#### Configure redirect URI \{#configure-redirect-uri}
+
+<Tabs groupId="swift-sdk-version" defaultValue="v2">
+
+<TabItem value="v2" label="v2 (beta)">
+
+<ConfigureRedirectUri
+  figureSrc="/img/assets/ios-redirect-uri.png"
+  redirectUri="io.logto.app://callback"
+/>
+
+In v2, the sign-in experience opens in [`ASWebAuthenticationSession`](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession) (the system browser), and the redirect is routed back to your app through OS-level callback matching. For a custom scheme redirect URI such as `io.logto.app://callback`, register only the scheme part (`io.logto.app`) in your app's `Info.plist`, then add the full redirect URI to your Logto application's Redirect URIs.
+
+In Xcode, open your app target, select **Info**, expand **URL Types**, and add one entry with `io.logto.app` in **URL Schemes**. If you edit `Info.plist` directly, add:
+
+```xml title="Info.plist"
+<key>CFBundleURLTypes</key>
+<array>
+  <dict>
+    <key>CFBundleTypeRole</key>
+    <string>Editor</string>
+    <key>CFBundleURLName</key>
+    <string>io.logto.app</string>
+    <key>CFBundleURLSchemes</key>
+    <array>
+      <string>io.logto.app</string>
+    </array>
+  </dict>
+</array>
+```
+
+For the browser flow in v2, you do not need to call `LogtoClient.handle(url:)`; that plugin handoff API was removed with the embedded WebView flow.
+
+<details>
+
+<summary>
+
+#### Use Universal Links instead of a custom scheme? \{#use-universal-links-instead-of-a-custom-scheme}
+
+</summary>
+
+You can also use an HTTPS redirect URI such as `https://example.com/callback`:
+
+1. Add the Associated Domains capability to your app.
+2. Configure `webcredentials:example.com` so `ASWebAuthenticationSession` can match HTTPS callbacks on iOS 17.4 and newer.
+3. If the same URL should also open your app as a Universal Link outside the authentication session, configure `applinks:example.com` and host a valid `apple-app-site-association` file for the domain and path.
+4. Add the HTTPS URI to your Logto application's Redirect URIs.
+5. Pass the same URI to `signInWithBrowser`.
+
+On iOS 17.4 and newer, the SDK uses `ASWebAuthenticationSession`'s HTTPS callback matching API so HTTPS redirects can automatically complete and dismiss the session. On older iOS versions, the authorization request can still use the HTTPS redirect URI, but the session may not close automatically unless your app handles the Universal Link callback itself. Keep a custom scheme redirect as a compatibility option if you need automatic completion on older iOS versions.
+
+</details>
+
+</TabItem>
+
+<TabItem value="v1" label="v1">
 
 <ConfigureRedirectUri
   figureSrc="/img/assets/ios-redirect-uri.png"
@@ -12,16 +70,82 @@ import SignInFlowSummary from '../../fragments/_web-sign-in-flow-summary.mdx';
 />
 
 :::info
-iOS SDK のリダイレクト URI は内部使用のみです。コネクターが要求するまで、[カスタム URL スキーム](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app) を追加する必要は _ありません_。
+The Redirect URI in iOS SDK is only for internal use. There's _NO NEED_ to add a [Custom URL Scheme](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app) until a connector asks.
 :::
 
-#### サインインとサインアウト \{#sign-in-and-sign-out}
+</TabItem>
+
+</Tabs>
+
+#### Sign-in and sign-out \{#sign-in-and-sign-out}
 
 <SignInNote calling=".signInWithBrowser(redirectUri:)" />
 
-`client.signInWithBrowser(redirectUri:)` を使用してユーザーをサインインし、`client.signOut()` を使用してユーザーをサインアウトできます。
+<Tabs groupId="swift-sdk-version" defaultValue="v2">
 
-例えば、SwiftUI アプリでは：
+<TabItem value="v2" label="v2 (beta)">
+
+In v2, `client.signOut(postLogoutRedirectUri:)` performs a complete sign-out: it clears the local credentials, revokes the refresh token, and ends the Logto session by opening the end session endpoint in the system browser. The browser then navigates back to your app through the post sign-out redirect URI. Before using it, switch to the application details page of Logto Console, add the post sign-out redirect URI `io.logto.app://signed-out` and click "Save changes". The post sign-out redirect URI can use the same custom scheme you registered for sign-in.
+
+For example, in a SwiftUI app:
+
+```swift title="ContentView.swift"
+struct ContentView: View {
+  @State var isAuthenticated: Bool
+
+  private let redirectUri = "io.logto.app://callback"
+  private let postLogoutRedirectUri = "io.logto.app://signed-out"
+
+  init() {
+    isAuthenticated = client.isAuthenticated
+  }
+
+  var body: some View {
+    VStack {
+      if isAuthenticated {
+        Button("Sign Out") {
+          Task { [self] in
+            let error = await client.signOut(postLogoutRedirectUri: postLogoutRedirectUri)
+            if let error = error {
+              print(error)
+              return
+            }
+            isAuthenticated = false
+          }
+        }
+      } else {
+        Button("Sign In") {
+          Task { [self] in
+            do {
+              try await client.signInWithBrowser(redirectUri: redirectUri)
+              isAuthenticated = true
+            } catch let error as LogtoClientErrors.SignIn {
+              // error occurred during sign in
+            } catch {
+              // other errors
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+:::note
+
+- You can also call `client.signOut()` without a post sign-out redirect URI. No Console configuration is needed in this case: the browser shows the Logto sign-out page, and the user returns to the app by dismissing it manually.
+- If no UI context is available, you can call `client.clearCredentials()` to clear the local credentials and revoke the refresh token. Note that this keeps the Logto session in the browser, so the next `signInWithBrowser` may silently sign the user back in through that session.
+
+:::
+
+</TabItem>
+
+<TabItem value="v1" label="v1">
+
+You can use `client.signInWithBrowser(redirectUri:)` to sign in the user and `client.signOut()` to sign out the user.
+
+For example, in a SwiftUI app:
 
 ```swift title="ContentView.swift"
 struct ContentView: View {
@@ -44,14 +168,12 @@ struct ContentView: View {
         Button("Sign In") {
           Task { [self] in
             do {
-              try await client.signInWithBrowser(redirectUri: "${
-                props.redirectUris[0] ?? 'io.logto://callback'
-              }")
+              try await client.signInWithBrowser(redirectUri: "io.logto://callback")
               isAuthenticated = true
             } catch let error as LogtoClientErrors.SignIn {
-              // サインイン中にエラーが発生しました
+              // error occurred during sign in
             } catch {
-              // その他のエラー
+              // other errors
             }
           }
         }
@@ -60,3 +182,7 @@ struct ContentView: View {
   }
 }
 ```
+
+</TabItem>
+
+</Tabs>

--- a/i18n/ko/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_add-sdk.mdx
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_add-sdk.mdx
@@ -1,12 +1,56 @@
-다음 URL을 사용하여 Swift Package Manager에서 Logto SDK를 종속성으로 추가하세요.
+import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs';
+
+:::note
+The minimum supported iOS version of Logto Swift SDK is iOS 13.
+:::
+
+Logto Swift SDK comes in two major versions:
+
+- **v1**: Opens the sign-in experience in an embedded WebView, which is required by the native social plugin targets, but does not support <MainSiteUrl href="/end-user-flows/sign-up-and-sign-in/passkey-sign-in">passkey sign-in</MainSiteUrl> (WebView does not support WebAuthn, the underlying standard of passkeys).
+- **v2 (beta)**: Opens the sign-in experience in [`ASWebAuthenticationSession`](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession) (the system browser), which unlocks passkey sign-in and shares the browser session. Note that v2 removes the native social plugin targets; social connectors still work through the browser. If you depend on the native WeChat or Alipay SDK handoff, stay on v1.
+
+This guide covers both versions. Choose your version in the tabs below, and the choice will be kept in sync throughout this guide.
+
+Use the following URL to add Logto SDK as a dependency in Swift Package Manager.
 
 ```bash
 https://github.com/logto-io/swift.git
 ```
 
-Xcode 11부터는 [Swift 패키지를 직접 가져올 수 있습니다](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) 추가 도구 없이.
+Since Xcode 11, you can [directly import a Swift package](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) w/o any additional tool.
 
-일부 기술적인 문제로 인해 현재 **Carthage** 및 **CocoaPods**는 지원하지 않습니다.
+When Xcode asks for the package version, choose the version you want to integrate:
+
+<Tabs groupId="swift-sdk-version" defaultValue="v2">
+
+<TabItem value="v2" label="v2 (beta)">
+
+v2 is released as `2.0.0-beta.x` prereleases until GA. Use `2.0.0-beta.1` or the latest `2.0.0-beta.x` prerelease as the version. During beta, we recommend selecting the prerelease explicitly instead of relying on a normal version range to pick it automatically.
+
+If you use `Package.swift` directly:
+
+```swift title="Package.swift"
+.package(url: "https://github.com/logto-io/swift.git", exact: "2.0.0-beta.1")
+```
+
+</TabItem>
+
+<TabItem value="v1" label="v1">
+
+Use the latest v1 release as the stable line. The latest v1 version is `1.2.0`.
+
+If you use `Package.swift` directly:
+
+```swift title="Package.swift"
+.package(url: "https://github.com/logto-io/swift.git", from: "1.2.0")
+```
+
+</TabItem>
+
+</Tabs>
+
+We do not support **Carthage** and **CocoaPods** at the time due to some technical issues.
 
 <details>
 
@@ -16,7 +60,7 @@ Xcode 11부터는 [Swift 패키지를 직접 가져올 수 있습니다](https:/
 
 </summary>
 
-Carthage는 [빌드를 위해 `xcodeproj` 파일이 필요합니다](https://github.com/Carthage/Carthage/issues/1226#issuecomment-290931385), 그러나 네이티브 소셜 플러그인을 위한 바이너리 타겟을 사용하고 있기 때문에 `swift package generate-xcodeproj`는 실패를 보고할 것입니다. 나중에 해결책을 찾도록 하겠습니다.
+Carthage [needs a `xcodeproj` file to build](https://github.com/Carthage/Carthage/issues/1226#issuecomment-290931385). We will try to find a workaround later.
 
 </details>
 
@@ -28,6 +72,6 @@ Carthage는 [빌드를 위해 `xcodeproj` 파일이 필요합니다](https://git
 
 </summary>
 
-CocoaPods는 [로컬 종속성](https://github.com/CocoaPods/CocoaPods/issues/3276) 및 모노레포를 지원하지 않으므로, 이 저장소에 대한 `.podspec`을 생성하기 어렵습니다.
+CocoaPods [does not support local dependency](https://github.com/CocoaPods/CocoaPods/issues/3276) and monorepo, thus it&apos;s hard to create a `.podspec` for this repo.
 
 </details>

--- a/i18n/ko/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_implement-sign-in-and-sign-out.mdx
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_implement-sign-in-and-sign-out.mdx
@@ -1,10 +1,68 @@
+import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs';
+
 import ConfigureRedirectUri from '../../fragments/_configure-redirect-uri.mdx';
 import SignInNote from '../../fragments/_sign-in-note.mdx';
 import SignInFlowSummary from '../../fragments/_web-sign-in-flow-summary.mdx';
 
 <SignInFlowSummary />
 
-#### 리디렉트 URI 구성 \{#configure-redirect-uri}
+#### Configure redirect URI \{#configure-redirect-uri}
+
+<Tabs groupId="swift-sdk-version" defaultValue="v2">
+
+<TabItem value="v2" label="v2 (beta)">
+
+<ConfigureRedirectUri
+  figureSrc="/img/assets/ios-redirect-uri.png"
+  redirectUri="io.logto.app://callback"
+/>
+
+In v2, the sign-in experience opens in [`ASWebAuthenticationSession`](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession) (the system browser), and the redirect is routed back to your app through OS-level callback matching. For a custom scheme redirect URI such as `io.logto.app://callback`, register only the scheme part (`io.logto.app`) in your app's `Info.plist`, then add the full redirect URI to your Logto application's Redirect URIs.
+
+In Xcode, open your app target, select **Info**, expand **URL Types**, and add one entry with `io.logto.app` in **URL Schemes**. If you edit `Info.plist` directly, add:
+
+```xml title="Info.plist"
+<key>CFBundleURLTypes</key>
+<array>
+  <dict>
+    <key>CFBundleTypeRole</key>
+    <string>Editor</string>
+    <key>CFBundleURLName</key>
+    <string>io.logto.app</string>
+    <key>CFBundleURLSchemes</key>
+    <array>
+      <string>io.logto.app</string>
+    </array>
+  </dict>
+</array>
+```
+
+For the browser flow in v2, you do not need to call `LogtoClient.handle(url:)`; that plugin handoff API was removed with the embedded WebView flow.
+
+<details>
+
+<summary>
+
+#### Use Universal Links instead of a custom scheme? \{#use-universal-links-instead-of-a-custom-scheme}
+
+</summary>
+
+You can also use an HTTPS redirect URI such as `https://example.com/callback`:
+
+1. Add the Associated Domains capability to your app.
+2. Configure `webcredentials:example.com` so `ASWebAuthenticationSession` can match HTTPS callbacks on iOS 17.4 and newer.
+3. If the same URL should also open your app as a Universal Link outside the authentication session, configure `applinks:example.com` and host a valid `apple-app-site-association` file for the domain and path.
+4. Add the HTTPS URI to your Logto application's Redirect URIs.
+5. Pass the same URI to `signInWithBrowser`.
+
+On iOS 17.4 and newer, the SDK uses `ASWebAuthenticationSession`'s HTTPS callback matching API so HTTPS redirects can automatically complete and dismiss the session. On older iOS versions, the authorization request can still use the HTTPS redirect URI, but the session may not close automatically unless your app handles the Universal Link callback itself. Keep a custom scheme redirect as a compatibility option if you need automatic completion on older iOS versions.
+
+</details>
+
+</TabItem>
+
+<TabItem value="v1" label="v1">
 
 <ConfigureRedirectUri
   figureSrc="/img/assets/ios-redirect-uri.png"
@@ -12,16 +70,82 @@ import SignInFlowSummary from '../../fragments/_web-sign-in-flow-summary.mdx';
 />
 
 :::info
-iOS SDK의 리디렉트 URI는 내부 사용을 위한 것입니다. 커넥터가 요청하기 전까지는 [Custom URL Scheme](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app)을 추가할 _필요가 없습니다_.
+The Redirect URI in iOS SDK is only for internal use. There's _NO NEED_ to add a [Custom URL Scheme](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app) until a connector asks.
 :::
 
-#### 로그인 및 로그아웃 \{#sign-in-and-sign-out}
+</TabItem>
+
+</Tabs>
+
+#### Sign-in and sign-out \{#sign-in-and-sign-out}
 
 <SignInNote calling=".signInWithBrowser(redirectUri:)" />
 
-`client.signInWithBrowser(redirectUri:)`를 사용하여 사용자를 로그인시키고, `client.signOut()`을 사용하여 사용자를 로그아웃시킬 수 있습니다.
+<Tabs groupId="swift-sdk-version" defaultValue="v2">
 
-예를 들어, SwiftUI 앱에서:
+<TabItem value="v2" label="v2 (beta)">
+
+In v2, `client.signOut(postLogoutRedirectUri:)` performs a complete sign-out: it clears the local credentials, revokes the refresh token, and ends the Logto session by opening the end session endpoint in the system browser. The browser then navigates back to your app through the post sign-out redirect URI. Before using it, switch to the application details page of Logto Console, add the post sign-out redirect URI `io.logto.app://signed-out` and click "Save changes". The post sign-out redirect URI can use the same custom scheme you registered for sign-in.
+
+For example, in a SwiftUI app:
+
+```swift title="ContentView.swift"
+struct ContentView: View {
+  @State var isAuthenticated: Bool
+
+  private let redirectUri = "io.logto.app://callback"
+  private let postLogoutRedirectUri = "io.logto.app://signed-out"
+
+  init() {
+    isAuthenticated = client.isAuthenticated
+  }
+
+  var body: some View {
+    VStack {
+      if isAuthenticated {
+        Button("Sign Out") {
+          Task { [self] in
+            let error = await client.signOut(postLogoutRedirectUri: postLogoutRedirectUri)
+            if let error = error {
+              print(error)
+              return
+            }
+            isAuthenticated = false
+          }
+        }
+      } else {
+        Button("Sign In") {
+          Task { [self] in
+            do {
+              try await client.signInWithBrowser(redirectUri: redirectUri)
+              isAuthenticated = true
+            } catch let error as LogtoClientErrors.SignIn {
+              // error occurred during sign in
+            } catch {
+              // other errors
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+:::note
+
+- You can also call `client.signOut()` without a post sign-out redirect URI. No Console configuration is needed in this case: the browser shows the Logto sign-out page, and the user returns to the app by dismissing it manually.
+- If no UI context is available, you can call `client.clearCredentials()` to clear the local credentials and revoke the refresh token. Note that this keeps the Logto session in the browser, so the next `signInWithBrowser` may silently sign the user back in through that session.
+
+:::
+
+</TabItem>
+
+<TabItem value="v1" label="v1">
+
+You can use `client.signInWithBrowser(redirectUri:)` to sign in the user and `client.signOut()` to sign out the user.
+
+For example, in a SwiftUI app:
 
 ```swift title="ContentView.swift"
 struct ContentView: View {
@@ -44,14 +168,12 @@ struct ContentView: View {
         Button("Sign In") {
           Task { [self] in
             do {
-              try await client.signInWithBrowser(redirectUri: "${
-                props.redirectUris[0] ?? 'io.logto://callback'
-              }")
+              try await client.signInWithBrowser(redirectUri: "io.logto://callback")
               isAuthenticated = true
             } catch let error as LogtoClientErrors.SignIn {
-              // 로그인 중 오류 발생
+              // error occurred during sign in
             } catch {
-              // 기타 오류
+              // other errors
             }
           }
         }
@@ -60,3 +182,7 @@ struct ContentView: View {
   }
 }
 ```
+
+</TabItem>
+
+</Tabs>

--- a/i18n/pt-BR/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_add-sdk.mdx
+++ b/i18n/pt-BR/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_add-sdk.mdx
@@ -1,12 +1,56 @@
-Use o seguinte URL para adicionar Logto SDK como uma dependência no Swift Package Manager.
+import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs';
+
+:::note
+The minimum supported iOS version of Logto Swift SDK is iOS 13.
+:::
+
+Logto Swift SDK comes in two major versions:
+
+- **v1**: Opens the sign-in experience in an embedded WebView, which is required by the native social plugin targets, but does not support <MainSiteUrl href="/end-user-flows/sign-up-and-sign-in/passkey-sign-in">passkey sign-in</MainSiteUrl> (WebView does not support WebAuthn, the underlying standard of passkeys).
+- **v2 (beta)**: Opens the sign-in experience in [`ASWebAuthenticationSession`](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession) (the system browser), which unlocks passkey sign-in and shares the browser session. Note that v2 removes the native social plugin targets; social connectors still work through the browser. If you depend on the native WeChat or Alipay SDK handoff, stay on v1.
+
+This guide covers both versions. Choose your version in the tabs below, and the choice will be kept in sync throughout this guide.
+
+Use the following URL to add Logto SDK as a dependency in Swift Package Manager.
 
 ```bash
 https://github.com/logto-io/swift.git
 ```
 
-Desde o Xcode 11, você pode [importar diretamente um pacote Swift](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) sem qualquer ferramenta adicional.
+Since Xcode 11, you can [directly import a Swift package](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) w/o any additional tool.
 
-Não oferecemos suporte ao **Carthage** e **CocoaPods** no momento devido a alguns problemas técnicos.
+When Xcode asks for the package version, choose the version you want to integrate:
+
+<Tabs groupId="swift-sdk-version" defaultValue="v2">
+
+<TabItem value="v2" label="v2 (beta)">
+
+v2 is released as `2.0.0-beta.x` prereleases until GA. Use `2.0.0-beta.1` or the latest `2.0.0-beta.x` prerelease as the version. During beta, we recommend selecting the prerelease explicitly instead of relying on a normal version range to pick it automatically.
+
+If you use `Package.swift` directly:
+
+```swift title="Package.swift"
+.package(url: "https://github.com/logto-io/swift.git", exact: "2.0.0-beta.1")
+```
+
+</TabItem>
+
+<TabItem value="v1" label="v1">
+
+Use the latest v1 release as the stable line. The latest v1 version is `1.2.0`.
+
+If you use `Package.swift` directly:
+
+```swift title="Package.swift"
+.package(url: "https://github.com/logto-io/swift.git", from: "1.2.0")
+```
+
+</TabItem>
+
+</Tabs>
+
+We do not support **Carthage** and **CocoaPods** at the time due to some technical issues.
 
 <details>
 
@@ -16,7 +60,7 @@ Não oferecemos suporte ao **Carthage** e **CocoaPods** no momento devido a algu
 
 </summary>
 
-Carthage [precisa de um arquivo `xcodeproj` para compilar](https://github.com/Carthage/Carthage/issues/1226#issuecomment-290931385), mas `swift package generate-xcodeproj` irá relatar uma falha, pois estamos usando alvos binários para plugins sociais nativos. Tentaremos encontrar uma solução alternativa mais tarde.
+Carthage [needs a `xcodeproj` file to build](https://github.com/Carthage/Carthage/issues/1226#issuecomment-290931385). We will try to find a workaround later.
 
 </details>
 
@@ -28,6 +72,6 @@ Carthage [precisa de um arquivo `xcodeproj` para compilar](https://github.com/Ca
 
 </summary>
 
-CocoaPods [não suporta dependência local](https://github.com/CocoaPods/CocoaPods/issues/3276) e monorepo, portanto, é difícil criar um `.podspec` para este repositório.
+CocoaPods [does not support local dependency](https://github.com/CocoaPods/CocoaPods/issues/3276) and monorepo, thus it&apos;s hard to create a `.podspec` for this repo.
 
 </details>

--- a/i18n/pt-BR/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_implement-sign-in-and-sign-out.mdx
+++ b/i18n/pt-BR/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_implement-sign-in-and-sign-out.mdx
@@ -1,10 +1,68 @@
+import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs';
+
 import ConfigureRedirectUri from '../../fragments/_configure-redirect-uri.mdx';
 import SignInNote from '../../fragments/_sign-in-note.mdx';
 import SignInFlowSummary from '../../fragments/_web-sign-in-flow-summary.mdx';
 
 <SignInFlowSummary />
 
-#### Configurar URI de redirecionamento \{#configure-redirect-uri}
+#### Configure redirect URI \{#configure-redirect-uri}
+
+<Tabs groupId="swift-sdk-version" defaultValue="v2">
+
+<TabItem value="v2" label="v2 (beta)">
+
+<ConfigureRedirectUri
+  figureSrc="/img/assets/ios-redirect-uri.png"
+  redirectUri="io.logto.app://callback"
+/>
+
+In v2, the sign-in experience opens in [`ASWebAuthenticationSession`](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession) (the system browser), and the redirect is routed back to your app through OS-level callback matching. For a custom scheme redirect URI such as `io.logto.app://callback`, register only the scheme part (`io.logto.app`) in your app's `Info.plist`, then add the full redirect URI to your Logto application's Redirect URIs.
+
+In Xcode, open your app target, select **Info**, expand **URL Types**, and add one entry with `io.logto.app` in **URL Schemes**. If you edit `Info.plist` directly, add:
+
+```xml title="Info.plist"
+<key>CFBundleURLTypes</key>
+<array>
+  <dict>
+    <key>CFBundleTypeRole</key>
+    <string>Editor</string>
+    <key>CFBundleURLName</key>
+    <string>io.logto.app</string>
+    <key>CFBundleURLSchemes</key>
+    <array>
+      <string>io.logto.app</string>
+    </array>
+  </dict>
+</array>
+```
+
+For the browser flow in v2, you do not need to call `LogtoClient.handle(url:)`; that plugin handoff API was removed with the embedded WebView flow.
+
+<details>
+
+<summary>
+
+#### Use Universal Links instead of a custom scheme? \{#use-universal-links-instead-of-a-custom-scheme}
+
+</summary>
+
+You can also use an HTTPS redirect URI such as `https://example.com/callback`:
+
+1. Add the Associated Domains capability to your app.
+2. Configure `webcredentials:example.com` so `ASWebAuthenticationSession` can match HTTPS callbacks on iOS 17.4 and newer.
+3. If the same URL should also open your app as a Universal Link outside the authentication session, configure `applinks:example.com` and host a valid `apple-app-site-association` file for the domain and path.
+4. Add the HTTPS URI to your Logto application's Redirect URIs.
+5. Pass the same URI to `signInWithBrowser`.
+
+On iOS 17.4 and newer, the SDK uses `ASWebAuthenticationSession`'s HTTPS callback matching API so HTTPS redirects can automatically complete and dismiss the session. On older iOS versions, the authorization request can still use the HTTPS redirect URI, but the session may not close automatically unless your app handles the Universal Link callback itself. Keep a custom scheme redirect as a compatibility option if you need automatic completion on older iOS versions.
+
+</details>
+
+</TabItem>
+
+<TabItem value="v1" label="v1">
 
 <ConfigureRedirectUri
   figureSrc="/img/assets/ios-redirect-uri.png"
@@ -12,16 +70,82 @@ import SignInFlowSummary from '../../fragments/_web-sign-in-flow-summary.mdx';
 />
 
 :::info
-O URI de redirecionamento no iOS SDK é apenas para uso interno. Não há _NECESSIDADE_ de adicionar um [Esquema de URL Personalizado](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app) até que um conector solicite.
+The Redirect URI in iOS SDK is only for internal use. There's _NO NEED_ to add a [Custom URL Scheme](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app) until a connector asks.
 :::
 
-#### Login e logout \{#sign-in-and-sign-out}
+</TabItem>
+
+</Tabs>
+
+#### Sign-in and sign-out \{#sign-in-and-sign-out}
 
 <SignInNote calling=".signInWithBrowser(redirectUri:)" />
 
-Você pode usar `client.signInWithBrowser(redirectUri:)` para fazer login do usuário e `client.signOut()` para fazer logout do usuário.
+<Tabs groupId="swift-sdk-version" defaultValue="v2">
 
-Por exemplo, em um aplicativo SwiftUI:
+<TabItem value="v2" label="v2 (beta)">
+
+In v2, `client.signOut(postLogoutRedirectUri:)` performs a complete sign-out: it clears the local credentials, revokes the refresh token, and ends the Logto session by opening the end session endpoint in the system browser. The browser then navigates back to your app through the post sign-out redirect URI. Before using it, switch to the application details page of Logto Console, add the post sign-out redirect URI `io.logto.app://signed-out` and click "Save changes". The post sign-out redirect URI can use the same custom scheme you registered for sign-in.
+
+For example, in a SwiftUI app:
+
+```swift title="ContentView.swift"
+struct ContentView: View {
+  @State var isAuthenticated: Bool
+
+  private let redirectUri = "io.logto.app://callback"
+  private let postLogoutRedirectUri = "io.logto.app://signed-out"
+
+  init() {
+    isAuthenticated = client.isAuthenticated
+  }
+
+  var body: some View {
+    VStack {
+      if isAuthenticated {
+        Button("Sign Out") {
+          Task { [self] in
+            let error = await client.signOut(postLogoutRedirectUri: postLogoutRedirectUri)
+            if let error = error {
+              print(error)
+              return
+            }
+            isAuthenticated = false
+          }
+        }
+      } else {
+        Button("Sign In") {
+          Task { [self] in
+            do {
+              try await client.signInWithBrowser(redirectUri: redirectUri)
+              isAuthenticated = true
+            } catch let error as LogtoClientErrors.SignIn {
+              // error occurred during sign in
+            } catch {
+              // other errors
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+:::note
+
+- You can also call `client.signOut()` without a post sign-out redirect URI. No Console configuration is needed in this case: the browser shows the Logto sign-out page, and the user returns to the app by dismissing it manually.
+- If no UI context is available, you can call `client.clearCredentials()` to clear the local credentials and revoke the refresh token. Note that this keeps the Logto session in the browser, so the next `signInWithBrowser` may silently sign the user back in through that session.
+
+:::
+
+</TabItem>
+
+<TabItem value="v1" label="v1">
+
+You can use `client.signInWithBrowser(redirectUri:)` to sign in the user and `client.signOut()` to sign out the user.
+
+For example, in a SwiftUI app:
 
 ```swift title="ContentView.swift"
 struct ContentView: View {
@@ -44,14 +168,12 @@ struct ContentView: View {
         Button("Sign In") {
           Task { [self] in
             do {
-              try await client.signInWithBrowser(redirectUri: "${
-                props.redirectUris[0] ?? 'io.logto://callback'
-              }")
+              try await client.signInWithBrowser(redirectUri: "io.logto://callback")
               isAuthenticated = true
             } catch let error as LogtoClientErrors.SignIn {
-              // erro ocorreu durante o login
+              // error occurred during sign in
             } catch {
-              // outros erros
+              // other errors
             }
           }
         }
@@ -60,3 +182,7 @@ struct ContentView: View {
   }
 }
 ```
+
+</TabItem>
+
+</Tabs>

--- a/i18n/th/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_add-sdk.mdx
+++ b/i18n/th/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_add-sdk.mdx
@@ -1,12 +1,56 @@
-ใช้ URL ต่อไปนี้เพื่อเพิ่ม Logto SDK เป็น dependency ใน Swift Package Manager
+import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs';
+
+:::note
+The minimum supported iOS version of Logto Swift SDK is iOS 13.
+:::
+
+Logto Swift SDK comes in two major versions:
+
+- **v1**: Opens the sign-in experience in an embedded WebView, which is required by the native social plugin targets, but does not support <MainSiteUrl href="/end-user-flows/sign-up-and-sign-in/passkey-sign-in">passkey sign-in</MainSiteUrl> (WebView does not support WebAuthn, the underlying standard of passkeys).
+- **v2 (beta)**: Opens the sign-in experience in [`ASWebAuthenticationSession`](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession) (the system browser), which unlocks passkey sign-in and shares the browser session. Note that v2 removes the native social plugin targets; social connectors still work through the browser. If you depend on the native WeChat or Alipay SDK handoff, stay on v1.
+
+This guide covers both versions. Choose your version in the tabs below, and the choice will be kept in sync throughout this guide.
+
+Use the following URL to add Logto SDK as a dependency in Swift Package Manager.
 
 ```bash
 https://github.com/logto-io/swift.git
 ```
 
-ตั้งแต่ Xcode 11 เป็นต้นมา คุณสามารถ [นำเข้า Swift package ได้โดยตรง](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) โดยไม่ต้องใช้เครื่องมือเพิ่มเติมใด ๆ
+Since Xcode 11, you can [directly import a Swift package](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) w/o any additional tool.
 
-ขณะนี้ เรายังไม่รองรับ **Carthage** และ **CocoaPods** เนื่องจากปัญหาทางเทคนิคบางประการ
+When Xcode asks for the package version, choose the version you want to integrate:
+
+<Tabs groupId="swift-sdk-version" defaultValue="v2">
+
+<TabItem value="v2" label="v2 (beta)">
+
+v2 is released as `2.0.0-beta.x` prereleases until GA. Use `2.0.0-beta.1` or the latest `2.0.0-beta.x` prerelease as the version. During beta, we recommend selecting the prerelease explicitly instead of relying on a normal version range to pick it automatically.
+
+If you use `Package.swift` directly:
+
+```swift title="Package.swift"
+.package(url: "https://github.com/logto-io/swift.git", exact: "2.0.0-beta.1")
+```
+
+</TabItem>
+
+<TabItem value="v1" label="v1">
+
+Use the latest v1 release as the stable line. The latest v1 version is `1.2.0`.
+
+If you use `Package.swift` directly:
+
+```swift title="Package.swift"
+.package(url: "https://github.com/logto-io/swift.git", from: "1.2.0")
+```
+
+</TabItem>
+
+</Tabs>
+
+We do not support **Carthage** and **CocoaPods** at the time due to some technical issues.
 
 <details>
 
@@ -16,7 +60,7 @@ https://github.com/logto-io/swift.git
 
 </summary>
 
-Carthage [ต้องการไฟล์ `xcodeproj` เพื่อ build](https://github.com/Carthage/Carthage/issues/1226#issuecomment-290931385) แต่ `swift package generate-xcodeproj` จะรายงานข้อผิดพลาด เนื่องจากเราใช้ binary targets สำหรับปลั๊กอินโซเชียลแบบ native เราจะพยายามหาวิธีแก้ไขในภายหลัง
+Carthage [needs a `xcodeproj` file to build](https://github.com/Carthage/Carthage/issues/1226#issuecomment-290931385). We will try to find a workaround later.
 
 </details>
 
@@ -28,6 +72,6 @@ Carthage [ต้องการไฟล์ `xcodeproj` เพื่อ build](h
 
 </summary>
 
-CocoaPods [ไม่รองรับ local dependency](https://github.com/CocoaPods/CocoaPods/issues/3276) และ monorepo ดังนั้นจึงยากที่จะสร้าง `.podspec` สำหรับ repo นี้
+CocoaPods [does not support local dependency](https://github.com/CocoaPods/CocoaPods/issues/3276) and monorepo, thus it&apos;s hard to create a `.podspec` for this repo.
 
 </details>

--- a/i18n/th/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_implement-sign-in-and-sign-out.mdx
+++ b/i18n/th/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_implement-sign-in-and-sign-out.mdx
@@ -1,10 +1,68 @@
+import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs';
+
 import ConfigureRedirectUri from '../../fragments/_configure-redirect-uri.mdx';
 import SignInNote from '../../fragments/_sign-in-note.mdx';
 import SignInFlowSummary from '../../fragments/_web-sign-in-flow-summary.mdx';
 
 <SignInFlowSummary />
 
-#### กำหนดค่า Redirect URI \{#configure-redirect-uri}
+#### Configure redirect URI \{#configure-redirect-uri}
+
+<Tabs groupId="swift-sdk-version" defaultValue="v2">
+
+<TabItem value="v2" label="v2 (beta)">
+
+<ConfigureRedirectUri
+  figureSrc="/img/assets/ios-redirect-uri.png"
+  redirectUri="io.logto.app://callback"
+/>
+
+In v2, the sign-in experience opens in [`ASWebAuthenticationSession`](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession) (the system browser), and the redirect is routed back to your app through OS-level callback matching. For a custom scheme redirect URI such as `io.logto.app://callback`, register only the scheme part (`io.logto.app`) in your app's `Info.plist`, then add the full redirect URI to your Logto application's Redirect URIs.
+
+In Xcode, open your app target, select **Info**, expand **URL Types**, and add one entry with `io.logto.app` in **URL Schemes**. If you edit `Info.plist` directly, add:
+
+```xml title="Info.plist"
+<key>CFBundleURLTypes</key>
+<array>
+  <dict>
+    <key>CFBundleTypeRole</key>
+    <string>Editor</string>
+    <key>CFBundleURLName</key>
+    <string>io.logto.app</string>
+    <key>CFBundleURLSchemes</key>
+    <array>
+      <string>io.logto.app</string>
+    </array>
+  </dict>
+</array>
+```
+
+For the browser flow in v2, you do not need to call `LogtoClient.handle(url:)`; that plugin handoff API was removed with the embedded WebView flow.
+
+<details>
+
+<summary>
+
+#### Use Universal Links instead of a custom scheme? \{#use-universal-links-instead-of-a-custom-scheme}
+
+</summary>
+
+You can also use an HTTPS redirect URI such as `https://example.com/callback`:
+
+1. Add the Associated Domains capability to your app.
+2. Configure `webcredentials:example.com` so `ASWebAuthenticationSession` can match HTTPS callbacks on iOS 17.4 and newer.
+3. If the same URL should also open your app as a Universal Link outside the authentication session, configure `applinks:example.com` and host a valid `apple-app-site-association` file for the domain and path.
+4. Add the HTTPS URI to your Logto application's Redirect URIs.
+5. Pass the same URI to `signInWithBrowser`.
+
+On iOS 17.4 and newer, the SDK uses `ASWebAuthenticationSession`'s HTTPS callback matching API so HTTPS redirects can automatically complete and dismiss the session. On older iOS versions, the authorization request can still use the HTTPS redirect URI, but the session may not close automatically unless your app handles the Universal Link callback itself. Keep a custom scheme redirect as a compatibility option if you need automatic completion on older iOS versions.
+
+</details>
+
+</TabItem>
+
+<TabItem value="v1" label="v1">
 
 <ConfigureRedirectUri
   figureSrc="/img/assets/ios-redirect-uri.png"
@@ -12,16 +70,82 @@ import SignInFlowSummary from '../../fragments/_web-sign-in-flow-summary.mdx';
 />
 
 :::info
-Redirect URI ใน iOS SDK ใช้สำหรับการทำงานภายในเท่านั้น _ไม่จำเป็นต้อง_ เพิ่ม [Custom URL Scheme](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app) จนกว่าจะมีตัวเชื่อมต่อร้องขอ
+The Redirect URI in iOS SDK is only for internal use. There's _NO NEED_ to add a [Custom URL Scheme](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app) until a connector asks.
 :::
 
-#### การลงชื่อเข้าใช้และออกจากระบบ \{#sign-in-and-sign-out}
+</TabItem>
+
+</Tabs>
+
+#### Sign-in and sign-out \{#sign-in-and-sign-out}
 
 <SignInNote calling=".signInWithBrowser(redirectUri:)" />
 
-คุณสามารถใช้ `client.signInWithBrowser(redirectUri:)` เพื่อให้ผู้ใช้ลงชื่อเข้าใช้ และ `client.signOut()` เพื่อออกจากระบบ
+<Tabs groupId="swift-sdk-version" defaultValue="v2">
 
-ตัวอย่างเช่น ในแอป SwiftUI:
+<TabItem value="v2" label="v2 (beta)">
+
+In v2, `client.signOut(postLogoutRedirectUri:)` performs a complete sign-out: it clears the local credentials, revokes the refresh token, and ends the Logto session by opening the end session endpoint in the system browser. The browser then navigates back to your app through the post sign-out redirect URI. Before using it, switch to the application details page of Logto Console, add the post sign-out redirect URI `io.logto.app://signed-out` and click "Save changes". The post sign-out redirect URI can use the same custom scheme you registered for sign-in.
+
+For example, in a SwiftUI app:
+
+```swift title="ContentView.swift"
+struct ContentView: View {
+  @State var isAuthenticated: Bool
+
+  private let redirectUri = "io.logto.app://callback"
+  private let postLogoutRedirectUri = "io.logto.app://signed-out"
+
+  init() {
+    isAuthenticated = client.isAuthenticated
+  }
+
+  var body: some View {
+    VStack {
+      if isAuthenticated {
+        Button("Sign Out") {
+          Task { [self] in
+            let error = await client.signOut(postLogoutRedirectUri: postLogoutRedirectUri)
+            if let error = error {
+              print(error)
+              return
+            }
+            isAuthenticated = false
+          }
+        }
+      } else {
+        Button("Sign In") {
+          Task { [self] in
+            do {
+              try await client.signInWithBrowser(redirectUri: redirectUri)
+              isAuthenticated = true
+            } catch let error as LogtoClientErrors.SignIn {
+              // error occurred during sign in
+            } catch {
+              // other errors
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+:::note
+
+- You can also call `client.signOut()` without a post sign-out redirect URI. No Console configuration is needed in this case: the browser shows the Logto sign-out page, and the user returns to the app by dismissing it manually.
+- If no UI context is available, you can call `client.clearCredentials()` to clear the local credentials and revoke the refresh token. Note that this keeps the Logto session in the browser, so the next `signInWithBrowser` may silently sign the user back in through that session.
+
+:::
+
+</TabItem>
+
+<TabItem value="v1" label="v1">
+
+You can use `client.signInWithBrowser(redirectUri:)` to sign in the user and `client.signOut()` to sign out the user.
+
+For example, in a SwiftUI app:
 
 ```swift title="ContentView.swift"
 struct ContentView: View {
@@ -44,14 +168,12 @@ struct ContentView: View {
         Button("Sign In") {
           Task { [self] in
             do {
-              try await client.signInWithBrowser(redirectUri: "${
-                props.redirectUris[0] ?? 'io.logto://callback'
-              }")
+              try await client.signInWithBrowser(redirectUri: "io.logto://callback")
               isAuthenticated = true
             } catch let error as LogtoClientErrors.SignIn {
-              // เกิดข้อผิดพลาดระหว่างการลงชื่อเข้าใช้
+              // error occurred during sign in
             } catch {
-              // ข้อผิดพลาดอื่น ๆ
+              // other errors
             }
           }
         }
@@ -60,3 +182,7 @@ struct ContentView: View {
   }
 }
 ```
+
+</TabItem>
+
+</Tabs>

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_add-sdk.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_add-sdk.mdx
@@ -1,12 +1,56 @@
-使用以下 URL 将 Logto SDK 添加为 Swift Package Manager 中的依赖项。
+import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs';
+
+:::note
+The minimum supported iOS version of Logto Swift SDK is iOS 13.
+:::
+
+Logto Swift SDK comes in two major versions:
+
+- **v1**: Opens the sign-in experience in an embedded WebView, which is required by the native social plugin targets, but does not support <MainSiteUrl href="/end-user-flows/sign-up-and-sign-in/passkey-sign-in">passkey sign-in</MainSiteUrl> (WebView does not support WebAuthn, the underlying standard of passkeys).
+- **v2 (beta)**: Opens the sign-in experience in [`ASWebAuthenticationSession`](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession) (the system browser), which unlocks passkey sign-in and shares the browser session. Note that v2 removes the native social plugin targets; social connectors still work through the browser. If you depend on the native WeChat or Alipay SDK handoff, stay on v1.
+
+This guide covers both versions. Choose your version in the tabs below, and the choice will be kept in sync throughout this guide.
+
+Use the following URL to add Logto SDK as a dependency in Swift Package Manager.
 
 ```bash
 https://github.com/logto-io/swift.git
 ```
 
-自 Xcode 11 起，你可以 [直接导入 Swift 包](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app)，无需任何额外工具。
+Since Xcode 11, you can [directly import a Swift package](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) w/o any additional tool.
 
-由于一些技术问题，我们目前不支持 **Carthage** 和 **CocoaPods**。
+When Xcode asks for the package version, choose the version you want to integrate:
+
+<Tabs groupId="swift-sdk-version" defaultValue="v2">
+
+<TabItem value="v2" label="v2 (beta)">
+
+v2 is released as `2.0.0-beta.x` prereleases until GA. Use `2.0.0-beta.1` or the latest `2.0.0-beta.x` prerelease as the version. During beta, we recommend selecting the prerelease explicitly instead of relying on a normal version range to pick it automatically.
+
+If you use `Package.swift` directly:
+
+```swift title="Package.swift"
+.package(url: "https://github.com/logto-io/swift.git", exact: "2.0.0-beta.1")
+```
+
+</TabItem>
+
+<TabItem value="v1" label="v1">
+
+Use the latest v1 release as the stable line. The latest v1 version is `1.2.0`.
+
+If you use `Package.swift` directly:
+
+```swift title="Package.swift"
+.package(url: "https://github.com/logto-io/swift.git", from: "1.2.0")
+```
+
+</TabItem>
+
+</Tabs>
+
+We do not support **Carthage** and **CocoaPods** at the time due to some technical issues.
 
 <details>
 
@@ -16,7 +60,7 @@ https://github.com/logto-io/swift.git
 
 </summary>
 
-Carthage [需要一个 `xcodeproj` 文件来构建](https://github.com/Carthage/Carthage/issues/1226#issuecomment-290931385)，但是 `swift package generate-xcodeproj` 会报告失败，因为我们使用了本机社交插件的二进制目标。我们会尝试寻找解决方法。
+Carthage [needs a `xcodeproj` file to build](https://github.com/Carthage/Carthage/issues/1226#issuecomment-290931385). We will try to find a workaround later.
 
 </details>
 
@@ -28,6 +72,6 @@ Carthage [需要一个 `xcodeproj` 文件来构建](https://github.com/Carthage/
 
 </summary>
 
-CocoaPods [不支持本地依赖](https://github.com/CocoaPods/CocoaPods/issues/3276)和 monorepo，因此很难为此仓库创建 `.podspec` 文件。
+CocoaPods [does not support local dependency](https://github.com/CocoaPods/CocoaPods/issues/3276) and monorepo, thus it&apos;s hard to create a `.podspec` for this repo.
 
 </details>

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_implement-sign-in-and-sign-out.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_implement-sign-in-and-sign-out.mdx
@@ -1,10 +1,68 @@
+import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs';
+
 import ConfigureRedirectUri from '../../fragments/_configure-redirect-uri.mdx';
 import SignInNote from '../../fragments/_sign-in-note.mdx';
 import SignInFlowSummary from '../../fragments/_web-sign-in-flow-summary.mdx';
 
 <SignInFlowSummary />
 
-#### 配置重定向 URI \{#configure-redirect-uri}
+#### Configure redirect URI \{#configure-redirect-uri}
+
+<Tabs groupId="swift-sdk-version" defaultValue="v2">
+
+<TabItem value="v2" label="v2 (beta)">
+
+<ConfigureRedirectUri
+  figureSrc="/img/assets/ios-redirect-uri.png"
+  redirectUri="io.logto.app://callback"
+/>
+
+In v2, the sign-in experience opens in [`ASWebAuthenticationSession`](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession) (the system browser), and the redirect is routed back to your app through OS-level callback matching. For a custom scheme redirect URI such as `io.logto.app://callback`, register only the scheme part (`io.logto.app`) in your app's `Info.plist`, then add the full redirect URI to your Logto application's Redirect URIs.
+
+In Xcode, open your app target, select **Info**, expand **URL Types**, and add one entry with `io.logto.app` in **URL Schemes**. If you edit `Info.plist` directly, add:
+
+```xml title="Info.plist"
+<key>CFBundleURLTypes</key>
+<array>
+  <dict>
+    <key>CFBundleTypeRole</key>
+    <string>Editor</string>
+    <key>CFBundleURLName</key>
+    <string>io.logto.app</string>
+    <key>CFBundleURLSchemes</key>
+    <array>
+      <string>io.logto.app</string>
+    </array>
+  </dict>
+</array>
+```
+
+For the browser flow in v2, you do not need to call `LogtoClient.handle(url:)`; that plugin handoff API was removed with the embedded WebView flow.
+
+<details>
+
+<summary>
+
+#### Use Universal Links instead of a custom scheme? \{#use-universal-links-instead-of-a-custom-scheme}
+
+</summary>
+
+You can also use an HTTPS redirect URI such as `https://example.com/callback`:
+
+1. Add the Associated Domains capability to your app.
+2. Configure `webcredentials:example.com` so `ASWebAuthenticationSession` can match HTTPS callbacks on iOS 17.4 and newer.
+3. If the same URL should also open your app as a Universal Link outside the authentication session, configure `applinks:example.com` and host a valid `apple-app-site-association` file for the domain and path.
+4. Add the HTTPS URI to your Logto application's Redirect URIs.
+5. Pass the same URI to `signInWithBrowser`.
+
+On iOS 17.4 and newer, the SDK uses `ASWebAuthenticationSession`'s HTTPS callback matching API so HTTPS redirects can automatically complete and dismiss the session. On older iOS versions, the authorization request can still use the HTTPS redirect URI, but the session may not close automatically unless your app handles the Universal Link callback itself. Keep a custom scheme redirect as a compatibility option if you need automatic completion on older iOS versions.
+
+</details>
+
+</TabItem>
+
+<TabItem value="v1" label="v1">
 
 <ConfigureRedirectUri
   figureSrc="/img/assets/ios-redirect-uri.png"
@@ -12,16 +70,82 @@ import SignInFlowSummary from '../../fragments/_web-sign-in-flow-summary.mdx';
 />
 
 :::info
-iOS SDK 中的重定向 URI 仅供内部使用。_不需要_ 添加 [自定义 URL 方案](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app) ，除非连接器要求。
+The Redirect URI in iOS SDK is only for internal use. There's _NO NEED_ to add a [Custom URL Scheme](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app) until a connector asks.
 :::
 
-#### 登录和登出 \{#sign-in-and-sign-out}
+</TabItem>
+
+</Tabs>
+
+#### Sign-in and sign-out \{#sign-in-and-sign-out}
 
 <SignInNote calling=".signInWithBrowser(redirectUri:)" />
 
-你可以使用 `client.signInWithBrowser(redirectUri:)` 来让用户登录，并使用 `client.signOut()` 来让用户登出。
+<Tabs groupId="swift-sdk-version" defaultValue="v2">
 
-例如，在 SwiftUI 应用中：
+<TabItem value="v2" label="v2 (beta)">
+
+In v2, `client.signOut(postLogoutRedirectUri:)` performs a complete sign-out: it clears the local credentials, revokes the refresh token, and ends the Logto session by opening the end session endpoint in the system browser. The browser then navigates back to your app through the post sign-out redirect URI. Before using it, switch to the application details page of Logto Console, add the post sign-out redirect URI `io.logto.app://signed-out` and click "Save changes". The post sign-out redirect URI can use the same custom scheme you registered for sign-in.
+
+For example, in a SwiftUI app:
+
+```swift title="ContentView.swift"
+struct ContentView: View {
+  @State var isAuthenticated: Bool
+
+  private let redirectUri = "io.logto.app://callback"
+  private let postLogoutRedirectUri = "io.logto.app://signed-out"
+
+  init() {
+    isAuthenticated = client.isAuthenticated
+  }
+
+  var body: some View {
+    VStack {
+      if isAuthenticated {
+        Button("Sign Out") {
+          Task { [self] in
+            let error = await client.signOut(postLogoutRedirectUri: postLogoutRedirectUri)
+            if let error = error {
+              print(error)
+              return
+            }
+            isAuthenticated = false
+          }
+        }
+      } else {
+        Button("Sign In") {
+          Task { [self] in
+            do {
+              try await client.signInWithBrowser(redirectUri: redirectUri)
+              isAuthenticated = true
+            } catch let error as LogtoClientErrors.SignIn {
+              // error occurred during sign in
+            } catch {
+              // other errors
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+:::note
+
+- You can also call `client.signOut()` without a post sign-out redirect URI. No Console configuration is needed in this case: the browser shows the Logto sign-out page, and the user returns to the app by dismissing it manually.
+- If no UI context is available, you can call `client.clearCredentials()` to clear the local credentials and revoke the refresh token. Note that this keeps the Logto session in the browser, so the next `signInWithBrowser` may silently sign the user back in through that session.
+
+:::
+
+</TabItem>
+
+<TabItem value="v1" label="v1">
+
+You can use `client.signInWithBrowser(redirectUri:)` to sign in the user and `client.signOut()` to sign out the user.
+
+For example, in a SwiftUI app:
 
 ```swift title="ContentView.swift"
 struct ContentView: View {
@@ -44,12 +168,10 @@ struct ContentView: View {
         Button("Sign In") {
           Task { [self] in
             do {
-              try await client.signInWithBrowser(redirectUri: "${
-                props.redirectUris[0] ?? 'io.logto://callback'
-              }")
+              try await client.signInWithBrowser(redirectUri: "io.logto://callback")
               isAuthenticated = true
             } catch let error as LogtoClientErrors.SignIn {
-              // error occured during sign in
+              // error occurred during sign in
             } catch {
               // other errors
             }
@@ -60,3 +182,7 @@ struct ContentView: View {
   }
 }
 ```
+
+</TabItem>
+
+</Tabs>

--- a/i18n/zh-TW/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_add-sdk.mdx
+++ b/i18n/zh-TW/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_add-sdk.mdx
@@ -1,12 +1,56 @@
-使用以下 URL 在 Swift Package Manager 中新增 Logto SDK 作為相依項目。
+import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs';
+
+:::note
+The minimum supported iOS version of Logto Swift SDK is iOS 13.
+:::
+
+Logto Swift SDK comes in two major versions:
+
+- **v1**: Opens the sign-in experience in an embedded WebView, which is required by the native social plugin targets, but does not support <MainSiteUrl href="/end-user-flows/sign-up-and-sign-in/passkey-sign-in">passkey sign-in</MainSiteUrl> (WebView does not support WebAuthn, the underlying standard of passkeys).
+- **v2 (beta)**: Opens the sign-in experience in [`ASWebAuthenticationSession`](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession) (the system browser), which unlocks passkey sign-in and shares the browser session. Note that v2 removes the native social plugin targets; social connectors still work through the browser. If you depend on the native WeChat or Alipay SDK handoff, stay on v1.
+
+This guide covers both versions. Choose your version in the tabs below, and the choice will be kept in sync throughout this guide.
+
+Use the following URL to add Logto SDK as a dependency in Swift Package Manager.
 
 ```bash
 https://github.com/logto-io/swift.git
 ```
 
-自 Xcode 11 起，你可以[直接匯入 Swift package](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app)，無需任何額外工具。
+Since Xcode 11, you can [directly import a Swift package](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) w/o any additional tool.
 
-由於一些技術問題，我們目前不支援 **Carthage** 和 **CocoaPods**。
+When Xcode asks for the package version, choose the version you want to integrate:
+
+<Tabs groupId="swift-sdk-version" defaultValue="v2">
+
+<TabItem value="v2" label="v2 (beta)">
+
+v2 is released as `2.0.0-beta.x` prereleases until GA. Use `2.0.0-beta.1` or the latest `2.0.0-beta.x` prerelease as the version. During beta, we recommend selecting the prerelease explicitly instead of relying on a normal version range to pick it automatically.
+
+If you use `Package.swift` directly:
+
+```swift title="Package.swift"
+.package(url: "https://github.com/logto-io/swift.git", exact: "2.0.0-beta.1")
+```
+
+</TabItem>
+
+<TabItem value="v1" label="v1">
+
+Use the latest v1 release as the stable line. The latest v1 version is `1.2.0`.
+
+If you use `Package.swift` directly:
+
+```swift title="Package.swift"
+.package(url: "https://github.com/logto-io/swift.git", from: "1.2.0")
+```
+
+</TabItem>
+
+</Tabs>
+
+We do not support **Carthage** and **CocoaPods** at the time due to some technical issues.
 
 <details>
 
@@ -16,7 +60,7 @@ https://github.com/logto-io/swift.git
 
 </summary>
 
-Carthage [需要一個 `xcodeproj` 檔案來建置](https://github.com/Carthage/Carthage/issues/1226#issuecomment-290931385)，但由於我們使用原生社交插件的二進位目標，`swift package generate-xcodeproj` 會報錯。我們將嘗試尋找解決方案。
+Carthage [needs a `xcodeproj` file to build](https://github.com/Carthage/Carthage/issues/1226#issuecomment-290931385). We will try to find a workaround later.
 
 </details>
 
@@ -28,6 +72,6 @@ Carthage [需要一個 `xcodeproj` 檔案來建置](https://github.com/Carthage/
 
 </summary>
 
-CocoaPods [不支援本地相依項目](https://github.com/CocoaPods/CocoaPods/issues/3276)和 monorepo，因此很難為此 repo 創建 `.podspec`。
+CocoaPods [does not support local dependency](https://github.com/CocoaPods/CocoaPods/issues/3276) and monorepo, thus it&apos;s hard to create a `.podspec` for this repo.
 
 </details>

--- a/i18n/zh-TW/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_implement-sign-in-and-sign-out.mdx
+++ b/i18n/zh-TW/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_implement-sign-in-and-sign-out.mdx
@@ -1,10 +1,68 @@
+import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs';
+
 import ConfigureRedirectUri from '../../fragments/_configure-redirect-uri.mdx';
 import SignInNote from '../../fragments/_sign-in-note.mdx';
 import SignInFlowSummary from '../../fragments/_web-sign-in-flow-summary.mdx';
 
 <SignInFlowSummary />
 
-#### 設定重定向 URI \{#configure-redirect-uri}
+#### Configure redirect URI \{#configure-redirect-uri}
+
+<Tabs groupId="swift-sdk-version" defaultValue="v2">
+
+<TabItem value="v2" label="v2 (beta)">
+
+<ConfigureRedirectUri
+  figureSrc="/img/assets/ios-redirect-uri.png"
+  redirectUri="io.logto.app://callback"
+/>
+
+In v2, the sign-in experience opens in [`ASWebAuthenticationSession`](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession) (the system browser), and the redirect is routed back to your app through OS-level callback matching. For a custom scheme redirect URI such as `io.logto.app://callback`, register only the scheme part (`io.logto.app`) in your app's `Info.plist`, then add the full redirect URI to your Logto application's Redirect URIs.
+
+In Xcode, open your app target, select **Info**, expand **URL Types**, and add one entry with `io.logto.app` in **URL Schemes**. If you edit `Info.plist` directly, add:
+
+```xml title="Info.plist"
+<key>CFBundleURLTypes</key>
+<array>
+  <dict>
+    <key>CFBundleTypeRole</key>
+    <string>Editor</string>
+    <key>CFBundleURLName</key>
+    <string>io.logto.app</string>
+    <key>CFBundleURLSchemes</key>
+    <array>
+      <string>io.logto.app</string>
+    </array>
+  </dict>
+</array>
+```
+
+For the browser flow in v2, you do not need to call `LogtoClient.handle(url:)`; that plugin handoff API was removed with the embedded WebView flow.
+
+<details>
+
+<summary>
+
+#### Use Universal Links instead of a custom scheme? \{#use-universal-links-instead-of-a-custom-scheme}
+
+</summary>
+
+You can also use an HTTPS redirect URI such as `https://example.com/callback`:
+
+1. Add the Associated Domains capability to your app.
+2. Configure `webcredentials:example.com` so `ASWebAuthenticationSession` can match HTTPS callbacks on iOS 17.4 and newer.
+3. If the same URL should also open your app as a Universal Link outside the authentication session, configure `applinks:example.com` and host a valid `apple-app-site-association` file for the domain and path.
+4. Add the HTTPS URI to your Logto application's Redirect URIs.
+5. Pass the same URI to `signInWithBrowser`.
+
+On iOS 17.4 and newer, the SDK uses `ASWebAuthenticationSession`'s HTTPS callback matching API so HTTPS redirects can automatically complete and dismiss the session. On older iOS versions, the authorization request can still use the HTTPS redirect URI, but the session may not close automatically unless your app handles the Universal Link callback itself. Keep a custom scheme redirect as a compatibility option if you need automatic completion on older iOS versions.
+
+</details>
+
+</TabItem>
+
+<TabItem value="v1" label="v1">
 
 <ConfigureRedirectUri
   figureSrc="/img/assets/ios-redirect-uri.png"
@@ -12,16 +70,82 @@ import SignInFlowSummary from '../../fragments/_web-sign-in-flow-summary.mdx';
 />
 
 :::info
-iOS SDK 中的重定向 URI 僅供內部使用。在連接器要求之前，_不需要_ 添加 [自訂 URL Scheme](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app)。
+The Redirect URI in iOS SDK is only for internal use. There's _NO NEED_ to add a [Custom URL Scheme](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app) until a connector asks.
 :::
 
-#### 登入與登出 \{#sign-in-and-sign-out}
+</TabItem>
+
+</Tabs>
+
+#### Sign-in and sign-out \{#sign-in-and-sign-out}
 
 <SignInNote calling=".signInWithBrowser(redirectUri:)" />
 
-你可以使用 `client.signInWithBrowser(redirectUri:)` 來讓使用者登入，並使用 `client.signOut()` 來讓使用者登出。
+<Tabs groupId="swift-sdk-version" defaultValue="v2">
 
-例如，在 SwiftUI 應用程式中：
+<TabItem value="v2" label="v2 (beta)">
+
+In v2, `client.signOut(postLogoutRedirectUri:)` performs a complete sign-out: it clears the local credentials, revokes the refresh token, and ends the Logto session by opening the end session endpoint in the system browser. The browser then navigates back to your app through the post sign-out redirect URI. Before using it, switch to the application details page of Logto Console, add the post sign-out redirect URI `io.logto.app://signed-out` and click "Save changes". The post sign-out redirect URI can use the same custom scheme you registered for sign-in.
+
+For example, in a SwiftUI app:
+
+```swift title="ContentView.swift"
+struct ContentView: View {
+  @State var isAuthenticated: Bool
+
+  private let redirectUri = "io.logto.app://callback"
+  private let postLogoutRedirectUri = "io.logto.app://signed-out"
+
+  init() {
+    isAuthenticated = client.isAuthenticated
+  }
+
+  var body: some View {
+    VStack {
+      if isAuthenticated {
+        Button("Sign Out") {
+          Task { [self] in
+            let error = await client.signOut(postLogoutRedirectUri: postLogoutRedirectUri)
+            if let error = error {
+              print(error)
+              return
+            }
+            isAuthenticated = false
+          }
+        }
+      } else {
+        Button("Sign In") {
+          Task { [self] in
+            do {
+              try await client.signInWithBrowser(redirectUri: redirectUri)
+              isAuthenticated = true
+            } catch let error as LogtoClientErrors.SignIn {
+              // error occurred during sign in
+            } catch {
+              // other errors
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+:::note
+
+- You can also call `client.signOut()` without a post sign-out redirect URI. No Console configuration is needed in this case: the browser shows the Logto sign-out page, and the user returns to the app by dismissing it manually.
+- If no UI context is available, you can call `client.clearCredentials()` to clear the local credentials and revoke the refresh token. Note that this keeps the Logto session in the browser, so the next `signInWithBrowser` may silently sign the user back in through that session.
+
+:::
+
+</TabItem>
+
+<TabItem value="v1" label="v1">
+
+You can use `client.signInWithBrowser(redirectUri:)` to sign in the user and `client.signOut()` to sign out the user.
+
+For example, in a SwiftUI app:
 
 ```swift title="ContentView.swift"
 struct ContentView: View {
@@ -44,14 +168,12 @@ struct ContentView: View {
         Button("Sign In") {
           Task { [self] in
             do {
-              try await client.signInWithBrowser(redirectUri: "${
-                props.redirectUris[0] ?? 'io.logto://callback'
-              }")
+              try await client.signInWithBrowser(redirectUri: "io.logto://callback")
               isAuthenticated = true
             } catch let error as LogtoClientErrors.SignIn {
-              // 登入過程中發生錯誤
+              // error occurred during sign in
             } catch {
-              // 其他錯誤
+              // other errors
             }
           }
         }
@@ -60,3 +182,7 @@ struct ContentView: View {
   }
 }
 ```
+
+</TabItem>
+
+</Tabs>


### PR DESCRIPTION
## Summary

- add v1 / v2 tabs to the Swift SDK quick-start installation and integration guide
- document Swift SDK v2 beta installation with `2.0.0-beta.1`
- update redirect URI setup for the v2 `ASWebAuthenticationSession` flow, including custom scheme registration and Universal Links notes
- document v2 browser sign-out via `signOut(postLogoutRedirectUri:)`, sign-out without redirect, and `clearCredentials()`
- sync the updated Swift quick-start fragments to localized current docs, following the Android docs update pattern in #1423

## Verification

- `git diff --check`
- `pnpm exec eslint docs/quick-starts/framework/swift/_add-sdk.mdx docs/quick-starts/framework/swift/_implement-sign-in-and-sign-out.mdx i18n/de/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_add-sdk.mdx i18n/de/docusaurus-plugin-content-docs/current/quick-starts/framework/swift/_implement-sign-in-and-sign-out.mdx`
- `pnpm build`