### PR TITLE
docs: document send rate limiting and Message.RateLimited webhook

### DIFF
--- a/docs/developers/webhooks/events.mdx
+++ b/docs/developers/webhooks/events.mdx
@@ -125,9 +125,10 @@ This guide list the different Logto webhook events and explains when each event 
 
 ### Security \{#security}
 
-| Event type         | Description                                                                                                                                                                                                                                                 |
-| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Identifier.Lockout | A user account is locked due to consecutive failed identity verification attempts. Can be triggered in the following flows:<br /><ul><li>Password verification failed</li><li>Code verification failed</li><li>One-time token verification failed</li></ul> |
+| Event type          | Description                                                                                                                                                                                                                                                 |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Identifier.Lockout  | A user account is locked due to consecutive failed identity verification attempts. Can be triggered in the following flows:<br /><ul><li>Password verification failed</li><li>Code verification failed</li><li>One-time token verification failed</li></ul> |
+| Message.RateLimited | An end user exceeds the per-recipient [send rate limit](/security/send-rate-limit) for verification codes. Fires only on the end-user send paths (Experience API and Account API), with a payload of `{ action, recipient }`.                               |
 
 ## FAQs \{#faqs}
 

--- a/docs/security/README.mdx
+++ b/docs/security/README.mdx
@@ -60,6 +60,16 @@ Logto delivers robust secure access management designed to counter these risks h
     },
     {
       type: 'link',
+      label: 'Send rate limit',
+      href: '/security/send-rate-limit',
+      description:
+        'Cap verification code and message sends per recipient to prevent inbox spam and SMS pumping abuse.',
+      customProps: {
+        icon: <SendEmailIcon />,
+      },
+    },
+    {
+      type: 'link',
       label: 'Hide account existence',
       href: '/end-user-flows/sign-up-and-sign-in',
       description:

--- a/docs/security/send-rate-limit.mdx
+++ b/docs/security/send-rate-limit.mdx
@@ -1,0 +1,38 @@
+---
+slug: /security/send-rate-limit
+sidebar_label: Send rate limit
+sidebar_position: 5
+---
+
+# Send rate limiting
+
+Logto applies a built-in, per-recipient rate limit to outbound verification codes and other messages sent over email and SMS. It protects your users and your messaging providers from send abuse—such as an attacker spamming a victim's inbox or phone with codes, or pumping SMS traffic to inflate your costs.
+
+This limit is **mandatory and system-level**: it applies to every tenant regardless of plan and is **not** tenant-configurable. It is independent of:
+
+- The **[identifier lockout](/security/identifier-lockout)** and **[CAPTCHA](/security/captcha)** policies, which throttle _failed verification attempts_ at verify-time rather than the act of _sending_.
+- The global per-tenant API rate limit (error code `request.rate_limited`), which bounds overall request volume across a tenant.
+
+## How it works \{#how-it-works}
+
+- **Per-recipient cap**: Logto limits how many messages can be sent to the same recipient (email address or phone number) within a short rolling time window. By default, this allows up to **10 sends per recipient every 10 minutes**.
+- **Where it applies**: all server-side send paths, including Experience API and Account API verification-code sends (sign-in, register, reset password, MFA, and identifier binding), Management API verification-code sends, organization invitation send and resend, and Account (`/me`) verification-code sends.
+- **When the cap is exceeded**: the request is rejected with HTTP `429` and the error code `request.message_rate_limited`—distinct from the global tenant limiter (`request.rate_limited`) and the verify-time lockout (`session.verification_blocked_too_many_attempts`), so you can handle it specifically in your integration.
+
+## Monitor rate-limited sends with a webhook \{#monitor-rate-limited-sends-with-a-webhook}
+
+When an **end user** hits the per-recipient cap, Logto triggers the `Message.RateLimited` [webhook event](/developers/webhooks/webhooks-events#exception-hook-events), so you can alert on or respond to send abuse.
+
+- **Fires for**: end-user verification-code send paths only—the Experience API and Account API. It does **not** fire for first-party or admin-initiated sends (Management API verification codes, organization invitations, or `/me`).
+- **Payload**: the hook context includes the `action` (for example, `VerificationCodeSend`) and the `recipient` (the email address or phone number).
+
+**Common use cases:**
+
+- Send security alerts to your team for review.
+- Trigger downstream anti-abuse automation for the affected recipient.
+
+Navigate to <CloudLink to="/webhooks">Console > Webhooks</CloudLink> to subscribe, or create the hook via the Management API. For the detailed event structure and configuration, see [Webhooks](/developers/webhooks).
+
+## Suppressed delivery to unknown recipients \{#suppressed-delivery-to-unknown-recipients}
+
+To prevent account enumeration, when sign-up via an identifier is disabled, a sign-in verification code requested for an email address or phone number that **no account owns** is silently not delivered, and the API responds the same as it would for a real send. An attacker therefore can't use these responses to tell which addresses are registered. Delivery to existing users is unaffected. See also [Hide account existence](/end-user-flows/sign-up-and-sign-in).


### PR DESCRIPTION
## Summary

Refs LOG-13687. Documents the send-time abuse-protection features shipping with the Email Security Enhancements release (logto-io/logto#9087).

- New **Security → Send rate limit** page (`docs/security/send-rate-limit.mdx`): the mandatory, system-level per-recipient send rate limit; the `429` / `request.message_rate_limited` error contract and how it differs from `request.rate_limited` and the verify-time lockout; the `Message.RateLimited` webhook (end-user paths only, `{ action, recipient }` payload); and the registration-disabled delivery-suppression (anti-enumeration) behavior.
- Adds the `Message.RateLimited` row to **Developers → Webhooks → events** (exception hook events).
- Adds a "Send rate limit" card to the **Security** index page.

**Security-conscious scoping:** the page intentionally omits the exact threshold/window, the fail-open behavior, and internal keying details — publishing those would help an attacker tune around the limit. It documents the developer-facing contract only, and does not mention the internal ops-only override.

> ⚠️ **Merge with the release.** The underlying behavior is gated behind `isDevFeaturesEnabled` until logto-io/logto#9087 ships, so this should publish alongside that release — not before.
