### PR TITLE
docs: update email blocklist wildcard usage

### DIFF
--- a/docs/security/blocklist.mdx
+++ b/docs/security/blocklist.mdx
@@ -26,6 +26,8 @@ You can create a custom email blocklist by specifying a list of email addresses 
 
 For instance, adding `@example.com` to the blocklist will block all email addresses with that domain. Similarly, adding `foo@example.com` will specifically block that email address.
 
+You can also use `*` as a wildcard in the local part or domain. For example, `foo*@example.com` blocks addresses such as `foo1@example.com` and `foo.bar@example.com`, while `@*.example.com` blocks addresses from subdomains such as `user@team.example.com`. Wildcard rules still need to follow the same email address or domain entry formats, and matching is case-insensitive. To block both a root domain and its subdomains, add both entries, such as `@example.com` and `@*.example.com`.
+
 :::note
 
 Disposable emails, subaddressing, and custom email are restricted during [new-user registration](/end-user-flows/sign-up-and-sign-in/sign-up), [linking email during social sign-in](/end-user-flows/sign-up-and-sign-in/social-sign-in#collect-sign-up-identifiers), and updating emails via [Account API](/end-user-flows/account-settings/by-account-api#update-or-link-new-email). Existing users with these email addresses can still sign in.

--- a/i18n/de/docusaurus-plugin-content-docs/current/security/blocklist.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/security/blocklist.mdx
@@ -26,6 +26,8 @@ Du kannst eine benutzerdefinierte E-Mail-Blocklist erstellen, indem du eine List
 
 Wenn du beispielsweise `@example.com` zur Blocklist hinzufügst, werden alle E-Mail-Adressen mit dieser Domain blockiert. Ebenso wird durch das Hinzufügen von `foo@example.com` genau diese E-Mail-Adresse blockiert.
 
+Du kannst `*` auch als Wildcard im lokalen Teil oder in der Domain verwenden. Zum Beispiel blockiert `foo*@example.com` Adressen wie `foo1@example.com` und `foo.bar@example.com`, während `@*.example.com` Adressen aus Subdomains wie `user@team.example.com` blockiert. Wildcard-Regeln müssen weiterhin demselben Format für E-Mail-Adressen oder Domain-Einträge folgen, und die Übereinstimmung ist nicht case-sensitiv. Um sowohl eine Root-Domain als auch ihre Subdomains zu blockieren, füge beide Einträge hinzu, z. B. `@example.com` und `@*.example.com`.
+
 :::note
 
 Wegwerf-E-Mails, Subaddressing und benutzerdefinierte E-Mails sind während der [Neuregistrierung von Benutzern](/end-user-flows/sign-up-and-sign-in/sign-up), [Verknüpfung von E-Mails während der sozialen Anmeldung](/end-user-flows/sign-up-and-sign-in/social-sign-in#collect-sign-up-identifiers) und beim Aktualisieren von E-Mails über die [Account API](/end-user-flows/account-settings/by-account-api#update-or-link-new-email) eingeschränkt. Bestehende Benutzer mit diesen E-Mail-Adressen können sich weiterhin anmelden.

--- a/i18n/es/docusaurus-plugin-content-docs/current/security/blocklist.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/current/security/blocklist.mdx
@@ -26,6 +26,8 @@ Puedes crear una lista de bloqueo de correo electrónico personalizada especific
 
 Por ejemplo, agregar `@example.com` a la lista de bloqueo bloqueará todas las direcciones de correo electrónico con ese dominio. De manera similar, agregar `foo@example.com` bloqueará específicamente esa dirección de correo electrónico.
 
+También puedes usar `*` como comodín en la parte local o en el dominio. Por ejemplo, `foo*@example.com` bloquea direcciones como `foo1@example.com` y `foo.bar@example.com`, mientras que `@*.example.com` bloquea direcciones de subdominios como `user@team.example.com`. Las reglas con comodines deben seguir usando el mismo formato de dirección de correo electrónico o entrada de dominio, y la coincidencia no distingue entre mayúsculas y minúsculas. Para bloquear tanto un dominio raíz como sus subdominios, agrega ambas entradas, como `@example.com` y `@*.example.com`.
+
 :::note
 
 Los correos electrónicos desechables, el subdireccionamiento y los correos electrónicos personalizados están restringidos durante el [registro de nuevos usuarios](/end-user-flows/sign-up-and-sign-in/sign-up), [vinculación de correo electrónico durante el inicio de sesión social](/end-user-flows/sign-up-and-sign-in/social-sign-in#collect-sign-up-identifiers), y la actualización de correos electrónicos a través de [Account API](/end-user-flows/account-settings/by-account-api#update-or-link-new-email). Los usuarios existentes con estas direcciones de correo electrónico aún pueden iniciar sesión.

--- a/i18n/fr/docusaurus-plugin-content-docs/current/security/blocklist.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/security/blocklist.mdx
@@ -26,6 +26,8 @@ Vous pouvez créer une liste de blocage personnalisée en spécifiant une liste 
 
 Par exemple, ajouter `@example.com` à la liste de blocage bloquera toutes les adresses e-mail de ce domaine. De même, ajouter `foo@example.com` bloquera spécifiquement cette adresse e-mail.
 
+Vous pouvez également utiliser `*` comme caractère générique dans la partie locale ou le domaine. Par exemple, `foo*@example.com` bloque des adresses comme `foo1@example.com` et `foo.bar@example.com`, tandis que `@*.example.com` bloque les adresses de sous-domaines comme `user@team.example.com`. Les règles avec caractère générique doivent toujours respecter les mêmes formats d'adresse e-mail ou d'entrée de domaine, et la correspondance est insensible à la casse. Pour bloquer à la fois un domaine racine et ses sous-domaines, ajoutez les deux entrées, comme `@example.com` et `@*.example.com`.
+
 :::note
 
 Les e-mails jetables, le sous-adressage et les e-mails personnalisés sont restreints lors de la [création d'un nouvel utilisateur](/end-user-flows/sign-up-and-sign-in/sign-up), [la liaison d'un e-mail lors de la connexion sociale](/end-user-flows/sign-up-and-sign-in/social-sign-in#collect-sign-up-identifiers), et la mise à jour des e-mails via [Account API](/end-user-flows/account-settings/by-account-api#update-or-link-new-email). Les utilisateurs existants avec ces adresses e-mail peuvent toujours se connecter.

--- a/i18n/ja/docusaurus-plugin-content-docs/current/security/blocklist.mdx
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/security/blocklist.mdx
@@ -27,6 +27,8 @@ sidebar_position: 3
 
 例えば、`@example.com` をブロックリストに追加すると、そのドメインのすべてのメールアドレスがブロックされます。同様に、`foo@example.com` を追加すると、そのメールアドレスのみがブロックされます。
 
+ローカルパートまたはドメインでは、`*` をワイルドカードとして使用することもできます。例えば、`foo*@example.com` は `foo1@example.com` や `foo.bar@example.com` などのアドレスをブロックし、`@*.example.com` は `user@team.example.com` などのサブドメインのアドレスをブロックします。ワイルドカードルールも、同じメールアドレスまたはドメインエントリの形式に従う必要があり、照合では大文字と小文字は区別されません。ルートドメインとそのサブドメインの両方をブロックするには、`@example.com` と `@*.example.com` のように両方のエントリを追加してください。
+
 :::note
 
 使い捨てメール、サブアドレッシング、カスタムメールは、[新規ユーザー登録](/end-user-flows/sign-up-and-sign-in/sign-up)、[ソーシャルサインイン時のメールリンク](/end-user-flows/sign-up-and-sign-in/social-sign-in#collect-sign-up-identifiers)、[Account API](/end-user-flows/account-settings/by-account-api#update-or-link-new-email) 経由でのメール更新時に制限されます。これらのメールアドレスを持つ既存ユーザーは引き続きサインインできます。

--- a/i18n/ko/docusaurus-plugin-content-docs/current/security/blocklist.mdx
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/security/blocklist.mdx
@@ -27,6 +27,8 @@ sidebar_position: 3
 
 예를 들어, 차단 목록에 `@example.com`을 추가하면 해당 도메인을 가진 모든 이메일 주소가 차단됩니다. 마찬가지로, `foo@example.com`을 추가하면 해당 이메일 주소만 차단됩니다.
 
+로컬 파트나 도메인에 `*`를 와일드카드로 사용할 수도 있습니다. 예를 들어 `foo*@example.com`은 `foo1@example.com`, `foo.bar@example.com` 같은 주소를 차단하고, `@*.example.com`은 `user@team.example.com` 같은 하위 도메인의 주소를 차단합니다. 와일드카드 규칙도 동일한 이메일 주소 또는 도메인 항목 형식을 따라야 하며, 일치는 대소문자를 구분하지 않습니다. 루트 도메인과 하위 도메인을 모두 차단하려면 `@example.com`과 `@*.example.com`처럼 두 항목을 모두 추가하세요.
+
 :::note
 
 일회용 이메일, 서브어드레싱, 사용자 지정 이메일은 [신규 사용자 등록](/end-user-flows/sign-up-and-sign-in/sign-up), [소셜 로그인 시 이메일 연결](/end-user-flows/sign-up-and-sign-in/social-sign-in#collect-sign-up-identifiers), [Account API](/end-user-flows/account-settings/by-account-api#update-or-link-new-email)를 통한 이메일 업데이트 시 제한됩니다. 이미 해당 이메일 주소를 가진 기존 사용자는 계속 로그인할 수 있습니다.

--- a/i18n/pt-BR/docusaurus-plugin-content-docs/current/security/blocklist.mdx
+++ b/i18n/pt-BR/docusaurus-plugin-content-docs/current/security/blocklist.mdx
@@ -26,6 +26,8 @@ Você pode criar uma blocklist de e-mails personalizada especificando uma lista 
 
 Por exemplo, ao adicionar `@exemplo.com` à blocklist, todos os endereços de e-mail com esse domínio serão bloqueados. Da mesma forma, ao adicionar `foo@exemplo.com`, apenas esse endereço de e-mail será bloqueado.
 
+Você também pode usar `*` como curinga na parte local ou no domínio. Por exemplo, `foo*@example.com` bloqueia endereços como `foo1@example.com` e `foo.bar@example.com`, enquanto `@*.example.com` bloqueia endereços de subdomínios, como `user@team.example.com`. As regras com curinga ainda precisam seguir os mesmos formatos de endereço de e-mail ou entrada de domínio, e a correspondência não diferencia maiúsculas de minúsculas. Para bloquear tanto um domínio raiz quanto seus subdomínios, adicione as duas entradas, como `@example.com` e `@*.example.com`.
+
 :::note
 
 E-mails descartáveis, subendereçamento e e-mails personalizados são restritos durante o [cadastro de novos usuários](/end-user-flows/sign-up-and-sign-in/sign-up), [vinculação de e-mail durante login social](/end-user-flows/sign-up-and-sign-in/social-sign-in#collect-sign-up-identifiers) e atualização de e-mails via [Account API](/end-user-flows/account-settings/by-account-api#update-or-link-new-email). Usuários existentes com esses endereços de e-mail ainda podem fazer login.

--- a/i18n/th/docusaurus-plugin-content-docs/current/security/blocklist.mdx
+++ b/i18n/th/docusaurus-plugin-content-docs/current/security/blocklist.mdx
@@ -26,6 +26,8 @@ sidebar_position: 3
 
 ตัวอย่างเช่น การเพิ่ม `@example.com` ลงในรายการบล็อกจะบล็อกอีเมลทั้งหมดที่ใช้โดเมนนั้น หรือการเพิ่ม `foo@example.com` จะบล็อกเฉพาะอีเมลนั้น
 
+คุณยังสามารถใช้ `*` เป็น wildcard ในส่วน local part หรือโดเมนได้ เช่น `foo*@example.com` จะบล็อกอีเมลอย่าง `foo1@example.com` และ `foo.bar@example.com` ส่วน `@*.example.com` จะบล็อกอีเมลจาก subdomain เช่น `user@team.example.com` กฎ wildcard ยังคงต้องอยู่ในรูปแบบที่อยู่อีเมลหรือรายการโดเมนแบบเดียวกัน และการจับคู่ไม่คำนึงถึงตัวพิมพ์เล็ก-ใหญ่ หากต้องการบล็อกทั้ง root domain และ subdomain ให้เพิ่มทั้งสองรายการ เช่น `@example.com` และ `@*.example.com`
+
 :::note
 
 อีเมลแบบใช้ครั้งเดียว, subaddressing และอีเมลแบบกำหนดเองจะถูกจำกัดในระหว่าง [การลงทะเบียนผู้ใช้ใหม่](/end-user-flows/sign-up-and-sign-in/sign-up), [การเชื่อมโยงอีเมลระหว่างการเข้าสู่ระบบโซเชียล](/end-user-flows/sign-up-and-sign-in/social-sign-in#collect-sign-up-identifiers), และการอัปเดตอีเมลผ่าน [Account API](/end-user-flows/account-settings/by-account-api#update-or-link-new-email) ผู้ใช้ที่มีอีเมลเหล่านี้อยู่แล้วสามารถลงชื่อเข้าใช้ได้ตามปกติ

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/security/blocklist.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/security/blocklist.mdx
@@ -26,6 +26,8 @@ sidebar_position: 3
 
 例如，将 `@example.com` 添加到阻止列表后，将阻止所有该域名下的邮箱地址。同样，添加 `foo@example.com` 将只阻止该邮箱地址。
 
+你也可以在邮箱用户名部分或域名中使用 `*` 作为通配符。例如，`foo*@example.com` 会阻止 `foo1@example.com`、`foo.bar@example.com` 等邮箱地址，而 `@*.example.com` 会阻止 `user@team.example.com` 等子域名下的邮箱地址。通配符规则仍需符合相同的邮箱地址或域名条目格式，且匹配时不区分大小写。若要同时阻止根域名及其子域名，请同时添加两个条目，例如 `@example.com` 和 `@*.example.com`。
+
 :::note
 
 一次性邮箱、子地址和自定义邮箱会在[新用户注册](/end-user-flows/sign-up-and-sign-in/sign-up)、[社交登录时关联邮箱](/end-user-flows/sign-up-and-sign-in/social-sign-in#collect-sign-up-identifiers)以及通过 [Account API](/end-user-flows/account-settings/by-account-api#update-or-link-new-email) 更新邮箱时被限制。已有这些邮箱地址的用户仍可登录。

--- a/i18n/zh-TW/docusaurus-plugin-content-docs/current/security/blocklist.mdx
+++ b/i18n/zh-TW/docusaurus-plugin-content-docs/current/security/blocklist.mdx
@@ -26,6 +26,8 @@ sidebar_position: 3
 
 例如，將 `@example.com` 加入封鎖清單，將封鎖所有該網域的電子郵件地址。類似地，加入 `foo@example.com` 則只會封鎖該特定電子郵件地址。
 
+你也可以在電子郵件使用者名稱部分或網域中使用 `*` 作為萬用字元。例如，`foo*@example.com` 會封鎖 `foo1@example.com`、`foo.bar@example.com` 等電子郵件地址，而 `@*.example.com` 會封鎖 `user@team.example.com` 等子網域的電子郵件地址。萬用字元規則仍需符合相同的電子郵件地址或網域項目格式，且比對時不區分大小寫。若要同時封鎖根網域及其子網域，請同時加入兩個項目，例如 `@example.com` 和 `@*.example.com`。
+
 :::note
 
 一次性電子郵件、子地址與自訂電子郵件封鎖，會在 [新使用者註冊](/end-user-flows/sign-up-and-sign-in/sign-up)、[社交登入時連結電子郵件](/end-user-flows/sign-up-and-sign-in/social-sign-in#collect-sign-up-identifiers)、以及透過 [Account API](/end-user-flows/account-settings/by-account-api#update-or-link-new-email) 更新電子郵件時生效。已存在的使用者若已使用這些電子郵件地址，仍可登入。


### PR DESCRIPTION
## Summary
- Document wildcard support for custom email blocklist rules, including local-part and domain examples.
- Clarify case-insensitive matching and how to block both a root domain and subdomains.
- Sync the same guidance to existing localized security blocklist docs.

## Testing
N/A