### PR TITLE
docs: document custom domain verification files

### DIFF
--- a/docs/logto-cloud/custom-domain.mdx
+++ b/docs/logto-cloud/custom-domain.mdx
@@ -18,6 +18,7 @@ Your custom domains are used for several functions:
 - Callback URIs for [social connectors](/connectors/social-connectors) or [enterprise SSO connectors](/connectors/enterprise-connectors).
 - [Passkey](/end-user-flows/mfa/webauthn) and [passkey sign-in](/end-user-flows/sign-up-and-sign-in/passkey-sign-in) related URLs (Changing the domain after users have linked Passkeys may block both MFA and sign-in with those credentials).
 - [SDK endpoint](/integrate-logto/application-data-structure#openid-provider-configuration-endpoint) for integrating Logto with your application.
+- Domain ownership verification files for third-party platforms (for example WeChat, Apple, or other services that require a static file on your domain).
 
 ## Multiple custom domains \{#multiple-custom-domains}
 
@@ -56,6 +57,34 @@ To add a new custom domain in the Logto Console, follow these steps:
    2. Verification typically takes a few minutes but can take up to 24 hours, depending on the DNS provider. Feel free to navigate away during the process.
 
 To add multiple custom domains, simply repeat the above steps for each domain you want to configure.
+
+## Domain verification files \{#domain-verification-files}
+
+Some third-party platforms require you to host a small text or JSON file on your domain to prove ownership before you can use their OAuth, SSO, or other integrations. Because a Logto custom domain points to Logto Cloud, you cannot upload that file to your own origin. Logto can host those files for you.
+
+After a custom domain is **Active**, open the domain card in <CloudLink to="/tenant-settings/domains">Console > Settings > Domains</CloudLink> and use the **Domain verification files** section to add, update, or remove files.
+
+**Supported paths**
+
+- Root-level filenames with an extension, such as `/MP_verify_xxx.txt` or `/apple-developer-domain-association.txt`
+- Paths under `/.well-known/`, such as `/.well-known/apple-developer-domain-association.txt`
+
+Only letters, numbers, dots, hyphens, and underscores are allowed in path segments. Nested paths outside `/.well-known/` are not supported.
+
+**Limits**
+
+- Up to **10** verification files per custom domain
+- Content size up to **16,384** characters per file
+- Content type: plain text (`text/plain`) or JSON (`application/json`)
+
+Once saved, Logto serves an exact match for `GET` and `HEAD` requests on the custom domain, for example:
+
+```
+https://auth.example.com/MP_verify_xxx.txt
+https://auth.example.com/.well-known/apple-developer-domain-association.txt
+```
+
+Existing Logto routes always take precedence. Verification files are only served when no other Logto handler matches the path.
 
 ## Troubleshooting \{#troubleshooting}
 


### PR DESCRIPTION
## Summary

Document the custom domain verification files feature released in logto-io/logto#9220 (implementation: logto-io/logto#9194).

Adds a section to the custom domains guide covering:

- When and why to use verification files (WeChat, Apple, and similar third-party ownership checks)
- How to configure them in Console after a domain is Active
- Supported paths (root filenames with extensions and `/.well-known/`)
- Limits (10 files, 16 KB content, text/JSON)
- How files are served relative to existing Logto routes

## Testing

- [x] Reviewed rendered markdown structure against the product behavior
- [ ] Local docs site preview