### PR TITLE
feat: add llms.txt

### DIFF
--- a/static/llms.txt
+++ b/static/llms.txt
@@ -1,0 +1,50 @@
+# Logto documentation
+
+> Official documentation for Logto, an identity and access management (IAM) platform for developers. Covers authentication (sign-up and sign-in, social sign-in, enterprise SSO, MFA, passwordless), authorization (RBAC, API protection), multi-tenant organizations, user management, and auth for AI agents and MCP servers, with quick starts for popular web, mobile, and backend frameworks.
+
+Logto is built on OpenID Connect (OIDC), OAuth 2.1, and SAML. It runs as a hosted service (Logto Cloud) or self-hosted from the open-source core at github.com/logto-io/logto. The product site is logto.io; this site hosts the documentation.
+
+## Getting started
+
+- [Introduction](https://docs.logto.io/introduction): What Logto is and how it works
+- [Plan your architecture](https://docs.logto.io/introduction/plan-your-architecture): Choosing between B2C and B2B setups
+- [Set up Logto Cloud](https://docs.logto.io/introduction/set-up-logto-cloud): Create a tenant and configure your first application
+- [Quick starts](https://docs.logto.io/quick-starts): Integration guides for web, mobile, and backend frameworks
+
+## Core guides
+
+- [Integrate Logto](https://docs.logto.io/integrate-logto): Connect your applications to Logto
+- [End-user flows](https://docs.logto.io/end-user-flows): Sign-up and sign-in, social sign-in, enterprise SSO, MFA, and account management
+- [Authorization](https://docs.logto.io/authorization): Role-based access control and permissions
+- [API protection](https://docs.logto.io/api-protection): Validate Logto-issued tokens in your backend, per framework
+- [Organizations](https://docs.logto.io/organizations): Multi-tenant organizations for B2B apps
+- [User management](https://docs.logto.io/user-management): Manage users, profiles, and identities
+- [Connectors](https://docs.logto.io/connectors): Email, SMS, social, and enterprise SSO connectors
+- [Integrations](https://docs.logto.io/integrations): Per-provider setup guides for social sign-in, enterprise SSO, email, and SMS
+- [Customization](https://docs.logto.io/customization): Sign-in experience branding, custom UI, and localization
+- [Security](https://docs.logto.io/security): Password policies and attack protection
+- [Developers](https://docs.logto.io/developers): Webhooks, audit logs, and custom token claims
+
+## AI and MCP
+
+- [AI integration use cases](https://docs.logto.io/use-cases/ai): Overview of using Logto with AI apps, agents, and MCP servers
+- [Add auth to an MCP server](https://docs.logto.io/use-cases/ai/mcp-server-add-auth)
+- [Enable third-party AI agent access](https://docs.logto.io/use-cases/ai/enable-third-party-ai-agent-access)
+- [Connect your agent to third-party APIs](https://docs.logto.io/use-cases/ai/connect-your-agent-to-third-party-apis)
+- [Logto MCP server](https://docs.logto.io/logto-cloud/logto-mcp-server): Remote MCP server that sets up Logto integrations and answers Logto questions from your AI application
+
+## Deployment
+
+- [Logto Cloud](https://docs.logto.io/logto-cloud): The hosted service, plans, and tenant settings
+- [Logto OSS](https://docs.logto.io/logto-oss): Self-hosting the open-source core
+
+## API reference
+
+- [Logto API reference](https://openapi.logto.io): REST API reference for Logto
+
+## Other Logto sites
+
+- [logto.io](https://logto.io): Product site and pricing
+- [Blog](https://blog.logto.io): Guides on authentication, authorization, and identity management
+- [Auth Wiki](https://auth-wiki.logto.io): Encyclopedia of authentication and authorization concepts
+- [GitHub](https://github.com/logto-io/logto): Open-source core repository


### PR DESCRIPTION
## Summary

Add a hand-curated `llms.txt` served at `https://docs.logto.io/llms.txt`, following the [llms.txt convention](https://llmstxt.org). AI search and retrieval crawlers (ChatGPT search, Claude, Perplexity) read this file to understand what a site covers and which pages matter. Docs is our strongest asset on the AI side, so giving crawlers a curated map of the doc tree helps them retrieve and cite the right pages.

The file contains a short overview plus curated links with one-line descriptions: getting-started pages, core guide sections, the AI/MCP use-case pages, deployment options, the API reference, and cross-references to our other properties (logto.io, blog.logto.io, auth-wiki.logto.io). Companion PR for the main site: logto-io/website#1077.

Notes:

- A curated index beats an auto-generated dump of all 300+ pages here: retrieval works section by section, and the section roots are stable URLs.
- Served from `static/`, so it ships at the site root like `robots.txt`.
- Every linked URL verified to return 200; section descriptions checked against the actual doc content (e.g. the MCP server page's stated capabilities).

## Testing

Tested locally. All linked URLs verified to return 200 in production.

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments