### PR TITLE
docs: add Actions documentation

### DIFF
--- a/docs/developers/README.mdx
+++ b/docs/developers/README.mdx
@@ -8,6 +8,7 @@ In order to provide convenience to our users, Logto offers a series of commonly 
 
 ```mdx-code-block
 import DocCardList from '@theme/DocCardList';
+import Action from '@site/src/assets/developer.svg';
 import JwtClaims from '@site/docs/developers/assets/icons/jwt-claims.svg';
 import UserImpersonation from '@site/docs/developers/assets/icons/role.svg';
 import Key from '@site/docs/developers/assets/icons/key.svg';
@@ -33,6 +34,15 @@ import Settings from '@site/docs/developers/assets/icons/gear.svg';
       description: 'Control which extended claims are included in ID tokens, following the OIDC specification.',
       customProps: {
         icon: <JwtClaims />,
+      }
+    },
+    {
+      type: 'link',
+      label: 'Actions',
+      href: '/developers/actions',
+      description: 'Run synchronous custom code in the authentication flow to migrate or enrich users.',
+      customProps: {
+        icon: <Action />,
       }
     },
     {

--- a/docs/developers/actions/README.mdx
+++ b/docs/developers/actions/README.mdx
@@ -1,0 +1,87 @@
+---
+sidebar_position: 4
+---
+
+# Actions
+
+Logto Actions let you run trusted JavaScript at specific points in the authentication flow. An action runs synchronously: the authentication request waits for the script, and the script result can update the user or determine whether the flow continues.
+
+Actions are useful when the decision must happen inside the authentication flow. Common use cases include:
+
+- Migrating users and passwords from a legacy identity system when they first sign in.
+- Refreshing user profile or application-specific data before Logto completes a sign-in.
+- Calling an external service and applying its result to the Logto user.
+
+:::note
+Actions are available in Logto OSS and Logto Cloud Enterprise plans.
+:::
+
+:::warning
+Action scripts can affect authentication and modify user data. Only trusted administrators should be allowed to view, create, edit, test, enable, or delete them.
+
+In self-hosted deployments, action scripts run in a virtual machine inside the Logto process. Treat them as trusted server-side code, not as a security boundary for untrusted code.
+:::
+
+## How Actions fit into sign-in \{#how-actions-fit-into-sign-in}
+
+Logto currently provides two action types:
+
+```mermaid
+flowchart LR
+  A["Password sign-in attempt"] --> B{"Local password is valid?"}
+  B -->|"Yes"| E["Continue authentication"]
+  B -->|"No"| C["Post first-factor verification Action"]
+  C -->|"Credentials accepted"| D["Create or update user and save local password"]
+  C -->|"Declined or failed"| X["Reject invalid credentials"]
+  D --> E
+  E --> F["Complete MFA (if required)"]
+  F --> G["Post sign-in Action"]
+  G --> H["Complete sign-in and issue tokens"]
+```
+
+| Action type                                                                          | When it runs                                                                                                                                    | What it can do                                                                                                                                        |
+| ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Post first-factor verification](/developers/actions/post-first-factor-verification) | During a password sign-in, only after Logto's local password verification fails. It does not run when the local password is valid.              | Verify the submitted credentials against a legacy system, then create a new Logto user or update an existing user and migrate the submitted password. |
+| [Post sign-in](/developers/actions/post-sign-in)                                     | After the user has completed all authentication factors, including MFA when required, and before Logto completes the sign-in and issues tokens. | Update and enrich the existing Logto user using the final sign-in context.                                                                            |
+
+Both action types run only for `SignIn` interactions in the Experience API. Post first-factor verification applies only to password sign-in; Post sign-in is independent of the authentication method.
+
+## Script model \{#script-model}
+
+Each action type has one configuration and one JavaScript entry function named `runAction`:
+
+```js
+const runAction = async ({ event, environmentVariables = {} }) => {
+  // Inspect the event, optionally fetch external data, and return
+  // a result supported by this action type.
+};
+```
+
+The payload contains:
+
+- `event`: The production authentication event. Its shape depends on the action type.
+- `environmentVariables`: The string values configured for this action. These values are passed through the function payload; they are not available through `process.env`.
+
+The editor provides type information, but the saved script is executed as JavaScript. The script may be asynchronous and can use the injected `fetch` function to call external HTTPS APIs. It cannot import packages or access Node.js globals such as `require` or `process`.
+
+The supported result is different for each action type; see the corresponding reference page before enabling an Action.
+
+## Actions and Webhooks \{#actions-and-webhooks}
+
+Actions and [Webhooks](/developers/webhooks) serve different purposes:
+
+|                                            | Actions                                            | Webhooks                                                          |
+| ------------------------------------------ | -------------------------------------------------- | ----------------------------------------------------------------- |
+| Execution                                  | Synchronous and inline with authentication         | Asynchronous and outside the authentication request               |
+| Can affect the current authentication flow | Yes                                                | No                                                                |
+| Can modify a user from its result          | Yes, using the supported user patch                | Not directly; the receiver can call the Management API separately |
+| Event coverage                             | Selected authentication points                     | A broad set of interaction and data-change events                 |
+| Typical use                                | Credential migration, pre-token profile enrichment | Notifications, downstream synchronization, analytics              |
+
+Keep asynchronous work in Webhooks. Use an Action only when Logto needs the result before authentication can continue.
+
+## Next steps \{#next-steps}
+
+- [Configure and test Actions](/developers/actions/configure-and-test-actions)
+- [Migrate users on password sign-in](/developers/actions/post-first-factor-verification)
+- [Enrich a user after sign-in](/developers/actions/post-sign-in)

--- a/docs/developers/actions/configure-and-test-actions.mdx
+++ b/docs/developers/actions/configure-and-test-actions.mdx
@@ -1,0 +1,195 @@
+---
+id: configure-and-test-actions
+title: Configure and test Actions
+sidebar_label: Configure and test Actions
+sidebar_position: 2
+---
+
+# Configure and test Actions
+
+## Create an Action \{#create-an-action}
+
+1. Navigate to <CloudLink to="/actions">Console > Actions</CloudLink>.
+2. Select **Post first-factor verification** or **Post sign-in**.
+3. Implement the `runAction` function in the script editor.
+4. Under **Data source**, review the event and result types, configure environment variables, and find an example for fetching external data.
+5. Under **Test context**, adjust the sample event and run the script.
+6. Under **Settings**, enable the Action and choose its script-error behavior.
+7. Save the Action.
+
+Only a saved and enabled Action runs in production.
+
+## Implement `runAction` \{#implement-runaction}
+
+Keep the entry function name as `runAction`. It receives a single payload object:
+
+```js
+const runAction = async ({ event, environmentVariables = {} }) => {
+  return;
+};
+```
+
+Do not use the `api` object from custom token claim scripts; Actions do not provide it. To decline or continue without a user update, return the no-op value supported by the specific action type.
+
+### Fetch external data \{#fetch-external-data}
+
+Use the injected `fetch` function to call an external API. For example, a Post sign-in Action can fetch a user profile:
+
+```js
+const runAction = async ({ event, environmentVariables = {} }) => {
+  const response = await fetch(environmentVariables.PROFILE_API_URL, {
+    headers: {
+      authorization: `Bearer ${environmentVariables.PROFILE_API_TOKEN}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Profile API returned ${response.status}`);
+  }
+
+  const profile = await response.json();
+
+  return {
+    action: 'updateUser',
+    user: {
+      name: profile.name,
+    },
+  };
+};
+```
+
+Actions run in the authentication request path. Keep external services fast and highly available, and assume that a user may retry the sign-in. Logto does not retry an Action or fall back from the Logto Cloud remote runner to local execution.
+
+### Use environment variables \{#use-environment-variables}
+
+Use environment variables for values that should not be hardcoded in the script, such as API URLs, tokens, and feature settings:
+
+```js
+const { API_URL, API_TOKEN } = environmentVariables;
+```
+
+Environment variables are part of the Action configuration and are visible to administrators who can read that configuration. Restrict Action-management access and never include secrets in the returned result or an error message.
+
+## Supported user patch \{#supported-user-patch}
+
+An Action can return only these user fields:
+
+| Field          | Description                               |
+| -------------- | ----------------------------------------- |
+| `username`     | Username                                  |
+| `primaryEmail` | Primary email address                     |
+| `primaryPhone` | Primary phone number                      |
+| `name`         | Display name                              |
+| `avatar`       | Avatar URL                                |
+| `profile`      | Standard OIDC profile fields              |
+| `customData`   | Additional JSON data for your application |
+
+The corresponding patch type is:
+
+```ts
+type ActionUserPatch = {
+  username?: string | null;
+  primaryEmail?: string | null;
+  primaryPhone?: string | null;
+  name?: string | null;
+  avatar?: string | null;
+  customData?: Record<string, JsonValue>;
+  profile?: {
+    familyName?: string;
+    givenName?: string;
+    middleName?: string;
+    nickname?: string;
+    preferredUsername?: string;
+    profile?: string;
+    website?: string;
+    gender?: string;
+    birthdate?: string;
+    zoneinfo?: string;
+    locale?: string;
+    address?: {
+      formatted?: string;
+      streetAddress?: string;
+      locality?: string;
+      region?: string;
+      postalCode?: string;
+      country?: string;
+    };
+  };
+};
+```
+
+Fields such as user ID, suspension state, identities, roles, organizations, MFA configuration, password hashes, and other internal fields are rejected.
+
+For updates, `profile` and `customData` are shallow-merged with the existing objects. Returning a nested object with an existing top-level key replaces the value at that key; it is not a deep merge. Identifier updates must also pass Logto's uniqueness checks.
+
+## Test context and dry runs \{#test-context-and-dry-runs}
+
+The **Test context** is sample JSON used only when you click **Run test**. It is saved with the Action for future tests, but production executions always use the real authentication event.
+
+A dry run:
+
+- Uses the current unsaved script, sample event, and environment variables.
+- Executes the script and displays its raw return value.
+- Does not save the Action or create or update a Logto user.
+- Does not emit a production Action audit event or execution metric.
+- Does not apply the production event and result validation for the selected action type.
+
+:::caution
+A successful dry run proves that the script executed, but not that its result will be accepted during a real authentication flow. Test the complete flow in a non-production tenant before enabling the Action in production.
+
+Successful test results are displayed as returned. Never return passwords, environment variables, API tokens, or other secrets from a script.
+:::
+
+## Handle errors \{#handle-errors}
+
+The **On script error** setting applies to execution failures such as a thrown exception, a rejected promise, a failed external request, or a runner failure. It does not make an invalid result valid.
+
+| Action type                    | `block` (default)                     | `allow`                                                                                                    |
+| ------------------------------ | ------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Post first-factor verification | Reject the invalid local credentials. | Not available in Console. Even if set through the API, an execution failure still rejects the credentials. |
+| Post sign-in                   | Fail the sign-in.                     | Continue the sign-in without applying the Action update.                                                   |
+
+For Post sign-in, a malformed or unsupported return value always fails the sign-in, even when `allow` is selected. Validate every success path in your script and return an explicit supported result or no-op.
+
+## Monitor executions \{#monitor-executions}
+
+Production executions create independent [audit log](/developers/audit-logs) events:
+
+- `Action.PostFirstFactorVerification`
+- `Action.PostSignIn`
+
+The audit record includes safe execution metadata such as the Action type, runtime location, duration, decision, and error-policy outcome. Passwords, environment-variable values, script source, and other sensitive values are redacted.
+
+## Configure Actions with the Management API \{#configure-actions-with-the-management-api}
+
+You can also manage Actions through the [Logto Management API](/integrate-logto/interact-with-management-api):
+
+| Method   | Endpoint                            | Purpose                              |
+| -------- | ----------------------------------- | ------------------------------------ |
+| `GET`    | `/api/configs/actions`              | List configured Actions              |
+| `GET`    | `/api/configs/actions/{actionType}` | Get one Action                       |
+| `PUT`    | `/api/configs/actions/{actionType}` | Create or replace an Action          |
+| `PATCH`  | `/api/configs/actions/{actionType}` | Partially update an Action           |
+| `DELETE` | `/api/configs/actions/{actionType}` | Delete an Action                     |
+| `POST`   | `/api/configs/actions/test`         | Dry-run a script with a sample event |
+
+The action type values retain their original identifiers for backward compatibility:
+
+- `inlineHook.postFirstFactorVerification`
+- `inlineHook.postSignIn`
+
+An Action configuration has this shape:
+
+```ts
+type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
+
+type ActionConfig = {
+  script: string;
+  environmentVariables?: Record<string, string>;
+  contextSample?: JsonValue;
+  enabled?: boolean;
+  onExecutionError?: 'block' | 'allow';
+};
+```
+
+When using the API, set `enabled: true` explicitly to run the Action. If `onExecutionError` is omitted, it defaults to `block`.

--- a/docs/developers/actions/configure-and-test-actions.mdx
+++ b/docs/developers/actions/configure-and-test-actions.mdx
@@ -29,7 +29,7 @@ const runAction = async ({ event, environmentVariables = {} }) => {
 };
 ```
 
-Do not use the `api` object from custom token claim scripts; Actions do not provide it. To decline or continue without a user update, return the no-op value supported by the specific action type.
+To decline or continue without a user update, return the no-op value supported by the specific action type.
 
 ### Fetch external data \{#fetch-external-data}
 

--- a/docs/developers/actions/post-first-factor-verification.mdx
+++ b/docs/developers/actions/post-first-factor-verification.mdx
@@ -1,0 +1,159 @@
+---
+id: post-first-factor-verification
+title: Post first-factor verification
+sidebar_label: Post first-factor verification
+sidebar_position: 3
+---
+
+# Post first-factor verification
+
+The Post first-factor verification Action supports just-in-time user migration from a legacy password system.
+
+Despite its name, this Action does not run after every successful first factor. It runs only when all of the following are true:
+
+- The Experience API interaction is `SignIn`.
+- The user submitted a username, email address, or phone number with a password.
+- Logto's local password verification failed.
+- If the identifier belongs to an existing Logto user, that user is not suspended.
+
+If the local password is valid, Logto continues without running the Action. Registration, forgot-password, non-password sign-in, and suspended-user attempts do not trigger it.
+
+## Event payload \{#event-payload}
+
+The `event` has this shape:
+
+```ts
+type PostFirstFactorVerificationEvent = {
+  // Retained for backward compatibility after the feature was renamed to Actions.
+  key: 'inlineHook.postFirstFactorVerification';
+  interactionEvent: 'SignIn';
+  verificationType: 'Password';
+  identifier: {
+    type: 'username' | 'email' | 'phone';
+    value: string;
+  };
+  user: {
+    id: string;
+    username: string | null;
+    primaryEmail: string | null;
+    primaryPhone: string | null;
+    name: string | null;
+    avatar: string | null;
+    customData: Record<string, unknown>;
+    profile: Record<string, unknown>;
+  } | null;
+  password: string;
+};
+```
+
+`user` is `null` when the identifier does not belong to a Logto user. Otherwise, it contains the existing user's editable profile context.
+
+:::danger
+`event.password` is the plaintext password submitted by the user. Send it only to your trusted legacy authentication endpoint over HTTPS. Never log it, store it, place it in `customData`, include it in an error, or return it from the Action.
+:::
+
+## Result \{#result}
+
+After the legacy system verifies the submitted credentials, return one of these results:
+
+```ts
+type PostFirstFactorVerificationResult =
+  | {
+      action: 'createUser';
+      passwordVerified: true;
+      user: ActionUserPatch;
+    }
+  | {
+      action: 'updateUser';
+      passwordVerified: true;
+      user: ActionUserPatch;
+    };
+```
+
+The result must match the event:
+
+- When `event.user` is `null`, return `createUser`.
+- When `event.user` is present, return `updateUser`.
+- `passwordVerified` must be the literal value `true`.
+- `user` may contain only the [supported user patch fields](/developers/actions/configure-and-test-actions#supported-user-patch).
+
+For a new user, Logto adds the submitted sign-in identifier when the result does not include it. The Action cannot change the submitted identifier to a different value. An email comparison is case-insensitive, phone numbers are compared after normalization, and usernames must match exactly.
+
+When the result is accepted, Logto hashes the submitted password with Argon2i and saves it as the user's local password. The script must not generate or return a password hash.
+
+Return `undefined` when the legacy system rejects the credentials. An empty, malformed, or unsupported result is also treated as invalid credentials.
+
+## Migration example \{#migration-example}
+
+Configure `LEGACY_VERIFY_URL` and `LEGACY_API_TOKEN` as Action environment variables, then adapt this script to your legacy API:
+
+```js
+const runAction = async ({ event, environmentVariables = {} }) => {
+  const response = await fetch(environmentVariables.LEGACY_VERIFY_URL, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${environmentVariables.LEGACY_API_TOKEN}`,
+    },
+    body: JSON.stringify({
+      identifier: event.identifier,
+      password: event.password,
+    }),
+  });
+
+  // Treat an authentication rejection as an ordinary invalid-credentials result.
+  if (response.status === 401 || response.status === 404) {
+    return;
+  }
+
+  if (!response.ok) {
+    throw new Error(`Legacy authentication service returned ${response.status}`);
+  }
+
+  const legacyUser = await response.json();
+
+  if (!legacyUser.passwordVerified) {
+    return;
+  }
+
+  return {
+    action: event.user ? 'updateUser' : 'createUser',
+    passwordVerified: true,
+    user: {
+      ...(legacyUser.name && { name: legacyUser.name }),
+      customData: {
+        migratedFrom: 'legacy',
+        legacyUserId: legacyUser.id,
+      },
+    },
+  };
+};
+```
+
+The first accepted sign-in works as follows:
+
+1. Local password verification fails, so Logto runs the Action.
+2. The script sends the identifier and password to the legacy system.
+3. The legacy system verifies the credentials and the script returns `createUser` or `updateUser`.
+4. Logto creates or updates the user and stores the submitted password as a new local Argon2i credential.
+5. The user completes MFA if required, and Logto completes the sign-in.
+6. On later sign-ins, the migrated local password succeeds, so this Action is no longer called for that user.
+
+## Security boundaries \{#security-boundaries}
+
+:::warning
+User and password writes from this Action happen before MFA is complete. If the user abandons or fails MFA, those writes remain.
+
+A user created by this Action also bypasses registration-only guards, including email blocklists, SSO-only domain rules, disabled sign-up mode, and registration mandatory-profile checks. Sentinel protection and MFA still apply.
+:::
+
+Use these safeguards:
+
+- Return `passwordVerified: true` only after the legacy system has positively verified the exact submitted password.
+- Keep the legacy endpoint private when possible, require service authentication, use HTTPS, and apply rate limiting.
+- Keep the returned user patch minimal. Do not copy unvalidated identifiers or profile data.
+- Test unknown-user creation, existing-user update, identifier collisions, suspended users, MFA, upstream failures, and concurrent attempts.
+- Monitor `Action.PostFirstFactorVerification` in [audit logs](/developers/audit-logs/event-types).
+- Keep the Action enabled only for the duration of the migration when practical.
+
+If you can export user data and compatible password hashes in advance, consider [bulk user migration](/user-management/user-migration) instead.

--- a/docs/developers/actions/post-sign-in.mdx
+++ b/docs/developers/actions/post-sign-in.mdx
@@ -1,0 +1,109 @@
+---
+id: post-sign-in
+title: Post sign-in
+sidebar_label: Post sign-in
+sidebar_position: 4
+---
+
+# Post sign-in
+
+The Post sign-in Action updates an existing user at the end of a successful sign-in. It runs after all authentication factors, including MFA when required, and before Logto completes the OIDC interaction and issues tokens.
+
+It runs for `SignIn` interactions regardless of whether the user authenticated with a password, verification code, social connector, enterprise SSO, passkey, or another supported method. It does not run during registration.
+
+## Event payload \{#event-payload}
+
+The event contains the final user context for the current sign-in:
+
+```ts
+type PostSignInEvent = {
+  // Retained for backward compatibility after the feature was renamed to Actions.
+  key: 'inlineHook.postSignIn';
+  interactionEvent: 'SignIn';
+  user: PostSignInUserContext;
+};
+```
+
+`event.user` includes the standard [user profile](/user-management/user-data#user-profile), plus:
+
+| Field                    | Description                                  |
+| ------------------------ | -------------------------------------------- |
+| `hasPassword`            | Whether the user has a local password        |
+| `ssoIdentities`          | Enterprise SSO identities linked to the user |
+| `mfaVerificationFactors` | MFA factor types configured for the user     |
+| `roles`                  | Global roles and their API resource scopes   |
+| `organizations`          | Organizations the user belongs to            |
+| `organizationRoles`      | Organization roles assigned to the user      |
+
+The context also includes fields such as `applicationId`, `lastSignInAt`, `createdAt`, and `updatedAt`. It does not include plaintext passwords, password hashes, MFA secrets, or connector token-set secrets.
+
+## Result and no-op behavior \{#result-and-no-op-behavior}
+
+Return this result to update the user:
+
+```ts
+type PostSignInResult = {
+  action: 'updateUser';
+  user?: ActionUserPatch;
+};
+```
+
+`user` may contain only the [supported user patch fields](/developers/actions/configure-and-test-actions#supported-user-patch).
+
+Return `undefined`, `null`, `{}`, or `{ action: 'updateUser' }` to continue without an Action user update. Other action names, primitive values, arrays, `user: null`, or unsupported user fields are invalid and fail the sign-in.
+
+:::note
+The `allow` script-error policy applies only when script execution fails. It does not allow a malformed result. Always return a supported update or no-op value.
+:::
+
+## Enrichment example \{#enrichment-example}
+
+This example requests current profile data from an external service and stores selected fields in Logto:
+
+```js
+const runAction = async ({ event, environmentVariables = {} }) => {
+  const response = await fetch(
+    `${environmentVariables.PROFILE_API_URL}/users/${encodeURIComponent(event.user.id)}`,
+    {
+      headers: {
+        authorization: `Bearer ${environmentVariables.PROFILE_API_TOKEN}`,
+      },
+    }
+  );
+
+  if (response.status === 404) {
+    return;
+  }
+
+  if (!response.ok) {
+    throw new Error(`Profile service returned ${response.status}`);
+  }
+
+  const externalProfile = await response.json();
+
+  return {
+    action: 'updateUser',
+    user: {
+      ...(externalProfile.name && { name: externalProfile.name }),
+      customData: {
+        profileSource: 'external',
+        customerTier: externalProfile.customerTier,
+        profileSyncedAt: new Date().toISOString(),
+      },
+    },
+  };
+};
+```
+
+The update completes before Logto finishes the sign-in. When the corresponding OIDC scopes are requested, claims derived from the updated user, such as profile claims in the ID token, can therefore reflect the new values in the current sign-in.
+
+## Ordering and failure behavior \{#ordering-and-failure-behavior}
+
+Before this Action runs, Logto may already have persisted normal sign-in side effects such as `lastSignInAt`, profile changes made during the interaction, MFA state, SSO identity synchronization, and just-in-time organization provisioning. Blocking the sign-in does not roll those changes back.
+
+Choose the error policy based on the role of the external data:
+
+- Use `block` when the update is required for a valid sign-in. This is the default.
+- Use `allow` when stale or missing enrichment data is acceptable. If script execution fails, Logto continues without applying the Action update.
+
+Keep the update idempotent and the external dependency fast. A Post sign-in Action runs on every applicable sign-in.

--- a/docs/developers/actions/post-sign-in.mdx
+++ b/docs/developers/actions/post-sign-in.mdx
@@ -56,6 +56,17 @@ Return `undefined`, `null`, `{}`, or `{ action: 'updateUser' }` to continue with
 The `allow` script-error policy applies only when script execution fails. It does not allow a malformed result. Always return a supported update or no-op value.
 :::
 
+## Updating sign-in identifiers \{#updating-sign-in-identifiers}
+
+Unlike [Post first-factor verification](/developers/actions/post-first-factor-verification), this Action may change the identifier fields `username`, `primaryEmail`, and `primaryPhone`, including the identifier the user just signed in with. Authentication is already complete when the Action runs, so the update only affects the stored profile and not the current sign-in decision.
+
+Two consequences are worth planning for:
+
+- **The user's future sign-in identifier changes.** A user who signed in with `old@example.com` can no longer use that address afterwards. Make sure the user retains a usable identifier, and treat the new value as confirmed, because Logto stores it as the user's primary email or phone number without an additional verification step.
+- **A collision aborts the sign-in.** If the new identifier already belongs to another user, Logto rejects the update with a `422` error such as `user.email_already_in_use`, and the interaction fails. This check runs outside the script, so the `allow` script-error policy does not suppress it. Resolve or skip conflicts inside the script rather than relying on the error policy.
+
+Only return an identifier field when the value comes from a source you trust, such as an upstream identity provider or a system of record.
+
 ## Enrichment example \{#enrichment-example}
 
 This example requests current profile data from an external service and stores selected fields in Logto:

--- a/docs/developers/audit-logs/README.mdx
+++ b/docs/developers/audit-logs/README.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 9
 ---
 
 # Audit logs

--- a/docs/developers/audit-logs/event-types.mdx
+++ b/docs/developers/audit-logs/event-types.mdx
@@ -32,6 +32,13 @@ Feel free to [contact us](https://logto.io/contact) if you’d like to share you
 | JwtCustomizer.AccessToken      | Get custom user access token claims |
 | JwtCustomizer.ClientCredential | Get custom M2M access token claims  |
 
+## Actions \{#actions}
+
+| Key                                | Name                                          |
+| ---------------------------------- | --------------------------------------------- |
+| Action.PostFirstFactorVerification | Execute Post first-factor verification Action |
+| Action.PostSignIn                  | Execute Post sign-in Action                   |
+
 ## Interaction lifecycle \{#interaction-lifecycle}
 
 | Key                | Name                |

--- a/docs/developers/sdk-conventions/README.mdx
+++ b/docs/developers/sdk-conventions/README.mdx
@@ -2,7 +2,7 @@
 id: sdk-conventions
 title: Platform SDK conventions
 sidebar_label: Platform SDK conventions
-sidebar_position: 9
+sidebar_position: 10
 ---
 
 # Platform SDK conventions

--- a/docs/developers/service-to-service-delegation.mdx
+++ b/docs/developers/service-to-service-delegation.mdx
@@ -2,7 +2,7 @@
 id: service-to-service-delegation
 title: Service-to-service delegation
 sidebar_label: Service-to-service delegation
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 import TokenExchangePrerequisites from './fragments/_token-exchange-prerequisites.mdx';

--- a/docs/developers/signing-keys.mdx
+++ b/docs/developers/signing-keys.mdx
@@ -2,7 +2,7 @@
 id: signing-keys
 title: Signing keys
 sidebar_label: Signing keys
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 # Signing keys

--- a/docs/developers/user-impersonation.mdx
+++ b/docs/developers/user-impersonation.mdx
@@ -2,7 +2,7 @@
 id: user-impersonation
 title: User impersonation
 sidebar_label: User impersonation
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 import TokenExchangePrerequisites from './fragments/_token-exchange-prerequisites.mdx';

--- a/docs/developers/webhooks/README.mdx
+++ b/docs/developers/webhooks/README.mdx
@@ -1,12 +1,14 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 ---
 
 # Webhooks
 
-Logto [Webhook](https://auth.wiki/webhook) provide real-time notifications for various events, including changes to user accounts, roles, permissions, organizations, organization roles, organization permissions, and [user interactions](/end-user-flows).
+Logto [Webhooks](https://auth.wiki/webhook) provide real-time notifications for various events, including changes to user accounts, roles, permissions, organizations, organization roles, organization permissions, and [user interactions](/end-user-flows).
 
-When an event is triggered, Logto sends an HTTP request to the Endpoint URL you provide, containing detailed information about the event, such as user ID, username, email, and other relevant details (for more about the data included in the payload and header, refer to [Webhook request](/developers/webhooks/webhooks-request)). Your application can process this request and take customized actions, like sending an email or updating data in database.
+When an event is triggered, Logto asynchronously sends an HTTP request to the endpoint URL you provide. The request contains details about the event, such as the user, application, and request context. See [Webhook request](/developers/webhooks/webhooks-request) for the payload and header reference.
+
+Webhook delivery happens outside the authentication request and cannot change the outcome of the current flow. For synchronous code that must finish before sign-in continues, use [Actions](/developers/actions).
 
 We continuously add more events based on user needs. If you have specific requirements for your business, please let us know.
 
@@ -24,14 +26,14 @@ Here are some examples of common Webhook use cases for CIAM:
 
 ## Terms \{#terms}
 
-| Item                                                                                                                                                                           | Description                                                                                                                                                                                              |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Event                                                                                                                                                                          | When a specific action is done, it will trigger a hook event with a specific type. E.g., Logto will emit a PostRegister hook event when the user finished the sign-up process and created a new account. |
-| Hook                                                                                                                                                                           | A single or series of actions that hook to a specific event. Action can be calling API, executing code snippets, etc.                                                                                    |
-| Webhook                                                                                                                                                                        | A subtype of hook that indicates calling an API with the event payload.                                                                                                                                  |
-| Say a developer wants to send a notification when user signs in via a new device, the developer can add a webhook that calls his security service API to the PostSignIn event. |
+| Item          | Description                                                                                         |
+| ------------- | --------------------------------------------------------------------------------------------------- |
+| Webhook event | A supported event type that Logto can deliver, such as `PostSignIn` or `User.Created`.              |
+| Webhook       | A configuration that subscribes to one or more events and sends their payloads to an HTTP endpoint. |
 
-Here's an example of enabling two web hooks for `PostSignIn` event in Logto:
+For example, to notify a security service after a user signs in, create a Webhook that subscribes to `PostSignIn`.
+
+Here's an example of enabling two Webhooks for the `PostSignIn` event in Logto:
 
 ```mermaid
 graph LR
@@ -63,11 +65,13 @@ graph LR
 <details>
 <summary>
 
-### Does Logto support synced webhooks? \{#does-logto-support-synced-webhooks}
+### Can Webhooks make a synchronous authentication decision? \{#does-logto-support-synced-webhooks}
 
 </summary>
 
-Although synced webhooks would make the user sign-in flow smoother, we don't support them yet (we will in the future). Therefore, scenarios that rely on synced webhooks currently all require different workarounds. If you have any questions, don't hesitate to contact us.
+No. Webhooks are asynchronous notifications, so their response cannot allow, block, or modify the current authentication flow.
+
+Use [Actions](/developers/actions) when Logto must run custom code, call an external API, or update a user before sign-in continues. Because Actions are synchronous, keep their external dependencies fast and reliable.
 
 </details>
 

--- a/docs/developers/webhooks/events.mdx
+++ b/docs/developers/webhooks/events.mdx
@@ -9,7 +9,7 @@ sidebar_position: 3
 
 This guide list the different Logto webhook events and explains when each event occurs.
 
-## User interaction hook events \{#user-interaction-hook-events}
+## User interaction webhook events \{#user-interaction-hook-events}
 
 | Event type        | Description                                                                 |
 | ----------------- | --------------------------------------------------------------------------- |
@@ -17,7 +17,7 @@ This guide list the different Logto webhook events and explains when each event 
 | PostSignIn        | A user successfully signs in via the UI interface.                          |
 | PostResetPassword | A user's password is successfully reset through the "Forgot password" flow. |
 
-## Data mutation hook events \{#data-mutation-hook-events}
+## Data mutation webhook events \{#data-mutation-hook-events}
 
 ### User \{#user}
 
@@ -121,7 +121,7 @@ This guide list the different Logto webhook events and explains when each event 
 | User registration                                                                                                                                                        | User.Created                    |
 | User auto-provisioned into an organization via [just-in-time provisioning](/organizations/just-in-time-provisioning) (matching email domain or enterprise SSO connector) | Organization.Membership.Updated |
 
-## Exception hook events \{#exception-hook-events}
+## Exception webhook events \{#exception-hook-events}
 
 ### Security \{#security}
 

--- a/docs/developers/webhooks/request.mdx
+++ b/docs/developers/webhooks/request.mdx
@@ -101,7 +101,7 @@ See [Users](/user-management/user-data) and [Applications](/integrate-logto/appl
 
 ## Data mutation event payloads \{#data-mutation-event-payloads}
 
-**Events:** every event under `User.*`, `Role.*`, `Scope.*`, `Organization.*`, `OrganizationRole.*`, `OrganizationScope.*`. See [Webhooks events → Data mutation hook events](/developers/webhooks/webhooks-events#data-mutation-hook-events) for the complete catalog.
+**Events:** every event under `User.*`, `Role.*`, `Scope.*`, `Organization.*`, `OrganizationRole.*`, `OrganizationScope.*`. See [Webhooks events → Data mutation webhook events](/developers/webhooks/webhooks-events#data-mutation-hook-events) for the complete catalog.
 
 The body always carries:
 
@@ -129,7 +129,7 @@ Present when the change was triggered by a Management API call.
 
 | Field        | Type     | Optional | Notes                                                                                |
 | ------------ | -------- | -------- | ------------------------------------------------------------------------------------ |
-| path         | `string` | ✅       | The path of the API call that triggered this hook.                                   |
+| path         | `string` | ✅       | The path of the API call that triggered this webhook.                                |
 | method       | `string` | ✅       | The HTTP method of the API call.                                                     |
 | status       | `number` | ✅       | The response status code of the API call.                                            |
 | params       | `object` | ✅       | The koa path params of the API call.                                                 |

--- a/docs/introduction/README.mdx
+++ b/docs/introduction/README.mdx
@@ -8,6 +8,7 @@ import BlockUserIcon from '@site/src/assets/block-user.svg';
 import CheckboxIcon from '@site/src/assets/checkbox.svg';
 import CloudIcon from '@site/src/assets/cloud.svg';
 import LogtoConsoleIcon from '@site/src/assets/console.svg';
+import DeveloperIcon from '@site/src/assets/developer.svg';
 import ExperienceIcon from '@site/src/assets/experience.svg';
 import GearPlusIcon from '@site/src/assets/gear-plus.svg';
 import GearIcon from '@site/src/assets/gear.svg';
@@ -150,6 +151,10 @@ Welcome to Logto documentation! Logto is an identity and access management (IAM)
     {
       icon: <GearPlusIcon />,
       docId: 'developers/custom-id-token/README',
+    },
+    {
+      icon: <DeveloperIcon />,
+      docId: 'developers/actions/README',
     },
     {
       icon: <ImpersonationIcon />,

--- a/docs/security/send-rate-limit.mdx
+++ b/docs/security/send-rate-limit.mdx
@@ -24,14 +24,14 @@ This limit is **mandatory and system-level**: it applies to every tenant regardl
 When an **end user** hits the per-recipient cap, Logto triggers the `Message.RateLimited` [webhook event](/developers/webhooks/webhooks-events#exception-hook-events), so you can alert on or respond to send abuse.
 
 - **Fires for**: end-user verification-code send paths only—the Experience API and Account API. It does **not** fire for first-party or admin-initiated sends (Management API verification codes, organization invitations, or `/me`).
-- **Payload**: the hook context includes the `action` (for example, `VerificationCodeSend`) and the `recipient` (the email address or phone number).
+- **Payload**: the webhook payload includes the `action` (for example, `VerificationCodeSend`) and the `recipient` (the email address or phone number).
 
 **Common use cases:**
 
 - Send security alerts to your team for review.
 - Trigger downstream anti-abuse automation for the affected recipient.
 
-Navigate to <CloudLink to="/webhooks">Console > Webhooks</CloudLink> to subscribe, or create the hook via the Management API. For the detailed event structure and configuration, see [Webhooks](/developers/webhooks).
+Navigate to <CloudLink to="/webhooks">Console > Webhooks</CloudLink> to subscribe, or create the Webhook via the Management API. For the detailed event structure and configuration, see [Webhooks](/developers/webhooks).
 
 ## Suppressed delivery to unknown recipients \{#suppressed-delivery-to-unknown-recipients}
 

--- a/docs/user-management/user-migration.mdx
+++ b/docs/user-management/user-migration.mdx
@@ -4,7 +4,16 @@ sidebar_position: 5
 
 # User migration
 
-Logto supports manual migration of existing users from another platform, this guide will show you how to import existing users via Management API and talk about things that you should consider before migrating.
+Logto supports both bulk and just-in-time migration of existing users from another identity system. This guide explains how to import users in bulk through the Management API and what to consider before migrating.
+
+## Choose a migration strategy \{#choose-a-migration-strategy}
+
+| Strategy               | Choose it when                                                                                                                                 | How it works                                                                                                                                                                                                                                                          |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Bulk migration         | You can export the user records and password hashes in a format Logto supports.                                                                | Import the users before cutover through the Management API, following the rest of this guide.                                                                                                                                                                         |
+| Just-in-time migration | You need to verify passwords against the existing system, cannot export compatible password hashes, or want to migrate active users gradually. | Configure a [Post first-factor verification Action](/developers/actions/post-first-factor-verification). On the user's first password sign-in, Logto verifies the credentials through your Action, creates or updates the user, and stores a new local password hash. |
+
+Just-in-time migration keeps the legacy authentication service in the sign-in request path until users are migrated. Use a fast, reliable HTTPS endpoint and keep it available for the migration period.
 
 ## User schema \{#user-schema}
 


### PR DESCRIPTION
## Summary

- add a new Actions documentation section covering the feature overview, configuration, testing, Management API, and supported user patches
- document the implementation-accurate behavior of Post first-factor verification and Post sign-in, including result validation, error policies, security boundaries, and the retained `inlineHook.*` wire identifiers
- add Actions to developer navigation and connect it with user migration, audit logs, and Webhooks guidance
- clarify that Webhooks are asynchronous while Actions run synchronously in the authentication flow

## Why

This prepares the documentation for the upcoming Actions launch tracked by [LOG-13882](https://linear.app/silverhand/issue/LOG-13882/docs). The feature was originally called inline hooks, so the documentation uses the Actions product name while preserving the legacy API and event identifiers required by the implementation.

## User impact

Developers can understand when each Action runs, safely implement and test scripts, use Actions for just-in-time password migration or post-sign-in enrichment, and choose between Actions and Webhooks without relying on outdated behavior descriptions.

## Validation

- Docusaurus production build for all locales
- targeted ESLint for all changed MDX files
- repository pre-commit lint
- `git diff --check`