### PR TITLE
docs: document outbound HTTP proxy configuration

### DIFF
--- a/docs/logto-oss/deployment-and-configuration.mdx
+++ b/docs/logto-oss/deployment-and-configuration.mdx
@@ -36,7 +36,7 @@ For more details about environment variables, see [Configuration](/concepts/core
 
 ### Outbound HTTP proxy \{#outbound-http-proxy}
 
-If your self-hosted Logto instance must use an HTTP proxy to reach external services, such as social connector APIs or CAPTCHA providers, enable Node.js environment proxy support and configure the standard proxy variables. This requires Node.js 22.21.0 or later, which is included in current official Logto Docker images.
+If your self-hosted Logto instance must use an HTTP proxy to reach external services, such as social connector APIs or CAPTCHA providers, enable environment proxy support and configure the standard proxy variables.
 
 For example, add the following environment variables to the Logto service in your Docker Compose configuration:
 
@@ -51,16 +51,12 @@ services:
       NO_PROXY: localhost,127.0.0.1,::1,postgres,.internal.example.com
 ```
 
-- `NODE_USE_ENV_PROXY=1` enables Node.js support for the proxy environment variables.
+- `NODE_USE_ENV_PROXY=1` enables environment proxy support.
 - `HTTP_PROXY` specifies the proxy for HTTP requests.
 - `HTTPS_PROXY` specifies the proxy for HTTPS requests. The proxy URL itself can use either HTTP or HTTPS.
 - `NO_PROXY` is a comma-separated list of hosts that should be reached directly. Include any internal HTTP endpoints that should not use the proxy.
 
-Node.js reads these variables when the process starts, so restart the Logto container after changing them. Lowercase variants (`http_proxy`, `https_proxy`, and `no_proxy`) are also supported and take precedence if both variants are set.
-
-This configuration applies to outbound requests that use Node.js's default HTTP, HTTPS, and Fetch clients. It does not apply to non-HTTP connections, such as SMTP, or to connectors and libraries that use a custom network agent or dispatcher.
-
-If the proxy intercepts HTTPS traffic using a private certificate authority, you may also need to mount its CA certificate into the container and set [`NODE_EXTRA_CA_CERTS`](https://nodejs.org/api/cli.html#node_extra_ca_certsfile) to the mounted file path.
+Note that this proxy configuration may not take effect for all outbound requests.
 
 ### HTTPS \{#https}
 

--- a/docs/logto-oss/deployment-and-configuration.mdx
+++ b/docs/logto-oss/deployment-and-configuration.mdx
@@ -51,7 +51,7 @@ services:
       NO_PROXY: localhost,127.0.0.1,::1,postgres,.internal.example.com
 ```
 
-- `NODE_USE_ENV_PROXY=1` enables environment proxy support.
+- `NODE_USE_ENV_PROXY=1` enables environment proxy support. On Node.js 22, this requires version 22.21.0 or later.
 - `HTTP_PROXY` specifies the proxy for HTTP requests.
 - `HTTPS_PROXY` specifies the proxy for HTTPS requests. The proxy URL itself can use either HTTP or HTTPS.
 - `NO_PROXY` is a comma-separated list of hosts that should be reached directly. Include any internal HTTP endpoints that should not use the proxy.

--- a/docs/logto-oss/deployment-and-configuration.mdx
+++ b/docs/logto-oss/deployment-and-configuration.mdx
@@ -34,6 +34,34 @@ For more details about environment variables, see [Configuration](/concepts/core
 
 - To use the [Secret Vault](/secret-vault), you need to set `SECRET_VAULT_KEK` to a base64-encoded string of your Key Encryption Key (KEK). This is used to encrypt Data Encryption Keys (DEK) in the Secret Vault. AES-256 (32 bytes) is recommended. Example: `crypto.randomBytes(32).toString('base64')`.
 
+### Outbound HTTP proxy \{#outbound-http-proxy}
+
+If your self-hosted Logto instance must use an HTTP proxy to reach external services, such as social connector APIs or CAPTCHA providers, enable Node.js environment proxy support and configure the standard proxy variables. This requires Node.js 22.21.0 or later, which is included in current official Logto Docker images.
+
+For example, add the following environment variables to the Logto service in your Docker Compose configuration:
+
+```yaml
+services:
+  logto:
+    image: ghcr.io/logto-io/logto:latest
+    environment:
+      NODE_USE_ENV_PROXY: '1'
+      HTTP_PROXY: http://proxy.example.com:3128
+      HTTPS_PROXY: http://proxy.example.com:3128
+      NO_PROXY: localhost,127.0.0.1,::1,postgres,.internal.example.com
+```
+
+- `NODE_USE_ENV_PROXY=1` enables Node.js support for the proxy environment variables.
+- `HTTP_PROXY` specifies the proxy for HTTP requests.
+- `HTTPS_PROXY` specifies the proxy for HTTPS requests. The proxy URL itself can use either HTTP or HTTPS.
+- `NO_PROXY` is a comma-separated list of hosts that should be reached directly. Include any internal HTTP endpoints that should not use the proxy.
+
+Node.js reads these variables when the process starts, so restart the Logto container after changing them. Lowercase variants (`http_proxy`, `https_proxy`, and `no_proxy`) are also supported and take precedence if both variants are set.
+
+This configuration applies to outbound requests that use Node.js's default HTTP, HTTPS, and Fetch clients. It does not apply to non-HTTP connections, such as SMTP, or to connectors and libraries that use a custom network agent or dispatcher.
+
+If the proxy intercepts HTTPS traffic using a private certificate authority, you may also need to mount its CA certificate into the container and set [`NODE_EXTRA_CA_CERTS`](https://nodejs.org/api/cli.html#node_extra_ca_certsfile) to the mounted file path.
+
 ### HTTPS \{#https}
 
 You may use Node.js to serve HTTPS directly or set up an HTTPS proxy / balancer in front of Node.js. See [Enabling HTTPS](/concepts/core-service/configuration/#enabling-https) for details.


### PR DESCRIPTION
## Summary

- document how self-hosted Logto deployments can enable environment proxy support
- provide a Docker Compose example for `NODE_USE_ENV_PROXY`, `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`
- clarify that the proxy configuration may not cover every outbound request

Closes logto-io/logto#9278