### PR TITLE
docs: document Grant.LimitExceeded webhook event

### DIFF
--- a/docs/developers/webhooks/events.mdx
+++ b/docs/developers/webhooks/events.mdx
@@ -129,6 +129,7 @@ This guide list the different Logto webhook events and explains when each event 
 | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Identifier.Lockout  | A user account is locked due to consecutive failed identity verification attempts. Can be triggered in the following flows:<br /><ul><li>Password verification failed</li><li>Code verification failed</li><li>One-time token verification failed</li></ul> |
 | Message.RateLimited | An end user exceeds the per-recipient [send rate limit](/security/send-rate-limit) for verification codes. Fires only on the end-user send paths (Experience API and Account API), with a payload of `{ action, recipient }`.                               |
+| Grant.LimitExceeded | A successful authorization pushes a user past an app's [max concurrent authenticated devices](/sessions/session-configs#max-concurrent-authenticated-devices-per-app) limit (`maxAllowedGrants`), so Logto revokes their oldest grants for that app.        |
 
 ## FAQs \{#faqs}
 

--- a/docs/developers/webhooks/request.mdx
+++ b/docs/developers/webhooks/request.mdx
@@ -403,14 +403,14 @@ Fired when a successful authorization pushes a user past an app's [max concurren
 
 This event is emitted from the OIDC authorization endpoint rather than the Experience API, so it does **not** carry `interactionEvent` or `sessionId`. Alongside the common fields and `ip`, the body carries:
 
-| Field                         | Type                | Optional | Notes                                                                                                                                 |
-| ----------------------------- | ------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| userId                        | `string`            |          | The user whose grants were revoked.                                                                                                   |
-| applicationId                 | `string`            |          | The application whose `maxAllowedGrants` limit was exceeded.                                                                          |
-| application                   | `ApplicationEntity` | ✅       | The application entity. Omitted if the application can't be resolved at delivery time.                                                |
-| maxAllowedGrants              | `number`            |          | The limit configured on the application when the event fired.                                                                         |
-| preRevocationActiveGrantCount | `number`            |          | The number of active grants the user held for this application before the revocation, including the one just issued.                  |
-| revokedGrantIds               | `string[]`          |          | The IDs of the grants that were actually revoked, oldest first. Use [Grants management](/sessions/grants-management) to inspect them. |
+| Field                         | Type                | Optional | Notes                                                                                                                          |
+| ----------------------------- | ------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| userId                        | `string`            |          | The user whose grants were revoked.                                                                                            |
+| applicationId                 | `string`            |          | The application whose `maxAllowedGrants` limit was exceeded.                                                                   |
+| application                   | `ApplicationEntity` | ✅       | The application entity. Omitted if the application can't be resolved at delivery time.                                         |
+| maxAllowedGrants              | `number`            |          | The limit configured on the application when the event fired.                                                                  |
+| preRevocationActiveGrantCount | `number`            |          | The number of active grants the user held for this application before the revocation, including the one just issued.           |
+| revokedGrantIds               | `string[]`          |          | The IDs of the grants that were actually revoked, oldest first. See [Looking up a revoked grant](#looking-up-a-revoked-grant). |
 
 Example payload:
 
@@ -434,6 +434,12 @@ Example payload:
   "revokedGrantIds": ["grant_001"]
 }
 ```
+
+#### Looking up a revoked grant \{#looking-up-a-revoked-grant}
+
+The grant records themselves are destroyed as part of the revocation, so the IDs in `revokedGrantIds` no longer resolve through the grant listing endpoints (`GET /api/users/{userId}/grants` and `GET /api/my-account/grants`) or the Console — those return **active** grants only. Treat the webhook payload as the primary record, and persist the IDs on your side if you need them later.
+
+The same eviction is also recorded in the [audit logs](/developers/audit-logs) under the `RevokeGrants` event key, which retains the grant IDs (as `revokeGrantIds`) alongside a `reason` of `maxAllowedGrants limit reached`. Note that the audit log records the grants Logto **attempted** to revoke, whereas the webhook's `revokedGrantIds` lists only those that succeeded; the two differ if a revocation partially fails.
 
 Delivery notes:
 

--- a/docs/developers/webhooks/request.mdx
+++ b/docs/developers/webhooks/request.mdx
@@ -27,7 +27,7 @@ The body is a JSON object. Its exact shape depends on which family the event bel
 | ----------------- | -------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
 | **User flow**     | `PostRegister`, `PostSignIn`, `PostResetPassword`                                            | A user completes a sign-up, sign-in, or password-reset flow handled by the Experience API.          |
 | **Data mutation** | `User.*`, `Role.*`, `Scope.*`, `Organization.*`, `OrganizationRole.*`, `OrganizationScope.*` | The underlying data model is mutated by a Management API call or a user flow on the Experience API. |
-| **Exception**     | `Identifier.Lockout`                                                                         | A security incident, for example an account locked after consecutive failed verification attempts.  |
+| **Exception**     | `Identifier.Lockout`, `Message.RateLimited`, `Grant.LimitExceeded`                           | A security incident, for example an account locked after consecutive failed verification attempts.  |
 
 Every family shares a small set of [common fields](#common-fields). Each family then layers on its own request-context fields plus an event-specific payload.
 
@@ -365,14 +365,15 @@ type OrganizationScope = {
 
 ## Exception event payloads \{#exception-event-payloads}
 
-**Events:** `Identifier.Lockout`.
+**Events:** `Identifier.Lockout`, `Message.RateLimited`, `Grant.LimitExceeded`.
 
-Fired on security incidents, for example an account locked after consecutive failed verification attempts. These events always originate from a user-facing flow, so the body carries:
+Fired on security incidents, for example an account locked after consecutive failed verification attempts, or grants evicted because an app's concurrent-device limit was exceeded.
 
-- The [common fields](#common-fields).
-- The `ip` field (same shape as data-mutation events).
-- The [Experience API context fields](#experience-api-context-fields).
-- The exception-specific fields below.
+Every exception event carries the [common fields](#common-fields) and an `ip` field (same shape as data-mutation events). The remaining fields depend on the event.
+
+### Identifier.Lockout \{#identifierlockout-payload}
+
+Originates from a user-facing flow, so the body also carries the [Experience API context fields](#experience-api-context-fields), plus:
 
 ```tsx
 enum SignInIdentifier {
@@ -386,3 +387,56 @@ enum SignInIdentifier {
 | ----- | ------------------ | -------- | ----------------------------------------------------------- |
 | type  | `SignInIdentifier` |          | The user's identifier type, e.g., email, phone or username. |
 | value | `string`           |          | The user's identifier value that triggered the lockout.     |
+
+### Message.RateLimited \{#messageratelimited-payload}
+
+Originates from a user-facing flow, so the body also carries the [Experience API context fields](#experience-api-context-fields), plus:
+
+| Field     | Type     | Optional | Notes                                                                                        |
+| --------- | -------- | -------- | -------------------------------------------------------------------------------------------- |
+| action    | `string` |          | The rate-limited action, e.g., `VerificationCodeSend`.                                       |
+| recipient | `string` |          | The email address or phone number that hit the [send rate limit](/security/send-rate-limit). |
+
+### Grant.LimitExceeded \{#grantlimitexceeded-payload}
+
+Fired when a successful authorization pushes a user past an app's [max concurrent authenticated devices](/sessions/session-configs#max-concurrent-authenticated-devices-per-app) limit (`maxAllowedGrants`) and Logto revokes their oldest grants for that app.
+
+This event is emitted from the OIDC authorization endpoint rather than the Experience API, so it does **not** carry `interactionEvent` or `sessionId`. Alongside the common fields and `ip`, the body carries:
+
+| Field                         | Type                | Optional | Notes                                                                                                                                 |
+| ----------------------------- | ------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| userId                        | `string`            |          | The user whose grants were revoked.                                                                                                   |
+| applicationId                 | `string`            |          | The application whose `maxAllowedGrants` limit was exceeded.                                                                          |
+| application                   | `ApplicationEntity` | ✅       | The application entity. Omitted if the application can't be resolved at delivery time.                                                |
+| maxAllowedGrants              | `number`            |          | The limit configured on the application when the event fired.                                                                         |
+| preRevocationActiveGrantCount | `number`            |          | The number of active grants the user held for this application before the revocation, including the one just issued.                  |
+| revokedGrantIds               | `string[]`          |          | The IDs of the grants that were actually revoked, oldest first. Use [Grants management](/sessions/grants-management) to inspect them. |
+
+Example payload:
+
+```json
+{
+  "hookId": "hook_abc",
+  "event": "Grant.LimitExceeded",
+  "createdAt": "2024-01-01T00:00:00.000Z",
+  "ip": "192.168.0.1",
+  "userAgent": "Mozilla/5.0",
+  "userId": "u_001",
+  "applicationId": "app_xyz",
+  "application": {
+    "id": "app_xyz",
+    "type": "SPA",
+    "name": "My app",
+    "description": "My app description"
+  },
+  "maxAllowedGrants": 2,
+  "preRevocationActiveGrantCount": 3,
+  "revokedGrantIds": ["grant_001"]
+}
+```
+
+Delivery notes:
+
+- The event fires only when at least one grant was **actually revoked**. An authorization that stays within the limit produces no event.
+- It fires on every authorization that exceeds the limit, so a user repeatedly signing in from more devices than allowed produces one event per eviction.
+- Dispatch is fire-and-forget: a slow or failing endpoint never blocks or fails the user's authorization. Failed deliveries are recorded in the audit logs like any other webhook.

--- a/docs/developers/webhooks/request.mdx
+++ b/docs/developers/webhooks/request.mdx
@@ -403,14 +403,14 @@ Fired when a successful authorization pushes a user past an app's [max concurren
 
 This event is emitted from the OIDC authorization endpoint rather than the Experience API, so it does **not** carry `interactionEvent` or `sessionId`. Alongside the common fields and `ip`, the body carries:
 
-| Field                         | Type                | Optional | Notes                                                                                                                          |
-| ----------------------------- | ------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| userId                        | `string`            |          | The user whose grants were revoked.                                                                                            |
-| applicationId                 | `string`            |          | The application whose `maxAllowedGrants` limit was exceeded.                                                                   |
-| application                   | `ApplicationEntity` | ✅       | The application entity. Omitted if the application can't be resolved at delivery time.                                         |
-| maxAllowedGrants              | `number`            |          | The limit configured on the application when the event fired.                                                                  |
-| preRevocationActiveGrantCount | `number`            |          | The number of active grants the user held for this application before the revocation, including the one just issued.           |
-| revokedGrantIds               | `string[]`          |          | The IDs of the grants that were actually revoked, oldest first. See [Looking up a revoked grant](#looking-up-a-revoked-grant). |
+| Field                         | Type                | Optional | Notes                                                                                                                |
+| ----------------------------- | ------------------- | -------- | -------------------------------------------------------------------------------------------------------------------- |
+| userId                        | `string`            |          | The user whose grants were revoked.                                                                                  |
+| applicationId                 | `string`            |          | The application whose `maxAllowedGrants` limit was exceeded.                                                         |
+| application                   | `ApplicationEntity` | ✅       | The application entity. Omitted if the application can't be resolved at delivery time.                               |
+| maxAllowedGrants              | `number`            |          | The limit configured on the application when the event fired.                                                        |
+| preRevocationActiveGrantCount | `number`            |          | The number of active grants the user held for this application before the revocation, including the one just issued. |
+| revokedGrantIds               | `string[]`          |          | The IDs of the grants that were actually revoked, oldest first.                                                      |
 
 Example payload:
 
@@ -435,14 +435,9 @@ Example payload:
 }
 ```
 
-#### Looking up a revoked grant \{#looking-up-a-revoked-grant}
-
-The grant records themselves are destroyed as part of the revocation, so the IDs in `revokedGrantIds` no longer resolve through the grant listing endpoints (`GET /api/users/{userId}/grants` and `GET /api/my-account/grants`) or the Console — those return **active** grants only. Treat the webhook payload as the primary record, and persist the IDs on your side if you need them later.
-
-The same eviction is also recorded in the [audit logs](/developers/audit-logs) under the `RevokeGrants` event key, which retains the grant IDs (as `revokeGrantIds`) alongside a `reason` of `maxAllowedGrants limit reached`. Note that the audit log records the grants Logto **attempted** to revoke, whereas the webhook's `revokedGrantIds` lists only those that succeeded; the two differ if a revocation partially fails.
-
 Delivery notes:
 
+- The revoked grant records are destroyed as part of the revocation, so the IDs in `revokedGrantIds` no longer resolve through the grant listing endpoints or the Console — those return **active** grants only. Treat the payload as the record, and persist the IDs on your side if you need them later.
 - The event fires only when at least one grant was **actually revoked**. An authorization that stays within the limit produces no event.
 - It fires on every authorization that exceeds the limit, so a user repeatedly signing in from more devices than allowed produces one event per eviction.
 - Dispatch is fire-and-forget: a slow or failing endpoint never blocks or fails the user's authorization. Failed deliveries are recorded in the audit logs like any other webhook.

--- a/docs/integrate-logto/application-data-structure.mdx
+++ b/docs/integrate-logto/application-data-structure.mdx
@@ -203,6 +203,8 @@ The OpenID Connect backchannel logout endpoint. See [Federated sign-out: Back-ch
 
 This setting is useful when you want to cap concurrent authenticated devices per app.
 
+Each eviction triggers the `Grant.LimitExceeded` [webhook event](/developers/webhooks/webhooks-events#exception-hook-events), so you can notify the user or track how often the limit is hit.
+
 :::note
 
 This field is not supported for:

--- a/docs/sessions/session-configs.mdx
+++ b/docs/sessions/session-configs.mdx
@@ -96,6 +96,20 @@ This setting is not supported for machine-to-machine apps, protected apps, and S
 
 :::
 
+### Monitor evictions with a webhook \{#monitor-evictions-with-a-webhook}
+
+When Logto revokes a user's oldest grants to enforce `maxAllowedGrants`, it triggers the `Grant.LimitExceeded` [webhook event](/developers/webhooks/webhooks-events#exception-hook-events), so you can react to devices being signed out rather than discovering it from support tickets.
+
+The payload identifies the user and app, the limit in effect, how many grants were active before the eviction, and the grant IDs that were revoked. See [Grant.LimitExceeded payload](/developers/webhooks/webhooks-request#grantlimitexceeded-payload) for the full structure.
+
+**Common use cases:**
+
+- Notify the user that they were signed out on another device, and from where.
+- Feed device-eviction rates into your analytics to tell whether the configured limit is too low.
+- Flag unusual eviction patterns for a single user as a possible credential-sharing or account-takeover signal.
+
+Navigate to <CloudLink to="/webhooks">Console > Webhooks</CloudLink> to subscribe, or create the hook via the Management API. See [Webhooks](/developers/webhooks) for configuration details.
+
 ## Related resources \{#related-resources}
 
 <Url href="/sessions">Sessions</Url>
@@ -103,5 +117,8 @@ This setting is not supported for machine-to-machine apps, protected apps, and S
 <Url href="/sessions/grants-management">Manage user authorized apps (grants)</Url>
 <Url href="/integrate-logto/application-data-structure#max-allowed-grants-maxallowedgrants">
   Application data structure: maxAllowedGrants
+</Url>
+<Url href="/developers/webhooks/webhooks-events#exception-hook-events">
+  Webhooks events: exception hook events
 </Url>
 <Url href="/integrate-logto/interact-with-management-api">Interact with Management API</Url>


### PR DESCRIPTION
## Summary

Documents the `Grant.LimitExceeded` webhook event added in [logto-io/logto#9230](https://github.com/logto-io/logto/pull/9230) (community contribution by @Kathircpe). The event fires when a successful authorization pushes a user past an app's `maxAllowedGrants` limit and Logto revokes their oldest grants.

### What changed

- **`docs/developers/webhooks/events.mdx`** — added `Grant.LimitExceeded` to the security exception hook events table.
- **`docs/developers/webhooks/request.mdx`** — restructured "Exception event payloads" into per-event subsections, since the family no longer has one shared shape. `Grant.LimitExceeded` is emitted from the OIDC authorization endpoint rather than the Experience API, so unlike `Identifier.Lockout` it carries no `interactionEvent` or `sessionId`. Added the full field table (`userId`, `applicationId`, `application`, `maxAllowedGrants`, `preRevocationActiveGrantCount`, `revokedGrantIds`), an example payload, and delivery notes.
- **`docs/sessions/session-configs.mdx`** — added "Monitor evictions with a webhook" under max concurrent authenticated devices, plus a related-resources link.
- **`docs/integrate-logto/application-data-structure.mdx`** — one-line pointer from the `maxAllowedGrants` field reference to the event.

### Out of the original scope, but included

`Message.RateLimited` shipped in the event catalog but was never added to `webhooks-request`. Splitting the exception section per-event made that omission structural, so it now has its own `{ action, recipient }` subsection and appears in the request-body family table.

### Expected result

Readers subscribing to `Grant.LimitExceeded` in Console can find the exact payload shape without reading the core source. The field names and optionality below were verified against `packages/core/src/event-listeners/authorization-success.ts` and `packages/core/src/libraries/hook/index.ts` at the merge commit:

- `revokedGrantIds` lists only grants that were **actually** revoked, oldest first (`pMap` preserves input order over the `iat`-sorted list).
- `application` is optional — the lookup is wrapped in `trySafe` and omitted on failure.
- Dispatch is fire-and-forget, so a failing endpoint never blocks the authorization.

## Testing

N/A

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
