### PR TITLE
docs: preserve ports in reverse proxy headers

### DIFF
--- a/docs/logto-oss/deployment-and-configuration.mdx
+++ b/docs/logto-oss/deployment-and-configuration.mdx
@@ -42,6 +42,8 @@ You may use Node.js to serve HTTPS directly or set up an HTTPS proxy / balancer 
 
 If you want to use reverse proxy on your server, for example Nginx or Apache, you need to map 3001 and 3002 ports separately in your proxy pass settings. Assuming you are using Nginx, your Logto auth endpoint is running on port 3001, and your Logto admin console is running on 3002, put the following config in nginx.conf:
 
+Set `TRUST_PROXY_HEADER=1` for Logto to trust the forwarded headers. Use `$http_host` for both `Host` and `X-Forwarded-Host` to preserve non-standard ports in the public URL.
+
 ```
 server {
   listen 443 ssl;
@@ -49,10 +51,11 @@ server {
   ...
 
   location / {
-    proxy_set_header Host $host;
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Forwarded-Host $http_host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto https;
+    proxy_set_header X-Forwarded-Proto $scheme;
 
     proxy_pass http://127.0.0.1:3001;
   }
@@ -72,10 +75,11 @@ server {
   ...
 
   location / {
-    proxy_set_header Host $host;
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Forwarded-Host $http_host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto https;
+    proxy_set_header X-Forwarded-Proto $scheme;
 
     proxy_pass http://127.0.0.1:3002;
   }


### PR DESCRIPTION
## Summary

- preserve non-standard ports in the Nginx reverse proxy examples by using `$http_host`
- explicitly set `X-Forwarded-Host` and derive `X-Forwarded-Proto` from the request scheme
- document the required `TRUST_PROXY_HEADER` setting

Closes logto-io/logto#9297