### PR TITLE
docs: document signed saml authentication requests for enterprise sso

### DIFF
--- a/docs/integrations/sso/entra-id-saml/README.mdx
+++ b/docs/integrations/sso/entra-id-saml/README.mdx
@@ -10,6 +10,7 @@ tutorial_config_name: Azure AD SSO application
 
 import GuideTip from '../../fragments/_sso_guide_tip.mdx';
 
+import SignedAuthnRequest from './_signed-authn-request.mdx';
 import Step1 from './_step-1.mdx';
 import Step2 from './_step-2.mdx';
 import Step3 from './_step-3.mdx';
@@ -41,3 +42,7 @@ With minimal configuration efforts, this connector allows integration with Micro
 ## Step 5: Set email domains and enable the SSO connector \{#step-5-set-email-domains-and-enable-the-sso-connector}
 
 <Step5 />
+
+## Optional: Enforce signed authentication requests \{#optional-enforce-signed-authentication-requests}
+
+<SignedAuthnRequest />

--- a/docs/integrations/sso/entra-id-saml/_integration.mdx
+++ b/docs/integrations/sso/entra-id-saml/_integration.mdx
@@ -1,3 +1,4 @@
+import SignedAuthnRequest from './_signed-authn-request.mdx';
 import Step1 from './_step-1.mdx';
 import Step2 from './_step-2.mdx';
 import Step3 from './_step-3.mdx';
@@ -23,3 +24,7 @@ import Step5 from './_step-5.mdx';
 ### Step 5: Set email domains and enable the SSO connector \{#step-5-set-email-domains-and-enable-the-sso-connector}
 
 <Step5 />
+
+### Optional: Enforce signed authentication requests \{#optional-enforce-signed-authentication-requests}
+
+<SignedAuthnRequest />

--- a/docs/integrations/sso/entra-id-saml/_signed-authn-request.mdx
+++ b/docs/integrations/sso/entra-id-saml/_signed-authn-request.mdx
@@ -1,0 +1,8 @@
+Microsoft Entra ID can require signed SAML authentication requests. To use this with Logto, follow this order to avoid any sign-in interruption:
+
+1. In the Logto connector's `Connection` tab, click **Generate new key** under **Request signing certificate**, and download the certificate of the active key.
+2. In the Entra ID application's single sign-on settings, upload the certificate under **Verification certificates**. See [Enforce signed SAML authentication requests](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/howto-enforce-signed-saml-authentication).
+3. Back in Logto, enable **Sign authentication request** on the connector and save.
+4. In Entra ID, check **Require verification certificates**, then test the sign-in flow.
+
+Entra ID only verifies requests signed with RSA-SHA256 (Logto's default algorithm), and enforces the requirement for SP-initiated sign-in requests. For the full setup and certificate rotation flow, see [Sign the SAML authentication request](https://docs.logto.io/integrations/saml-sso#optional-sign-the-saml-authentication-request).

--- a/docs/integrations/sso/saml/README.mdx
+++ b/docs/integrations/sso/saml/README.mdx
@@ -10,6 +10,7 @@ tutorial_config_name: SAML SSO application on your IdP
 
 import GuideTip from '../../fragments/_sso_guide_tip.mdx';
 
+import SignedAuthnRequest from './_signed-authn-request.mdx';
 import Step1 from './_step-1.mdx';
 import Step2 from './_step-2.mdx';
 import Step3 from './_step-3.mdx';
@@ -36,6 +37,10 @@ With minimal configuration efforts, this connector allows integration with any S
 ## Step4: Set email domains and enable the SSO connector \{#step4-set-email-domains-and-enable-the-sso-connector}
 
 <Step4 />
+
+## Optional: Sign the SAML authentication request \{#optional-sign-the-saml-authentication-request}
+
+<SignedAuthnRequest />
 
 ## Related resources \{#related-resources}
 

--- a/docs/integrations/sso/saml/_integration.mdx
+++ b/docs/integrations/sso/saml/_integration.mdx
@@ -1,3 +1,4 @@
+import SignedAuthnRequest from './_signed-authn-request.mdx';
 import Step1 from './_step-1.mdx';
 import Step2 from './_step-2.mdx';
 import Step3 from './_step-3.mdx';
@@ -18,3 +19,7 @@ Step 1: Create a SAML SSO application on your IdP \{#step-1-create-a-saml-sso-ap
 ### Step4: Set email domains and enable the SSO connector \{#step4-set-email-domains-and-enable-the-sso-connector}
 
 <Step4 />
+
+### Optional: Sign the SAML authentication request \{#optional-sign-the-saml-authentication-request}
+
+<SignedAuthnRequest />

--- a/docs/integrations/sso/saml/_signed-authn-request.mdx
+++ b/docs/integrations/sso/saml/_signed-authn-request.mdx
@@ -1,0 +1,21 @@
+By default, Logto sends SAML authentication requests (AuthnRequests) unsigned. If your IdP requires signed authentication requests, Logto can sign them with a generated Service Provider (SP) certificate. Signing is controlled entirely by the connector's **Sign authentication request** setting — Logto does not read the `WantAuthnRequestsSigned` flag from the IdP metadata.
+
+Set it up in this order to avoid any sign-in interruption:
+
+1. In the connector's `Connection` tab, find the **Request signing certificate** section and click **Generate new key**. The first key is activated automatically; keys generated later are staged as inactive for rotation.
+2. Download the active key's certificate and register it with your IdP.
+3. Enable **Sign authentication request** and save. Enabling requires an active signing key — saving without one is rejected.
+4. If your IdP has a separate option to require or verify signed requests, turn it on now, then test the sign-in flow.
+
+:::warning
+Keep the two sides in step. Enabling **Sign authentication request** before the certificate is registered — or requiring verification at the IdP before Logto signs — breaks sign-in through this connection until the other side catches up. IdPs that do not verify request signatures simply ignore the signature.
+:::
+
+Key management works independently of the toggle:
+
+- At most one key is **active**, and the active key signs every request. Key operations (generate, activate, deactivate, delete) take effect immediately.
+- To rotate certificates without downtime: generate a new key (staged as inactive), register its certificate with your IdP, then activate it — the previous key deactivates automatically and can be deleted afterwards.
+- The active key cannot be deleted, and it cannot be deactivated while **Sign authentication request** is enabled — disable signing first.
+- Turning the toggle off keeps all keys, so re-enabling resumes signing with the same certificate — no IdP-side rework needed.
+
+Logto signs requests with RSA-SHA256 by default. To use RSA-SHA512, set `requestSignatureAlgorithm` to `http://www.w3.org/2001/04/xmldsig-more#rsa-sha512` in the connector config via the Logto Management API.


### PR DESCRIPTION
## Summary
Documents the signed SAML AuthnRequest feature for enterprise SSO connectors (Refs LOG-13892; released in logto-io/logto#9314).

- New `_signed-authn-request.mdx` partial in the generic SAML guide (`/integrations/saml-sso`): what the **Sign authentication request** setting does (driven by the toggle, not the IdP metadata's `WantAuthnRequestsSigned`), outage-free setup order (generate key → register certificate → enable toggle → require verification at the IdP), key management and zero-downtime rotation, and the RSA-SHA256/SHA-512 algorithms. Wired into both `README.mdx` and `_integration.mdx` (tutorial generator) as an optional section after the numbered steps.
- Matching partial in the Entra ID (SAML) guide with the Entra-specific flow (**Verification certificates** / **Require verification certificates**) and its caveats (RSA-SHA256 only, SP-initiated enforcement), linking to the generic guide with an absolute URL so the tutorials-site build (which excludes the docs routes) doesn't break.

English source only — localized mirrors follow via the translation pipeline.

## Testing
N/A

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments