### PR TITLE
docs: actions are only available in logto cloud enterprise plans

### DIFF
--- a/docs/developers/actions/README.mdx
+++ b/docs/developers/actions/README.mdx
@@ -13,7 +13,7 @@ Actions are useful when the decision must happen inside the authentication flow.
 - Calling an external service and applying its result to the Logto user.
 
 :::note
-Actions are available in Logto OSS and Logto Cloud Enterprise plans.
+Actions are available in Logto Cloud Enterprise plans.
 :::
 
 :::warning

--- a/i18n/de/docusaurus-plugin-content-docs/current/developers/actions/README.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/developers/actions/README.mdx
@@ -13,7 +13,7 @@ Actions sind nützlich, wenn die Entscheidung innerhalb des Authentifizierungsab
 - Aufruf eines externen Dienstes und Anwendung seines Ergebnisses auf den Logto-Benutzer.
 
 :::note
-Actions sind in Logto OSS und Logto Cloud Enterprise-Plänen verfügbar.
+Actions sind in Logto Cloud Enterprise-Plänen verfügbar.
 :::
 
 :::warning

--- a/i18n/es/docusaurus-plugin-content-docs/current/developers/actions/README.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/current/developers/actions/README.mdx
@@ -13,7 +13,7 @@ Las acciones son útiles cuando la decisión debe ocurrir dentro del flujo de au
 - Llamar a un servicio externo y aplicar su resultado al usuario de Logto.
 
 :::note
-Las acciones están disponibles en Logto OSS y en los planes Enterprise de Logto Cloud.
+Las acciones están disponibles en los planes Enterprise de Logto Cloud.
 :::
 
 :::warning

--- a/i18n/fr/docusaurus-plugin-content-docs/current/developers/actions/README.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/developers/actions/README.mdx
@@ -13,7 +13,7 @@ Les actions sont utiles lorsque la décision doit être prise à l'intérieur du
 - L'appel à un service externe et l'application de son résultat à l'utilisateur Logto.
 
 :::note
-Les actions sont disponibles dans Logto OSS et les offres Logto Cloud Enterprise.
+Les actions sont disponibles dans les offres Logto Cloud Enterprise.
 :::
 
 :::warning

--- a/i18n/ja/docusaurus-plugin-content-docs/current/developers/actions/README.mdx
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/developers/actions/README.mdx
@@ -13,7 +13,7 @@ Logto アクション (Actions) を使うと、認証 (Authentication) フロー
 - 外部サービスを呼び出し、その結果を Logto ユーザーに適用する。
 
 :::note
-アクション (Actions) は Logto OSS および Logto Cloud Enterprise プランで利用できます。
+アクション (Actions) は Logto Cloud Enterprise プランで利用できます。
 :::
 
 :::warning

--- a/i18n/ko/docusaurus-plugin-content-docs/current/developers/actions/README.mdx
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/developers/actions/README.mdx
@@ -13,7 +13,7 @@ Logto 액션 (Actions)을 사용하면 인증 (Authentication) 플로우의 특�
 - 외부 서비스를 호출하고 그 결과를 Logto 사용자에 적용합니다.
 
 :::note
-액션은 Logto OSS 및 Logto Cloud Enterprise 요금제에서 사용할 수 있습니다.
+액션은 Logto Cloud Enterprise 요금제에서 사용할 수 있습니다.
 :::
 
 :::warning

--- a/i18n/pt-BR/docusaurus-plugin-content-docs/current/developers/actions/README.mdx
+++ b/i18n/pt-BR/docusaurus-plugin-content-docs/current/developers/actions/README.mdx
@@ -13,7 +13,7 @@ As actions são úteis quando a decisão precisa acontecer dentro do fluxo de au
 - Chamar um serviço externo e aplicar seu resultado ao usuário do Logto.
 
 :::note
-As actions estão disponíveis no Logto OSS e nos planos Enterprise do Logto Cloud.
+As actions estão disponíveis nos planos Enterprise do Logto Cloud.
 :::
 
 :::warning

--- a/i18n/th/docusaurus-plugin-content-docs/current/developers/actions/README.mdx
+++ b/i18n/th/docusaurus-plugin-content-docs/current/developers/actions/README.mdx
@@ -13,7 +13,7 @@ Actions มีประโยชน์เมื่อการตัดสิน
 - เรียกใช้บริการภายนอกและนำผลลัพธ์มาใช้กับผู้ใช้ Logto
 
 :::note
-Actions มีให้ใช้งานใน Logto OSS และ Logto Cloud Enterprise plans
+Actions มีให้ใช้งานใน Logto Cloud Enterprise plans
 :::
 
 :::warning

--- a/i18n/zh-CN/docusaurus-plugin-content-docs/current/developers/actions/README.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/current/developers/actions/README.mdx
@@ -13,7 +13,7 @@ Logto Actions 允许你在认证 (Authentication) 流程的特定节点运行受
 - 调用外部服务，并将其结果应用到 Logto 用户。
 
 :::note
-Actions 可用于 Logto OSS 和 Logto Cloud 企业版计划。
+Actions 可用于 Logto Cloud 企业版计划。
 :::
 
 :::warning

--- a/i18n/zh-TW/docusaurus-plugin-content-docs/current/developers/actions/README.mdx
+++ b/i18n/zh-TW/docusaurus-plugin-content-docs/current/developers/actions/README.mdx
@@ -13,7 +13,7 @@ Logto Actions 讓你能在驗證 (Authentication) 流程的特定階段執行受
 - 呼叫外部服務並將其結果應用於 Logto 使用者。
 
 :::note
-Actions 可用於 Logto OSS 與 Logto Cloud Enterprise 方案。
+Actions 可用於 Logto Cloud Enterprise 方案。
 :::
 
 :::warning


### PR DESCRIPTION
Removes Logto OSS from the Actions availability note, leaving Logto Cloud Enterprise plans only, across all 10 language files.