### PR TITLE
docs: note that script edit access is code execution on the host

### DIFF
--- a/docs/developers/actions/README.mdx
+++ b/docs/developers/actions/README.mdx
@@ -19,7 +19,7 @@ Actions are available in Logto Cloud Enterprise plans.
 :::warning
 Action scripts can affect authentication and modify user data. Only trusted administrators should be allowed to view, create, edit, test, enable, or delete them.
 
-In self-hosted deployments, action scripts run in a virtual machine inside the Logto process. Treat them as trusted server-side code, not as a security boundary for untrusted code.
+In self-hosted deployments, action scripts run inside the Logto server process with its privileges. Granting script edit or test access is equivalent to granting code execution on the Logto host, so the Admin Console should not be shared with untrusted users. Treat scripts as trusted server-side code; the runtime bounds a script's time and memory, but it is not a security boundary for untrusted code.
 :::
 
 ## How Actions fit into sign-in \{#how-actions-fit-into-sign-in}

--- a/docs/developers/custom-token-claims/README.mdx
+++ b/docs/developers/custom-token-claims/README.mdx
@@ -52,7 +52,7 @@ Logto built-in token claims cannot be overridden or modified. Custom claims will
 :::
 
 :::warning
-Security note: In self-hosted deployments, custom JWT scripts are executed with the same privileges as the Logto server process. This feature is intended for trusted administrators only. Do not allow untrusted or lower-privilege users to create, modify, or test these scripts.
+Security note: In self-hosted deployments, custom JWT scripts are executed with the same privileges as the Logto server process, so granting script edit or test access is equivalent to granting code execution on the Logto host. This feature is intended for trusted administrators only: do not allow untrusted or lower-privilege users to create, modify, or test these scripts, and do not share the Admin Console with them.
 :::
 
 ## Related resources \{#related-resources}


### PR DESCRIPTION
## Summary

Closes [LOG-13960](https://linear.app/silverhand/issue/LOG-13960/write-docs-note-on-the-oss-trust-model).

Custom JWT and Actions scripts run inside the self-hosted Logto server process with its privileges, so granting script edit or test access is equivalent to code execution on the Logto host, and the Admin Console should not be shared with untrusted users. This is stated in the existing security warnings on the two feature pages, where readers already are when the question comes up.

## Changes

- **Custom access token**: the warning now says script edit/test access equals code execution on the host, and adds that the Admin Console should not be shared with untrusted users.
- **Actions**: same, plus a correction — the warning described scripts as running "in a virtual machine inside the Logto process", which is the `node:vm` path being removed in this project. Scripts now run on a worker thread whose wall-clock and memory bounds contain runaway scripts but are explicitly not a security boundary.

## Testing

`npx eslint` and a full `npx docusaurus build` both pass.
