### PR TITLE
docs: unify the Account Center social callback URL

### DIFF
--- a/docs/end-user-flows/account-settings/by-account-center-ui.mdx
+++ b/docs/end-user-flows/account-settings/by-account-center-ui.mdx
@@ -181,16 +181,16 @@ Leave the field empty (or set `deleteAccountUrl` to `null`) to hide the account 
 
 ## Social connection callback URL \{#social-connection-callback-url}
 
-When a user links a social account from the Account Center, Logto uses a different redirect URI than the regular sign-in flow. The Account Center callback URL has the following format:
+Linking a social account from the Account Center uses the same callback URL as the regular sign-in flow:
 
 ```
-https://[your-tenant-endpoint]/account/callback/social/{connectorId}
+https://[your-tenant-endpoint]/callback/{connectorId}
 ```
 
-Where `{connectorId}` is the ID of the social connector (you can find it in <CloudLink to="/connectors/social">Console > Connectors > Social connectors</CloudLink>).
+Where `{connectorId}` is the ID of the social connector (you can find it in <CloudLink to="/connectors/social">Console > Connectors > Social connectors</CloudLink>). This is the **Callback URI** shown on the connector details page, and the only URL you need to add to the **Authorized redirect URIs** (or equivalent) list in your social provider's developer console (Google, GitHub, Facebook, etc.). Logto routes the callback to the sign-in flow or the Account Center automatically.
 
-:::caution
-You must add this URL to the **Authorized redirect URIs** (or equivalent) list in your social provider's developer console (Google, GitHub, Facebook, etc.) **in addition to** the standard sign-in callback URL `https://[your-tenant-endpoint]/callback/{connectorId}`. Otherwise, the link flow will fail with a redirect URI mismatch error.
+:::note
+Earlier versions of Logto used a separate `https://[your-tenant-endpoint]/account/callback/social/{connectorId}` URL for the Account Center. It is no longer requested as a redirect URI, so you can safely remove it from your social provider's list. Keeping the unified URL is what makes providers that allow only one redirect URI (such as QQ) usable with the Account Center.
 :::
 
 ## Security considerations \{#security-considerations}

--- a/docs/end-user-flows/account-settings/by-account-center-ui.mdx
+++ b/docs/end-user-flows/account-settings/by-account-center-ui.mdx
@@ -181,17 +181,13 @@ Leave the field empty (or set `deleteAccountUrl` to `null`) to hide the account 
 
 ## Social connection callback URL \{#social-connection-callback-url}
 
-Linking a social account from the Account Center uses the same callback URL as the regular sign-in flow:
+Linking a social account from the Account Center uses the same callback URL as signing in:
 
 ```
 https://[your-tenant-endpoint]/callback/{connectorId}
 ```
 
-Where `{connectorId}` is the ID of the social connector (you can find it in <CloudLink to="/connectors/social">Console > Connectors > Social connectors</CloudLink>). This is the **Callback URI** shown on the connector details page, and the only URL you need to add to the **Authorized redirect URIs** (or equivalent) list in your social provider's developer console (Google, GitHub, Facebook, etc.). Logto routes the callback to the sign-in flow or the Account Center automatically.
-
-:::note
-Earlier versions of Logto used a separate `https://[your-tenant-endpoint]/account/callback/social/{connectorId}` URL for the Account Center. It is no longer requested as a redirect URI, so you can safely remove it from your social provider's list. Keeping the unified URL is what makes providers that allow only one redirect URI (such as QQ) usable with the Account Center.
-:::
+Where `{connectorId}` is the ID of the social connector (you can find it in <CloudLink to="/connectors/social">Console > Connectors > Social connectors</CloudLink>). This is the **Callback URI** shown on the connector details page, and the only URL you need to add to the **Authorized redirect URIs** (or equivalent) list in your social provider's developer console (Google, GitHub, Facebook, etc.).
 
 ## Security considerations \{#security-considerations}
 

--- a/docs/end-user-flows/account-settings/by-account-center-ui.mdx
+++ b/docs/end-user-flows/account-settings/by-account-center-ui.mdx
@@ -181,13 +181,13 @@ Leave the field empty (or set `deleteAccountUrl` to `null`) to hide the account 
 
 ## Social connection callback URL \{#social-connection-callback-url}
 
-Linking a social account from the Account Center uses the same callback URL as signing in:
+Linking a social account from the Account Center uses the connector's callback URL:
 
 ```
 https://[your-tenant-endpoint]/callback/{connectorId}
 ```
 
-Where `{connectorId}` is the ID of the social connector (you can find it in <CloudLink to="/connectors/social">Console > Connectors > Social connectors</CloudLink>). This is the **Callback URI** shown on the connector details page, and the only URL you need to add to the **Authorized redirect URIs** (or equivalent) list in your social provider's developer console (Google, GitHub, Facebook, etc.).
+Where `{connectorId}` is the ID of the social connector. This is the **Callback URI** shown on the connector details page in <CloudLink to="/connectors/social">Console > Connectors > Social connectors</CloudLink>, which you register with your social provider when [setting up the connector](/connectors/social-connectors/).
 
 ## Security considerations \{#security-considerations}
 


### PR DESCRIPTION
Follow-up to logto-io/logto#9464, which unified the social callback URI between the Sign-in Experience and the Account Center.

The **Social connection callback URL** section described the Account Center as using a separate `/account/callback/social/{connectorId}` redirect URI, and told users they must register it with their social provider **in addition to** the sign-in callback URL. Both statements are now wrong: the Account Center initiates OAuth with the unified `/callback/{connectorId}` URI, and Admin Console shows that single URI on the connector details page.

The section now just states the current behavior — one callback URL, shared with sign-in — with no mention of the old URL or the transition, since there is nothing for a reader to act on.

Translations under `i18n/` are left to the automatic translation workflow.
