### PR TITLE
docs: clarify user identifier requirements

### DIFF
--- a/docs/user-management/manage-users.mdx
+++ b/docs/user-management/manage-users.mdx
@@ -22,7 +22,7 @@ It supports keyword mapping for [`name`](/user-management/user-data#name), [`id`
 
 Using the Console, developers can create new accounts for end-users. To do so, click on the "Add user" button in the screen's upper right corner.
 
-When creating a user in the Logto Console or via the Management API (not end user self-registered via the UI), you must provide at least one identifier: `primary email`, `primary phone`, or `username`. The `name` field is optional.
+When creating a user in the Logto Console, you must provide at least one identifier: `primary email`, `primary phone`, or `username`. The `name` field is optional. This requirement only applies to the Console. The Management API's [Create user endpoint](https://openapi.logto.io/operation/operation-createuser) can create a user without any of these identifiers.
 
 After the user is created, Logto will automatically generate a random password. The initial password will only appear one time, but you can [reset the password](./manage-users#reset-user-password) later. If you want to set a specific password, use the Management API `patch /api/users/{userId}/password` to update it after the user has been created.
 


### PR DESCRIPTION
Clarifies that Console-created users need a primary email, primary phone, or username, while the Management API can create a user without these identifiers.