### PR TITLE
docs: document script runtime web APIs

### DIFF
--- a/docs/developers/actions/README.mdx
+++ b/docs/developers/actions/README.mdx
@@ -62,7 +62,14 @@ The payload contains:
 - `event`: The production authentication event. Its shape depends on the action type.
 - `environmentVariables`: The string values configured for this action. These values are passed through the function payload; they are not available through `process.env`.
 
-The editor provides type information, but the saved script is executed as JavaScript. The script may be asynchronous and can use the injected `fetch` function to call external HTTPS APIs. It cannot import packages or access Node.js globals such as `require` or `process`.
+The editor provides type information, but the saved script is executed as JavaScript. The script may be asynchronous and can use these standard Web APIs in both Logto Cloud and self-hosted Logto:
+
+- `fetch`, `Request`, `Response`, and `Headers`
+- Web Crypto through `crypto` and `crypto.subtle`
+- `TextEncoder` and `TextDecoder`
+- `URL` and `URLSearchParams`
+
+Scripts cannot import packages. Avoid Node.js-specific globals and modules because they are not portable between self-hosted Logto and Logto Cloud and are not part of the supported script contract.
 
 The supported result is different for each action type; see the corresponding reference page before enabling an Action.
 

--- a/docs/developers/custom-token-claims/create-script.mdx
+++ b/docs/developers/custom-token-claims/create-script.mdx
@@ -257,9 +257,43 @@ api.denyAccess(message?: string): void
 
 The `api.denyAccess()` function allows you to deny the token issuing process with a custom message. You may use this function to enforce additional access validation over the token issuing process.
 
+## Runtime APIs \{#runtime-apis}
+
+Custom access token scripts can use these standard Web APIs in both Logto Cloud and self-hosted Logto:
+
+- `fetch`, `Request`, `Response`, and `Headers`
+- Web Crypto through `crypto` and `crypto.subtle`
+- `TextEncoder` and `TextDecoder`
+- `URL` and `URLSearchParams`
+
+For example, you can compute SHA-256 and HMAC-SHA-256 values with Web Crypto:
+
+```js
+const toHex = (buffer) =>
+  [...new Uint8Array(buffer)].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+
+const sha256 = async (input) =>
+  toHex(await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input)));
+
+const hmacSha256 = async (key, input) => {
+  const encoder = new TextEncoder();
+  const cryptoKey = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(key),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+
+  return toHex(await crypto.subtle.sign('HMAC', cryptoKey, encoder.encode(input)));
+};
+```
+
+Scripts cannot import packages. Avoid Node.js-specific globals and modules because they are not portable between self-hosted Logto and Logto Cloud and are not part of the supported script contract.
+
 ## Step 3: Fetch external data \{#step-3-fetch-external-data}
 
-You may use the node built-in `fetch` function to fetch external data in your script. The `fetch` function is a promise-based function that allows you to make HTTP requests to external APIs.
+You may use the standard `fetch` function to fetch external data in your script. The `fetch` function is a promise-based function that allows you to make HTTP requests to external APIs.
 
 ```jsx
 const getCustomJwtClaims = async ({ environmentVariables }) => {


### PR DESCRIPTION
## Summary

Document the standard Web APIs available to Custom JWT and Action scripts across Logto Cloud and self-hosted Logto.

Add Web Crypto SHA-256 and HMAC-SHA-256 examples, and clarify that package imports and Node.js-specific APIs are not part of the portable script contract.