### PR TITLE
docs: update AI use cases for MCP SDK v2 and mcp-auth 1.0

### DIFF
--- a/docs/use-cases/ai/README.mdx
+++ b/docs/use-cases/ai/README.mdx
@@ -5,7 +5,10 @@ description: Explore how Logto can help you build secure, AI-enabled experiences
 ---
 
 import Catalog from './fragments/_catalog.mdx';
+import ExploreAiSolutions from './fragments/_explore-ai-solutions.mdx';
 
 # AI integration use cases with Logto
+
+<ExploreAiSolutions />
 
 <Catalog />

--- a/docs/use-cases/ai/connect-your-agent-to-third-party-apis.mdx
+++ b/docs/use-cases/ai/connect-your-agent-to-third-party-apis.mdx
@@ -3,7 +3,11 @@ sidebar_position: 4
 sidebar_label: Connect your agent to third-party APIs
 ---
 
+import ExploreAiSolutions from './fragments/_explore-ai-solutions.mdx';
+
 # Connect your AI agent to third-party APIs
+
+<ExploreAiSolutions />
 
 This guide walks you through enabling your AI agent to access third-party APIs (e.g., Google Calendar, GitHub, etc.) on behalf of users. By leveraging Logto's social connectors and Secret Vault, you can securely store and manage access tokens, allowing your agent to perform automated tasks without repeatedly asking users to re-authenticate.
 

--- a/docs/use-cases/ai/enable-third-party-ai-agent-access.mdx
+++ b/docs/use-cases/ai/enable-third-party-ai-agent-access.mdx
@@ -4,8 +4,11 @@ sidebar_label: Enable third-party AI agent access to app
 ---
 
 import ConfigureThirdPartyAiAgent from './fragments/_configure-third-party-ai-agent.mdx';
+import ExploreAiSolutions from './fragments/_explore-ai-solutions.mdx';
 
 # Enable third-party AI agent access to your app
+
+<ExploreAiSolutions />
 
 This guide walks you through integrating Logto with your service and enabling AI agents to access it.
 

--- a/docs/use-cases/ai/fragments/_configure-third-party-ai-agent.mdx
+++ b/docs/use-cases/ai/fragments/_configure-third-party-ai-agent.mdx
@@ -59,13 +59,17 @@ You can manually create a third-party app in Logto Console for testing purposes 
 1. Sign in to your Logto Console.
 2. Go <CloudLink to="/applications">**Applications**</CloudLink> → **Create application** → **Third-party app** -> **OIDC**.
 3. Fill in the app name and other required fields, then click **Create application**.
-4. Click **Permissions** tab, in the **User** section, click "Add".
-5. In the opened dialog -> **User data** -> select **`profile`**, **`email`** permissions, then click **Save**.
-6. In the third-party app, configure scopes to request `openid profile email` permissions (scopes).
+4. Click the **Permissions** tab to grant [permissions](/integrate-logto/third-party-applications/permission-management) to the app:
 
-   **Note**: `openid` is required for OIDC, and `profile` and `email` are the permissions you added in the previous step.
+   - **User** section: user data permissions such as **`profile`** and **`email`**, for basic identity claims.
+   - **API resource** section: permissions (scopes) of the [API resources](/authorization/global-api-resources) you've defined in Logto, e.g., the API resource that represents your {props.serviceName ?? 'service'}.
+   - **Organization** section: organization permissions, if you use Logto organizations.
 
-7. Configure the **redirect URI** of your third-party application accordingly. Remember to update the redirect URI in Logto as well.
+5. In the third-party app, configure scopes to request the permissions you granted, e.g., `openid profile email` plus the API resource scopes.
+
+   **Note**: `openid` is required for OIDC. To receive an access token bound to an API resource, the app must also include the `resource` parameter in the authorization request. MCP clients that follow the latest MCP specification do this automatically based on the protected resource metadata.
+
+6. Configure the **redirect URI** of your third-party application accordingly. Remember to update the redirect URI in Logto as well.
 
 <img
   src="/img/assets/third-party-app-permissions.png"

--- a/docs/use-cases/ai/fragments/_explore-ai-solutions.mdx
+++ b/docs/use-cases/ai/fragments/_explore-ai-solutions.mdx
@@ -1,0 +1,3 @@
+:::tip
+Explore [Logto's AI solutions](https://logto.io/ai): authentication and authorization for MCP servers, AI agents, and apps.
+:::

--- a/docs/use-cases/ai/fragments/_mcp-prerequisites.mdx
+++ b/docs/use-cases/ai/fragments/_mcp-prerequisites.mdx
@@ -3,38 +3,35 @@ import Mermaid from '@theme/Mermaid';
 ## Prerequisites \{#prerequisites}
 
 - A [Logto Cloud](https://cloud.logto.io) (or self-hosted) tenant
-- Node.js or Python environment
+- Node.js >= 20 environment
 
 ### Understanding the architecture \{#understanding-the-architecture}
 
-- **MCP server**: The server that exposes tools and resources to MCP clients.
-- **MCP client**: A client used to initiate the authentication flow and test the integration. {<b>{props.isThirdParty ? 'The third-party AI agent will be used as the client in this guide.' : "We'll use the MCP Inspector as the client in this guide."}</b>}
-- **Logto**: Serves as the OpenID Connect provider (authorization server) and manages user identities.
+- **MCP server**: The server that exposes tools and resources to MCP clients. Following the [latest MCP specification](https://modelcontextprotocol.io/specification/latest/basic/authorization), it acts as an OAuth 2.0 resource server that validates access tokens issued by Logto.
+- **MCP client**: A client used to initiate the authentication flow and test the integration. {<b>{props.isThirdParty ? 'The third-party AI agent will be used as the client in this guide.' : "We'll use VS Code (with built-in MCP support) as the client in this guide."}</b>}
+- **Logto**: Serves as the OpenID Connect provider (authorization server), manages user identities, and issues audience-bound JWT access tokens for your MCP server.
 
 A non-normative sequence diagram illustrates the overall flow of the process:
 
 <Mermaid value={`sequenceDiagram
-    participant Client as MCP Client<br/>${props.isThirdParty ? '(third-party AI agent)' : '(MCP Inspector)'}
-    participant Server as MCP Server
-    participant Logto
+    participant Client as MCP Client<br/>${props.isThirdParty ? '(third-party AI agent)' : '(VS Code)'}
+    participant Server as MCP Server<br/>(resource server)
+    participant Logto as Logto<br/>(authorization server)
 
-    Server->>Logto: Request OpenID Connect configuration
-    Logto->>Server: Return configuration
-    Note over Server: Cache the configuration
-    Client->>Server: Request access to a tool
-    Server->>Client: Not authenticated (401 Unauthorized)
-    Client->>Server: Request OAuth 2.0 Authorization Server Metadata
-    Note over Server: In this context, “OpenID Connect configuration” and<br/>“OAuth 2.0 Authorization Server Metadata”<br/>refer to the same thing.
-    Server->>Client: Return OpenID Connect configuration retrieved from Logto
+    Client->>Server: MCP request (no token)
+    Server->>Client: 401 Unauthorized (WWW-Authenticate)
+    Client->>Server: Fetch protected resource metadata<br/>(/.well-known/oauth-protected-resource)
+    Server->>Client: Return metadata with authorization server info
+    Client->>Logto: Fetch authorization server metadata
+    Logto->>Client: Return OpenID Connect configuration
     Client->>Logto: Redirect to Logto for authentication
     Logto->>Logto: User authenticates
-    ${props.isThirdParty ? 'Logto->>Logto: User authorizes (consents) scopes<br/>to the third-party app' : ''}
-    Logto->>Client: Redirect back to MCP server with authorization code
-    Client->>Logto: Request access token using authorization code
-    Logto->>Client: Return access token
-    Client->>Server: Request tool with access token
-    Server->>Logto: Request user info using access token
-    Logto->>Server: Return user info
+    ${props.isThirdParty ? 'Logto->>Logto: User authorizes (consents) scopes<br/>to the third-party AI agent' : ''}
+    Logto->>Client: Redirect back with authorization code
+    Client->>Logto: Exchange code for access token<br/>(with the resource parameter)
+    Logto->>Client: Return access token (JWT, audience-bound)
+    Client->>Server: MCP request with access token
+    Server->>Server: Verify access token against Logto's JWKS<br/>(signature, issuer, audience, expiration)
     Server->>Client: Return tool response`}
 
 />

--- a/docs/use-cases/ai/fragments/_mcp-sample-code.mdx
+++ b/docs/use-cases/ai/fragments/_mcp-sample-code.mdx
@@ -1,15 +1,7 @@
-import TabItem from '@theme/TabItem';
-import Tabs from '@theme/Tabs';
+:::info[Sample code]
+The complete, runnable sample code for this guide can be found in the [mcp-auth/js](https://github.com/mcp-auth/js/tree/master/packages/sample-servers) repository:
 
-<Tabs groupId="sdk">
-<TabItem value="python" label="Python">
+- [`whoami-express`](https://github.com/mcp-auth/js/tree/master/packages/sample-servers/src/whoami-express): the "whoami" server in this guide, on Node.js with Express.
+- [`whoami`](https://github.com/mcp-auth/js/tree/master/packages/sample-servers/src/whoami): the same server built fetch-native (web-standard `Request` / `Response` with [Hono](https://hono.dev)), deployable to Cloudflare Workers.
 
-The full MCP server code can be found in the [mcp-auth/python](https://github.com/mcp-auth/python) repository.
-
-</TabItem>
-<TabItem value="node" label="Node.js">
-
-The full MCP server code can be found in the [mcp-auth/js](https://github.com/mcp-auth/js) repository.
-
-</TabItem>
-</Tabs>
+:::

--- a/docs/use-cases/ai/fragments/_mcp-set-up-server.mdx
+++ b/docs/use-cases/ai/fragments/_mcp-set-up-server.mdx
@@ -1,207 +1,135 @@
-import TabItem from '@theme/TabItem';
-import Tabs from '@theme/Tabs';
-
 ## Set up the MCP server \{#set-up-the-mcp-server}
 
+We will use the [MCP official SDK](https://github.com/modelcontextprotocol) v2 and [mcp-auth](https://mcp-auth.dev) to create an MCP server with a "whoami" tool that returns the current user's identity claims.
+
 ### Create project and install dependencies \{#create-project-and-install-dependencies}
-
-<Tabs groupId="sdk">
-<TabItem value="python" label="Python">
-
-```bash
-mkdir mcp-server
-cd mcp-server
-uv init # Or use your own project structure
-uv add "mcp[cli]" starlette uvicorn mcpauth # Or use any preferred package manager
-```
-
-</TabItem>
-<TabItem value="node" label="Node.js">
 
 ```bash
 mkdir mcp-server
 cd mcp-server
 npm init -y
-npm install @modelcontextprotocol/sdk express mcp-auth # Or use any preferred package manager
+npm pkg set type="module"
+npm pkg set main="whoami.js"
+npm pkg set scripts.start="node whoami.js"
+npm install @modelcontextprotocol/server @modelcontextprotocol/express @modelcontextprotocol/node express mcp-auth
 ```
 
-</TabItem>
-</Tabs>
+- `@modelcontextprotocol/server` is the core MCP SDK v2, which speaks web-standard `Request` / `Response`.
+- `@modelcontextprotocol/express` and `@modelcontextprotocol/node` adapt it to Express on Node.js.
+- `mcp-auth` supplies the token verifier and the OAuth discovery metadata for the MCP SDK.
 
-### Configure MCP auth with Logto \{#configure-mcp-auth-with-logto}
+:::note
+The MCP SDK v2 and mcp-auth are ESM only and require Node.js >= 20.
+:::
 
-Remember to replace `<your-logto-issuer-endpoint>` with the issuer endpoint you copied earlier.
+### Register the MCP server as an API resource \{#register-the-mcp-server-as-an-api-resource}
 
-<Tabs groupId="sdk">
-<TabItem value="python" label="Python">
+The [latest MCP specification](https://modelcontextprotocol.io/specification/latest/basic/authorization) requires access tokens to be bound to the resource they are issued for ([RFC 8707](https://datatracker.ietf.org/doc/html/rfc8707)), and mcp-auth enforces it: the token's `aud` claim must match your MCP server's resource identifier. In Logto, this is done by creating an API resource whose indicator matches your MCP server's URL:
 
-**In `whoami.py`:**
+1. Sign in to your Logto Console.
+2. Go to <CloudLink to="/api-resources">**API resources**</CloudLink> → **Create API resource**.
+3. Fill in the details, then click **Create API resource**:
+   - **API name**: Enter a name, e.g., "Who am I".
+   - **API identifier**: Enter `http://localhost:3001/`. It must match the resource identifier we'll configure in the MCP server.
 
-```python
-from mcpauth import MCPAuth
-from mcpauth.config import AuthServerType
-from mcpauth.utils import fetch_server_config
+:::note[Trailing slash in resource indicator]
+Always include a trailing slash (`/`) in the resource indicator. Due to a current bug in the MCP official SDK, clients using the SDK will automatically append a trailing slash to resource identifiers when initiating auth requests. If your resource indicator doesn't include the trailing slash, resource validation will fail for those clients.
+:::
 
-auth_issuer = '<your-logto-issuer-endpoint>'
-auth_server_config = fetch_server_config(auth_issuer, type=AuthServerType.OIDC)
-mcp_auth = MCPAuth(server=auth_server_config)
-```
+### Configure MCP Auth with Logto \{#configure-mcp-auth-with-logto}
 
-</TabItem>
-<TabItem value="node" label="Node.js">
+Declare your MCP server as a protected resource: its resource identifier and the authorization server it trusts. Remember to replace `<your-logto-issuer-endpoint>` with the issuer endpoint you copied earlier (found in the application details page under **Endpoints & Credentials**, e.g., `https://my-project.logto.app/oidc`).
 
 **In `whoami.js`:**
 
 ```js
-import { MCPAuth, fetchServerConfig } from 'mcp-auth';
+import { MCPAuth } from 'mcp-auth';
 
 const authIssuer = '<your-logto-issuer-endpoint>';
+
 const mcpAuth = new MCPAuth({
-  server: await fetchServerConfig(authIssuer, { type: 'oidc' }),
+  protectedResourceMetadata: {
+    // The resource identifier; must match the API resource indicator registered in Logto
+    resource: 'http://localhost:3001/',
+    // The authorization server trusted by this MCP server
+    authorizationServer: { issuer: authIssuer, type: 'oidc' },
+  },
 });
 ```
 
-</TabItem>
-</Tabs>
-
-### Implement token verification \{#implement-token-verification}
-
-Since we're going to verify the access token and retrieve user info, we need to implement the access token verification as follows:
-
-<Tabs groupId="sdk">
-<TabItem value="python" label="Python">
-
-```python
-import requests
-from mcpauth.types import AuthInfo
-
-def verify_access_token(token: str) -> AuthInfo:
-    endpoint = auth_server_config.metadata.userinfo_endpoint
-    response = requests.get(
-        endpoint,
-        headers={"Authorization": f"Bearer {token}"},
-    )
-    response.raise_for_status()
-    data = response.json()
-    return AuthInfo(
-        token=token,
-        subject=data.get("sub"),
-        issuer=auth_server_config.metadata.issuer,
-        claims=data,
-    )
-```
-
-</TabItem>
-<TabItem value="node" label="Node.js">
-
-```js
-const verifyToken = async (token) => {
-  const { userinfoEndpoint, issuer } = mcpAuth.config.server.metadata;
-  const response = await fetch(userinfoEndpoint, {
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  if (!response.ok) throw new Error('Token verification failed');
-  const userInfo = await response.json();
-  return {
-    token,
-    issuer,
-    subject: userInfo.sub,
-    claims: userInfo,
-  };
-};
-```
-
-</TabItem>
-</Tabs>
+The authorization server metadata is fetched lazily when first needed and cached afterwards. The `MCPAuth` instance verifies JWT access tokens against Logto's JWKS — signature, issuer, audience, and expiration are all enforced. No hand-written token verification is needed.
 
 ### Implement the "whoami" tool \{#implement-the-whoami-tool}
 
-Now, let's implement the "whoami" tool that returns the current user's identity claims requesting the userinfo endpoint with the access token sent by the client.
-
-:::note
-We are using the SSE transport for the example due to the lack of official support for the Streamable HTTP transport in the current version of the SDK. Theoretically, you can use any HTTP-compatible transport.
-:::
-
-<Tabs groupId="sdk">
-<TabItem value="python" label="Python">
-
-```python
-from mcp.server.fastmcp import FastMCP
-from starlette.applications import Starlette
-from starlette.routing import Mount
-from starlette.middleware import Middleware
-
-mcp = FastMCP("WhoAmI")
-
-@mcp.tool()
-def whoami() -> dict:
-    """
-    Returns the current user's identity information.
-    """
-    return (
-        mcp_auth.auth_info.claims
-        if mcp_auth.auth_info
-        else {"error": "Not authenticated"}
-    )
-
-bearer_auth = Middleware(mcp_auth.bearer_auth_middleware(verify_access_token))
-app = Starlette(
-    routes=[
-        mcp_auth.metadata_route(),  # Serves OIDC metadata for discovery
-        Mount('/', app=mcp.sse_app(), middleware=[bearer_auth]),
-    ],
-)
-```
-
-Run the server with:
-
-```bash
-uvicorn whoami:app --host 0.0.0.0 --port 3001
-```
-
-</TabItem>
-<TabItem value="node" label="Node.js">
+Now, let's implement the "whoami" tool that returns the current user's identity claims from the verified access token. Use `getAuthInfo` to read the auth info that mcp-auth has verified from the tool's callback context.
 
 ```js
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import express from 'express';
+import { McpServer } from '@modelcontextprotocol/server';
+import { getAuthInfo } from 'mcp-auth';
 
-// Create MCP server and register the whoami tool
-const server = new McpServer({ name: 'WhoAmI', version: '0.0.0' });
-server.tool('whoami', ({ authInfo }) => ({
-  content: [
-    { type: 'text', text: JSON.stringify(authInfo?.claims ?? { error: 'Not authenticated' }) },
-  ],
-}));
+// Factory function to create an MCP server instance
+// Each request gets its own server instance, keeping requests isolated
+const createMcpServer = () => {
+  const mcpServer = new McpServer({
+    name: 'WhoAmI',
+    version: '0.0.0',
+  });
 
-// Express app & MCP Auth middleware
-const app = express();
-app.use(mcpAuth.delegatedRouter());
-app.use(mcpAuth.bearerAuth(verifyToken));
+  // Add a tool to the server that returns the current user's information
+  mcpServer.registerTool(
+    'whoami',
+    {
+      description: 'Get the current user information',
+    },
+    (context) => {
+      const { claims } = getAuthInfo(context);
+      return {
+        content: [{ type: 'text', text: JSON.stringify(claims) }],
+      };
+    }
+  );
 
-// SSE transport (as in SDK docs)
-const transports = {};
-app.get('/sse', async (_req, res) => {
-  const transport = new SSEServerTransport('/messages', res);
-  transports[transport.sessionId] = transport;
-  res.on('close', () => delete transports[transport.sessionId]);
-  await server.connect(transport);
-});
-app.post('/messages', async (req, res) => {
-  const sessionId = String(req.query.sessionId);
-  const transport = transports[sessionId];
-  if (transport) await transport.handlePostMessage(req, res, req.body);
-  else res.status(400).send('No transport found for sessionId');
-});
+  return mcpServer;
+};
+```
 
-app.listen(3001);
+### Wire up the server \{#wire-up-the-server}
+
+Finally, serve the OAuth discovery documents (RFC 9728 / RFC 8414) so MCP clients can find your authorization server, and protect the MCP endpoint with the SDK's Bearer auth middleware.
+
+```js
+import {
+  createMcpExpressApp,
+  mcpAuthMetadataRouter,
+  requireBearerAuth,
+} from '@modelcontextprotocol/express';
+import { toNodeHandler } from '@modelcontextprotocol/node';
+import { createMcpHandler } from '@modelcontextprotocol/server';
+
+const PORT = 3001;
+
+// The MCP handler speaks web-standard Request / Response; `toNodeHandler` adapts it to Express
+const mcpNodeHandler = toNodeHandler(createMcpHandler(createMcpServer));
+
+const app = createMcpExpressApp();
+
+// Serve the OAuth discovery documents (`/.well-known/...`), public by design
+app.use(mcpAuthMetadataRouter(await mcpAuth.getAuthMetadataOptions()));
+
+app.all(
+  '/',
+  // Require a valid Bearer token; the verified auth info flows to the handler via `req.auth`
+  requireBearerAuth(mcpAuth.getBearerAuthOptions()),
+  // `createMcpExpressApp` applies `express.json()`, which drains the request stream, so the
+  // parsed body is passed along explicitly
+  async (request, response) => mcpNodeHandler(request, response, request.body)
+);
+
+app.listen(PORT);
 ```
 
 Run the server with:
 
 ```bash
-node whoami.js
+npm start
 ```
-
-</TabItem>
-</Tabs>

--- a/docs/use-cases/ai/mcp-server-add-auth.mdx
+++ b/docs/use-cases/ai/mcp-server-add-auth.mdx
@@ -3,77 +3,89 @@ sidebar_position: 1
 sidebar_label: Enable auth for MCP-powered apps
 ---
 
+import ExploreAiSolutions from './fragments/_explore-ai-solutions.mdx';
 import Prerequisites from './fragments/_mcp-prerequisites.mdx';
 import SampleCode from './fragments/_mcp-sample-code.mdx';
 import SetUpServer from './fragments/_mcp-set-up-server.mdx';
 
 # Enable auth for your MCP-powered apps with Logto
 
-This guide walks you through integrating Logto with your MCP server using [mcp-auth](https://mcp-auth.dev), allowing you to authenticate users and securely retrieve their identity information using the standard OpenID Connect flow.
+<ExploreAiSolutions />
+
+This guide walks you through integrating Logto with your MCP server using [mcp-auth](https://mcp-auth.dev) and the [MCP official SDK](https://github.com/modelcontextprotocol) v2, allowing you to authenticate users and securely read their verified identity from the access token.
 
 You'll learn how to:
 
 - Configure Logto as the authorization server for your MCP server.
 - Set up a “whoami” tool in your MCP server to return the current user's identity claims.
-- Test the flow with the MCP Inspector (MCP client).
+- Test the flow with VS Code (MCP client).
 
 After this tutorial, your MCP server will:
 
 - Authenticate users in your Logto tenant.
-- Return identity claims (`sub`, `username`, `name`, `email`, etc.) for the "whoami" tool invocation.
+- Verify JWT access tokens issued by Logto (signature, issuer, audience, and expiration).
+- Return the verified identity claims (`sub`, `iss`, `aud`, etc.) for the "whoami" tool invocation.
 
-Once the integration is complete, you can replace the MCP Inspector with your own MCP client, such as a web app, to access the tools and resources exposed by your MCP server.
+Once the integration is complete, you can replace VS Code with your own MCP client, such as a web app, to access the tools and resources exposed by your MCP server.
+
+<SampleCode />
 
 <Prerequisites />
 
 ## Set up app in Logto \{#set-up-app-in-logto}
 
+Your MCP client needs to be registered as an application in Logto to initiate the authorization flow. We'll register VS Code as the client in this guide:
+
 1. Sign in to your Logto Console.
 2. Go <CloudLink to="/applications">**Applications**</CloudLink> → **Create application** → **Create app without framework**.
-3. Choose type: Single-page app.
-4. Fill in the app name and other required fields, then click **Create application**.
-5. Save and copy the **App ID** and **Issuer endpoint**.
+3. Choose type: Native app.
+4. Fill in the app name (e.g., "VS Code") and other required fields, then click **Create application**.
+5. In the **Settings** / **Redirect URIs** section, add the following redirect URIs for VS Code, then save the changes:
+
+   ```
+   http://127.0.0.1
+   https://vscode.dev/redirect
+   ```
+
+6. Save and copy the **App ID** and **Issuer endpoint**.
 
 <SetUpServer />
 
 ## Test the integration \{#test-the-integration}
 
-1. Start the MCP server
-2. Start the MCP Inspector.
-
-   Due to the limit of the current MCP Inspector implementation, we need to use the forked version from mcp-auth:
+1. Start the MCP server:
 
    ```bash
-   git clone https://github.com/mcp-auth/inspector.git
-   cd inspector
-   npm install
-   npm run dev
+   npm start
    ```
 
-   Then, open the URL shown in the terminal.
+2. Connect VS Code to your MCP server:
 
-3. In the MCP Inspector:
+   1. Press `Command + Shift + P` (macOS) or `Ctrl + Shift + P` (Windows / Linux) to open the Command Palette.
+   2. Type `MCP: Add Server...` and select it.
+   3. Choose `HTTP` as the server type.
+   4. Enter the MCP server URL: `http://localhost:3001/`
+   5. When the OAuth flow starts, VS Code prompts for the **Client ID**: paste the **App ID** you copied earlier.
+   6. Since it's a public client without an app secret, just press Enter to skip the secret.
+   7. Complete the sign-in flow in your browser.
 
-   - **Transport Type**: `SSE`
-   - **URL**: `http://localhost:3001/sse`
-   - **OAuth Client ID**: Paste your Logto App ID
-   - **Auth Params**: `{"scope": "openid profile email"}`
-   - **Redirect URI**: This URL should be auto-populated. Copy it.
+3. After signing in, run the `whoami` tool in VS Code.
 
-4. Find the application you created earlier in the Logto Console, open the details page, and paste the redirect URI into the **Settings** / **Redirect URIs** section. Save the changes.
-5. Back in the MCP Inspector, click **Connect**. This should redirect you to the Logto sign-in experience.
-
-After completing sign-in, you should be redirected back to the MCP Inspector. Go to **Tools** -> **List Tools** -> **whoami** -> **Run Tool**.
-
-You should see user claims, such as:
+You should see the verified claims from the access token, such as:
 
 ```json
 {
+  "iss": "https://my-project.logto.app/oidc",
   "sub": "user_XXXX",
-  "username": "alice",
-  "name": "Alice Smith",
-  "email": "alice@example.com"
+  "aud": "http://localhost:3001/",
+  "client_id": "<your-app-id>"
 }
 ```
 
-<SampleCode />
+## Further reading \{#further-reading}
+
+Your MCP server now verifies inbound access tokens. As a next step, learn how it can securely call your downstream business APIs on behalf of users, without token passthrough or losing user context:
+
+<Url href="https://blog.logto.io/mcp-server-token-strategy">
+  How an MCP server calls your API on behalf of users: a production token strategy
+</Url>

--- a/docs/use-cases/ai/mcp-server-enable-third-party-ai-agent-access.mdx
+++ b/docs/use-cases/ai/mcp-server-enable-third-party-ai-agent-access.mdx
@@ -4,24 +4,31 @@ sidebar_label: Enable third-party AI agent access to MCP server
 ---
 
 import ConfigureThirdPartyAiAgent from './fragments/_configure-third-party-ai-agent.mdx';
+import ExploreAiSolutions from './fragments/_explore-ai-solutions.mdx';
 import Prerequisites from './fragments/_mcp-prerequisites.mdx';
 import SampleCode from './fragments/_mcp-sample-code.mdx';
 import SetUpServer from './fragments/_mcp-set-up-server.mdx';
 
 # Enable third-party AI agent access to your MCP server
 
-This guide walks you through integrating Logto with your MCP server using [mcp-auth](https://mcp-auth.dev), allowing you to authenticate users and securely retrieve their identity information using the standard OpenID Connect flow.
+<ExploreAiSolutions />
+
+This guide walks you through integrating Logto with your MCP server using [mcp-auth](https://mcp-auth.dev) and the [MCP official SDK](https://github.com/modelcontextprotocol) v2, allowing third-party AI agents to authenticate users with their consent and securely access your MCP server.
 
 You'll learn how to:
 
 - Configure Logto as the authorization server for your MCP server.
+- Onboard third-party AI agents, either by registering third-party apps or by enabling [dynamic app](/integrate-logto/third-party-applications/dynamic-apps) so any agent can connect without pre-registration.
 - Set up a “whoami” tool in your MCP server to return the current user's identity claims.
 - Test the flow with a third-party AI agent (MCP client).
 
 After this tutorial, your MCP server will:
 
-- Authenticate users in your Logto tenant.
-- Return identity claims (`sub`, `username`, `name`, `email`, etc.) for the "whoami" tool invocation.
+- Authenticate users in your Logto tenant, with user consent for third-party AI agents.
+- Verify JWT access tokens issued by Logto (signature, issuer, audience, and expiration).
+- Return the verified identity claims (`sub`, `iss`, `aud`, etc.) for the "whoami" tool invocation.
+
+<SampleCode />
 
 ## Difference between third-party AI agent (MCP client) and your own MCP client \{#difference-between-third-party-ai-agent-mcp-client-and-your-own-mcp-client}
 
@@ -62,10 +69,16 @@ If you want to integrate your MCP server with your own AI agent or app, please r
 ## Test the integration \{#test-the-integration}
 
 1. Start the MCP server.
-2. Start the AI agent.
-3. In the client, invoke the `whoami` tool to retrieve the current user's identity claims.
-4. The client should handle the 401 Unauthorized response and redirect the user to Logto for authentication.
-5. After successful authentication, the client should receive an access token and use it to make requests to the MCP server.
-6. The client should be able to retrieve the identity claims from the MCP server using the access token.
+2. Connect the third-party AI agent to your MCP server and invoke the `whoami` tool.
+3. The agent receives a 401 Unauthorized response, discovers Logto through the MCP server's protected resource metadata, and redirects the user to Logto for authentication.
+4. The user signs in and reviews the consent screen, which lists the permissions the agent requests, then approves (or denies) the access.
+5. The agent receives an audience-bound JWT access token and uses it to invoke the tool again.
+6. The MCP server verifies the access token against Logto's JWKS and returns the verified identity claims to the agent.
 
-<SampleCode />
+## Further reading \{#further-reading}
+
+Your MCP server now verifies inbound access tokens from third-party AI agents. As a next step, learn how it can securely call your downstream business APIs on behalf of users, without token passthrough or losing user context:
+
+<Url href="https://blog.logto.io/mcp-server-token-strategy">
+  How an MCP server calls your API on behalf of users: a production token strategy
+</Url>


### PR DESCRIPTION
## Summary

Update the AI use case docs for the MCP SDK v2 + mcp-auth 1.0 resource-server model, and add cross-links to Logto's AI solutions.

- Rewrite the MCP server setup guide with `@modelcontextprotocol/server` v2 and `mcp-auth@1.0`: protected resource metadata config, built-in JWT verification against JWKS, and an API resource registration step; drop the hand-rolled userinfo verifier, the SSE transport, and the outdated Python tab
- Update the sequence diagram to the RFC 9728 flow (protected resource metadata discovery + audience-bound JWT)
- Switch the first-party guide to a Native app client and test with VS Code instead of the forked MCP Inspector
- Mention dynamic app onboarding in the third-party MCP guide, and extend the manual third-party app steps with API resource permissions and the `resource` parameter
- Move the sample code note to the top of both MCP guides, listing the Express and fetch-native (Hono / Cloudflare Workers) samples
- Add an "Explore Logto's AI solutions" tip linking to https://logto.io/ai on all AI use case pages
- Add a "Further reading" link to the MCP server token strategy blog post in both MCP guides

## Testing

tested locally

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
