### PR TITLE
docs: mark android and swift sdk latest versions as ga

### DIFF
--- a/docs/quick-starts/framework/android/README.mdx
+++ b/docs/quick-starts/framework/android/README.mdx
@@ -71,7 +71,7 @@ Assuming you treat `io.logto.android` as the custom `LOGTO_REDIRECT_SCHEME`, and
 
 <Tabs groupId="android-sdk-version">
 
-<TabItem default value="v3" label="v3 (beta)">
+<TabItem default value="v3" label="v3">
 
 In v3, the sign-in experience opens in a [Custom Tab](https://developer.android.com/develop/ui/views/layout/webapps/overview-of-android-custom-tabs) (the system browser), and the redirect is routed back to your app through an OS-level intent filter. You need to declare the scheme of your redirect URI with the `logtoRedirectScheme` manifest placeholder in your app's build file:
 

--- a/docs/quick-starts/framework/android/_implement-sign-in-and-sign-out.mdx
+++ b/docs/quick-starts/framework/android/_implement-sign-in-and-sign-out.mdx
@@ -9,7 +9,7 @@ You can use `logtoClient.signIn` to sign in the user and `logtoClient.signOut` t
 
 <Tabs groupId="android-sdk-version">
 
-<TabItem default value="v3" label="v3 (beta)">
+<TabItem default value="v3" label="v3">
 
 In v3, `logtoClient.signOut` performs a complete sign-out: it clears the local credentials, revokes the refresh token, and ends the Logto session by opening the end session endpoint in the browser. The browser then navigates back to your app through the post sign-out redirect URI. Before using it, switch to the application details page of Logto Console, add the post sign-out redirect URI `io.logto.android://io.logto.sample/callback` and click "Save changes". The post sign-out redirect URI follows the same pattern as the redirect URI, and its scheme must also match the `logtoRedirectScheme` manifest placeholder.
 

--- a/docs/quick-starts/framework/android/_installation.mdx
+++ b/docs/quick-starts/framework/android/_installation.mdx
@@ -7,7 +7,7 @@ The minimum supported Android API level of Logto Android SDK is level 24.
 
 Logto Android SDK comes in two major versions:
 
-- **v3 (beta)**: Opens the sign-in experience in [Chrome Custom Tabs](https://developer.android.com/develop/ui/views/layout/webapps/overview-of-android-custom-tabs) (the system browser), which unlocks passkey sign-in and shares the browser session. Note that v3 removes support for the <MainSiteUrl href="/integrations/wechat-native">WeChat (Native)</MainSiteUrl> and <MainSiteUrl href="/integrations/alipay-native">Alipay (Native)</MainSiteUrl> connectors; you can use <MainSiteUrl href="/integrations/wechat-web">WeChat (Web)</MainSiteUrl> and <MainSiteUrl href="/integrations/alipay-web">Alipay (Web)</MainSiteUrl> instead, which work through the browser. If you depend on the native connectors, stay on v2.
+- **v3**: Opens the sign-in experience in [Chrome Custom Tabs](https://developer.android.com/develop/ui/views/layout/webapps/overview-of-android-custom-tabs) (the system browser), which unlocks passkey sign-in and shares the browser session. Note that v3 removes support for the <MainSiteUrl href="/integrations/wechat-native">WeChat (Native)</MainSiteUrl> and <MainSiteUrl href="/integrations/alipay-native">Alipay (Native)</MainSiteUrl> connectors; you can use <MainSiteUrl href="/integrations/wechat-web">WeChat (Web)</MainSiteUrl> and <MainSiteUrl href="/integrations/alipay-web">Alipay (Web)</MainSiteUrl> instead, which work through the browser. If you depend on the native connectors, stay on v2.
 - **v2**: Opens the sign-in experience in an embedded WebView, which is required by the native social connectors, but does not support <MainSiteUrl href="/end-user-flows/sign-up-and-sign-in/passkey-sign-in">passkey sign-in</MainSiteUrl> (WebView does not support WebAuthn, the underlying standard of passkeys).
 
 This guide covers both versions. Choose your version in the tabs below, and the choice will be kept in sync throughout this guide.
@@ -26,9 +26,9 @@ Add Logto Android SDK to your dependencies:
 
 <Tabs groupId="android-sdk-version">
 
-<TabItem default value="v3" label="v3 (beta)">
+<TabItem default value="v3" label="v3">
 
-v3 is released as `3.0.0-beta` prereleases until GA. Use the latest prerelease as the version:
+Use the latest v3 release as the version:
 
 <Tabs>
 
@@ -36,7 +36,7 @@ v3 is released as `3.0.0-beta` prereleases until GA. Use the latest prerelease a
 
 ```kotlin title="build.gradle.kts"
 dependencies {
-  implementation("io.logto.sdk:android:3.0.0-beta")
+  implementation("io.logto.sdk:android:3.0.0")
 }
 ```
 
@@ -46,7 +46,7 @@ dependencies {
 
 ```groovy title="build.gradle"
 dependencies {
-  implementation 'io.logto.sdk:android:3.0.0-beta'
+  implementation 'io.logto.sdk:android:3.0.0'
 }
 ```
 

--- a/docs/quick-starts/framework/swift/_add-sdk.mdx
+++ b/docs/quick-starts/framework/swift/_add-sdk.mdx
@@ -7,8 +7,8 @@ The minimum supported iOS version of Logto Swift SDK is iOS 13.
 
 Logto Swift SDK comes in two major versions:
 
+- **v2**: Opens the sign-in experience in [`ASWebAuthenticationSession`](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession) (the system browser), which unlocks passkey sign-in and shares the browser session. Note that v2 removes the native social plugin targets; social connectors still work through the browser. If you depend on the native WeChat or Alipay SDK handoff, stay on v1.
 - **v1**: Opens the sign-in experience in an embedded WebView, which is required by the native social plugin targets, but does not support <MainSiteUrl href="/end-user-flows/sign-up-and-sign-in/passkey-sign-in">passkey sign-in</MainSiteUrl> (WebView does not support WebAuthn, the underlying standard of passkeys).
-- **v2 (beta)**: Opens the sign-in experience in [`ASWebAuthenticationSession`](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession) (the system browser), which unlocks passkey sign-in and shares the browser session. Note that v2 removes the native social plugin targets; social connectors still work through the browser. If you depend on the native WeChat or Alipay SDK handoff, stay on v1.
 
 This guide covers both versions. Choose your version in the tabs below, and the choice will be kept in sync throughout this guide.
 
@@ -24,21 +24,21 @@ When Xcode asks for the package version, choose the version you want to integrat
 
 <Tabs groupId="swift-sdk-version" defaultValue="v2">
 
-<TabItem value="v2" label="v2 (beta)">
+<TabItem value="v2" label="v2">
 
-v2 is released as `2.0.0-beta.x` prereleases until GA. Use `2.0.0-beta.1` or the latest `2.0.0-beta.x` prerelease as the version. During beta, we recommend selecting the prerelease explicitly instead of relying on a normal version range to pick it automatically.
+Use the latest v2 release as the version. The latest v2 version is `2.0.0`.
 
 If you use `Package.swift` directly:
 
 ```swift title="Package.swift"
-.package(url: "https://github.com/logto-io/swift.git", exact: "2.0.0-beta.1")
+.package(url: "https://github.com/logto-io/swift.git", from: "2.0.0")
 ```
 
 </TabItem>
 
 <TabItem value="v1" label="v1">
 
-Use the latest v1 release as the stable line. The latest v1 version is `1.2.0`.
+Use the latest v1 release if you need the native social plugin targets. The latest v1 version is `1.2.0`.
 
 If you use `Package.swift` directly:
 

--- a/docs/quick-starts/framework/swift/_implement-sign-in-and-sign-out.mdx
+++ b/docs/quick-starts/framework/swift/_implement-sign-in-and-sign-out.mdx
@@ -11,7 +11,7 @@ import SignInFlowSummary from '../../fragments/_web-sign-in-flow-summary.mdx';
 
 <Tabs groupId="swift-sdk-version" defaultValue="v2">
 
-<TabItem value="v2" label="v2 (beta)">
+<TabItem value="v2" label="v2">
 
 <ConfigureRedirectUri
   figureSrc="/img/assets/ios-redirect-uri.png"
@@ -83,7 +83,7 @@ The Redirect URI in iOS SDK is only for internal use. There's _NO NEED_ to add a
 
 <Tabs groupId="swift-sdk-version" defaultValue="v2">
 
-<TabItem value="v2" label="v2 (beta)">
+<TabItem value="v2" label="v2">
 
 In v2, `client.signOut(postLogoutRedirectUri:)` performs a complete sign-out: it clears the local credentials, revokes the refresh token, and ends the Logto session by opening the end session endpoint in the system browser. The browser then navigates back to your app through the post sign-out redirect URI. Before using it, switch to the application details page of Logto Console, add the post sign-out redirect URI `io.logto.app://signed-out` and click "Save changes". The post sign-out redirect URI can use the same custom scheme you registered for sign-in.
 


### PR DESCRIPTION
## Summary

Update the Android and iOS (Swift) quick starts now that the latest SDK major versions are generally available.

- Android: drop the beta label from v3 and use `3.0.0` as the dependency version
- Swift: drop the beta label from v2 and use `from: "2.0.0"` instead of the `2.0.0-beta.1` prerelease pin
- Swift: list v2 before v1 in the version overview so the latest version comes first, matching the tab order

## Testing

tested locally

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)